### PR TITLE
feat(inventory): seed default items for new users

### DIFF
--- a/src/app/api/inventory/seed/route.ts
+++ b/src/app/api/inventory/seed/route.ts
@@ -1,0 +1,10 @@
+import { seedDefaultInventory } from "@/lib/inventory/Inventory";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const { userId } = await request.json();
+  if (!userId) return NextResponse.json({ error: "userId required" }, { status: 400 });
+
+  await seedDefaultInventory(userId);
+  return NextResponse.json({ ok: true });
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -13,12 +13,21 @@ export default function useSession() {
     }
 
     let sessionId = localStorage.getItem("ask-ah-mah-session");
+    const isNew = !sessionId;
     if (!sessionId) {
       sessionId = generateShortId();
       localStorage.setItem("ask-ah-mah-session", sessionId);
     }
     setUserId(sessionId);
     setIsLoading(false);
+
+    if (isNew) {
+      fetch("/api/inventory/seed", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: sessionId }),
+      });
+    }
   }, []);
 
   return { userId, isLoading };

--- a/src/lib/inventory/Inventory.ts
+++ b/src/lib/inventory/Inventory.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { DEFAULT_INVENTORY } from "./defaults";
 import { AddInventoryItem } from "./schemas";
 
 export async function getInventory(userId: string) {
@@ -64,6 +65,12 @@ export async function addInventoryItem(
       });
     }
   }
+}
+
+export async function seedDefaultInventory(userId: string) {
+  const count = await prisma.inventoryItem.count({ where: { userId } });
+  if (count > 0) return;
+  await addInventoryItem(DEFAULT_INVENTORY, userId);
 }
 
 export async function removeInventoryItem(

--- a/src/lib/inventory/defaults.ts
+++ b/src/lib/inventory/defaults.ts
@@ -1,0 +1,10 @@
+import type { AddInventoryItem } from "./schemas";
+
+export const DEFAULT_INVENTORY: AddInventoryItem[] = [
+  { name: "Salt", type: "ingredient", shelfLife: "long" },
+  { name: "Cooking oil", type: "ingredient", shelfLife: "long" },
+  { name: "Soy sauce", type: "ingredient", shelfLife: "long" },
+  { name: "Wok", type: "kitchenware", shelfLife: "long" },
+  { name: "Pot", type: "kitchenware", shelfLife: "long" },
+  { name: "Chef's knife", type: "kitchenware", shelfLife: "long" },
+];


### PR DESCRIPTION
Salt, cooking oil, soy sauce + wok, pot, chef's knife — the six universals that seed on first session so Ah Mah has context even before the user adds anything. Idempotent: skips if user already has inventory items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* New accounts are automatically populated with a default set of kitchen essentials upon creation, streamlining the user onboarding experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->