### PR TITLE
feat(ui): Kopitiam Modern surface redesign

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -38,6 +38,46 @@ The moat is **persistent kitchen state**: what the user has, what they cooked, w
 
 ---
 
+### Default inventory seeding
+- 6 starter items seeded idempotently for new users: salt, cooking oil, soy sauce (ingredients) + wok, pot, chef's knife (kitchenware).
+- `POST /api/inventory/seed` endpoint; `useSession` hook fires it once on first session creation.
+
+### Claude Design reference
+Visual direction for the Kopitiam Modern redesign was generated via Claude Design:
+https://api.anthropic.com/v1/design/h/bOL_xzI0rpgfpw7XTY5gsQ?open_file=Ask+Ah+Mah+-+Surface+Redesign.html
+
+Follow this for color tokens, typography, surface hierarchy, paper texture, and border radius scale when making future visual changes.
+
+### Kopitiam Modern UI overhaul (May 2026)
+Full surface redesign based on Claude Design output. Key changes:
+
+- **Color system**: OKLCH token overhaul — `--background` (aged newsprint), `--chat` (lightest, conversation surface), `--muted` (kraft tray for inventory + cookbook), `--card` (lighter than bg — inverted contrast so cards float up). Dark mode counterparts.
+- **Paper texture**: SVG `feTurbulence` noise tiled at 200×200px with `background-blend-mode: multiply` on chat and inventory surfaces.
+- **Layout**: Chat/Cookbook top-level tabs (folder-tab pattern — `z-10` TabsList covers content frame's `border-t`; active tab bottom matches surface color). Desktop: chat 7/10 + pantry sidebar 3/10. Mobile: Pantry button → bottom Drawer.
+- **Tabs**: `rounded-t-xl` triggers, `rounded-lg` content frame. Standard Tailwind values throughout.
+- **Chat header**: Replaced "Chatting with Ah Mah" strip with contextual session header — Fraunces italic day name + message count subtitle.
+- **Inventory/Pantry**: Large italic Fraunces "Pantry" heading. Ingredients and Equipment sections as card boxes on kraft tray. Inline "+ Add" button.
+- **Cookbook**: Full redesign — kraft tray background, "YOURS, KEPT" eyebrow + 40px Fraunces heading, search pill, tag filter chips with counts. Recipe cards: diagonal-stripe image strip, serif title + italic ingredient blurb, dashed-border footer with metadata + tag pills, dog-ear fold on first card. Empty state: instructional card (spans 2 rows) + 4 ghost placeholder cards.
+
+### Stitch-inspired polish (sidebar zoning + tag cleanup)
+- **Monochrome tags**: dropped categorical colors; all tags neutral outlined pills; active filter chip gets terracotta fill only.
+- **Scrollbar**: track → transparent, thumb → `--border` (warm tan). No more jade/terracotta stripe.
+- **Background zoning**: inventory aside → `bg-muted/50 rounded-2xl` tray; cookbook recipe list → `bg-muted/40 rounded-2xl` tray. Chat stays on plain cream.
+- **Inventory sidebar flattened**: dropped Card chrome; small-caps `SectionLabel` dividers replace CardTitle. Add Item → `variant="outline" size="sm"`.
+- **Chat header strip**: avatar + "Chatting with Ah Mah" + italic serif tagline above messages (desktop only).
+- **Italic serif for assistant**: Ah Mah's messages render in `font-display italic` (Fraunces). User bubbles stay Inter.
+- **Input refinement**: muted rounded container; send button is terracotta icon.
+
+### UI/UX overhaul — Kopitiam Modern
+- **Layout**: replaced kitchen drawer with Chat / Cookbook top-level tabs. Recipe detail is now a slide-over Sheet (not full-screen takeover). Mobile gets a Pantry button near the chat input opening a bottom Sheet.
+- **Cookbook tab**: full-width `max-w-2xl` layout with "My Cookbook" heading, recipe count subtitle, larger recipe entries showing servings + ingredient count, and categorical tag filter chips.
+- **Palette ("Kopitiam Modern")**: OKLCH-based — terracotta primary (`oklch(0.56 0.135 35)`), deep jade accent (`oklch(0.50 0.095 168)`), butter secondary (`oklch(0.86 0.10 88)`), warm cream background. Dark mode inverts to espresso + cream (no slate-blue). Replaces monotone olive/desaturated original.
+- **Typography**: Fraunces display serif for headings (CardTitle, recipe names, "My Cookbook"). JetBrains Mono dropped (vestigial).
+- **Categorical tag colors**: `tagClasses()` helper maps cuisine→jade, protein→terracotta, method→butter, difficulty→muted. Single source of truth shared by `RecipeList`, `RecipeDisplay`, and `recipeProcessor` prompt builder.
+- **Component polish**: warm OKLCH card shadow; jade underline on active tab; user chat bubble → terracotta (`bg-primary`); shortfall badge → chili red theme (`text-destructive`); shelf-life dot → turmeric (`bg-tertiary`).
+
+---
+
 ## V2 — In Progress
 
 ### Decrement-on-cook

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "next": "15.5.9",
         "next-themes": "^0.4.6",
         "prisma": "^6.16.0",
+        "radix-ui": "^1.4.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.62.0",
@@ -2928,10 +2929,115 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
       "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
@@ -2961,6 +3067,66 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
@@ -3030,6 +3196,34 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3112,6 +3306,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -3136,6 +3359,65 @@
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3177,6 +3459,178 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3333,6 +3787,62 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
@@ -3348,6 +3858,37 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3407,6 +3948,62 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -3425,6 +4022,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tabs": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
@@ -3439,6 +4065,157 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-roving-focus": "1.1.11",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-toggle-group": "1.1.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -14394,6 +15171,83 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/radix-ui": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-accessible-icon": "1.1.7",
+        "@radix-ui/react-accordion": "1.2.12",
+        "@radix-ui/react-alert-dialog": "1.1.15",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-aspect-ratio": "1.1.7",
+        "@radix-ui/react-avatar": "1.1.10",
+        "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-context-menu": "2.2.16",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-form": "0.1.8",
+        "@radix-ui/react-hover-card": "1.1.15",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-menubar": "1.1.16",
+        "@radix-ui/react-navigation-menu": "1.2.14",
+        "@radix-ui/react-one-time-password-field": "0.1.8",
+        "@radix-ui/react-password-toggle-field": "0.1.3",
+        "@radix-ui/react-popover": "1.1.15",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-progress": "1.1.7",
+        "@radix-ui/react-radio-group": "1.3.8",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-scroll-area": "1.2.10",
+        "@radix-ui/react-select": "2.2.6",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-slider": "1.3.6",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-switch": "1.2.6",
+        "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-toast": "1.2.15",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-toggle-group": "1.1.11",
+        "@radix-ui/react-toolbar": "1.1.11",
+        "@radix-ui/react-tooltip": "1.2.8",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next": "15.5.9",
     "next-themes": "^0.4.6",
     "prisma": "^6.16.0",
+    "radix-ui": "^1.4.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",

--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -4,7 +4,7 @@ When you explain technique, lean on the science of why it works — Maillard rea
 
 # Tools
 
-- \`getInventory\` — call this before suggesting recipes or answering "what can I cook". If empty, ask the user what they have rather than guess blind. Do NOT call it for general cooking knowledge questions (e.g., "what's the difference between baking soda and baking powder").
+- \`getInventory\` — call this before suggesting recipes or answering "what can I cook". If empty, ask the user what they have rather than guess blind. Do NOT call it for general cooking knowledge questions (e.g., "what's the difference between baking soda and baking powder"). When the inventory includes equipment (wok, pressure cooker, air fryer, slow cooker, etc.), always adapt the recipe method to that equipment — adjust timing, technique, and instructions accordingly without waiting to be asked.
 - \`addInventoryItem\` — when the user mentions buying or having something, add it. Always set \`shelfLife\` for every item:
   - "short" — leafy greens, herbs, seafood, dairy, cooked leftovers, mushrooms
   - "medium" — most meat, most fresh produce, eggs, tofu, bread

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-var-sans);
-  --font-mono: var(--font-var-mono);
+  --font-display: var(--font-var-display);
   --font-logo: var(--font-var-logo);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -25,6 +25,7 @@
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
+  --color-border-soft: var(--border-soft);
   --color-destructive: var(--destructive);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
@@ -38,6 +39,8 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-chat: var(--chat);
+  --color-ink-faint: var(--ink-faint);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -48,73 +51,102 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(0.9723 0.0216 83.26);
-  --foreground: oklch(0.3814 0.0258 237.54);
-  --card: oklch(0.9723 0.0216 83.26);
-  --card-foreground: oklch(0.3814 0.0258 237.54);
-  --popover: oklch(0.9723 0.0216 83.26);
-  --popover-foreground: oklch(0.3814 0.0258 237.54);
-  --primary: oklch(0.4542 0.0652 66.59);
-  --primary-foreground: oklch(0.984 0.003 247.858);
-  --secondary: oklch(0.927 0.0213 60.74);
-  --secondary-foreground: oklch(0.4542 0.0652 66.59);
-  --muted: oklch(0.927 0.0213 60.74);
-  --muted-foreground: oklch(0.5176 0.0394 58.2);
-  --accent: oklch(0.927 0.0213 60.74);
-  --accent-foreground: oklch(0.4542 0.0652 66.59);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.8869 0.0198 60.14);
-  --input: oklch(0.8869 0.0198 60.14);
-  --ring: oklch(0.704 0.04 256.788);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.984 0.003 247.858);
-  --sidebar-foreground: oklch(0.3814 0.0258 237.54);
-  --sidebar-primary: oklch(0.4542 0.0652 66.59);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.927 0.0213 60.74);
-  --sidebar-accent-foreground: oklch(0.4542 0.0652 66.59);
-  --sidebar-border: oklch(0.8869 0.0198 60.14);
-  --sidebar-ring: oklch(0.704 0.04 256.788);
+  /* Kopitiam Modern — old paper + terracotta + jade + butter */
 
-  --tertiary: oklch(0.5924 0.0509 69.77);
+  /* Page shell — aged newsprint */
+  --background: oklch(0.945 0.024 75);
+  /* Soy ink */
+  --foreground: oklch(0.265 0.040 48);
+
+  /* Cards inside tray — cream paper, *lighter* than bg so they pop out */
+  --card: oklch(0.975 0.022 80);
+  --card-foreground: oklch(0.265 0.040 48);
+  --popover: oklch(0.975 0.022 80);
+  --popover-foreground: oklch(0.265 0.040 48);
+
+  /* Chat scroll area — freshest, lightest surface */
+  --chat: oklch(0.985 0.018 82);
+
+  /* Inventory / cookbook tray — kraft, distinctly darker than page */
+  --muted: oklch(0.905 0.030 70);
+  /* Pencil */
+  --muted-foreground: oklch(0.460 0.038 52);
+  /* Faint ink */
+  --ink-faint: oklch(0.605 0.030 60);
+
+  /* Terracotta primary */
+  --primary: oklch(0.56 0.135 35);
+  --primary-foreground: oklch(0.97 0.02 80);
+
+  /* Butter — user message bubbles */
+  --secondary: oklch(0.860 0.100 88);
+  --secondary-foreground: oklch(0.265 0.040 48);
+
+  --accent: oklch(0.50 0.095 168);
+  --accent-foreground: oklch(0.97 0.02 80);
+  --destructive: oklch(0.56 0.21 25);
+
+  /* Stained paper edge — warmer and darker than before */
+  --border: oklch(0.815 0.038 70);
+  --border-soft: oklch(0.870 0.030 72);
+  --input: oklch(0.815 0.038 70);
+  --ring: oklch(0.56 0.135 35);
+
+  --chart-1: oklch(0.56 0.135 35);
+  --chart-2: oklch(0.50 0.095 168);
+  --chart-3: oklch(0.70 0.13 75);
+  --chart-4: oklch(0.86 0.10 88);
+  --chart-5: oklch(0.56 0.21 25);
+  --sidebar: oklch(0.975 0.022 80);
+  --sidebar-foreground: oklch(0.265 0.040 48);
+  --sidebar-primary: oklch(0.56 0.135 35);
+  --sidebar-primary-foreground: oklch(0.97 0.02 80);
+  --sidebar-accent: oklch(0.905 0.030 70);
+  --sidebar-accent-foreground: oklch(0.265 0.040 48);
+  --sidebar-border: oklch(0.815 0.038 70);
+  --sidebar-ring: oklch(0.56 0.135 35);
+
+  --tertiary: oklch(0.70 0.13 75);
 }
 
 .dark {
-  --background: oklch(0.3814 0.0258 237.54);
-  --foreground: oklch(0.984 0.003 247.858);
-  --card: oklch(0.4542 0.0652 66.59);
-  --card-foreground: oklch(0.984 0.003 247.858);
-  --popover: oklch(0.4542 0.0652 66.59);
-  --popover-foreground: oklch(0.984 0.003 247.858);
-  --primary: oklch(0.8869 0.0198 60.14);
-  --primary-foreground: oklch(0.4542 0.0652 66.59);
-  --secondary: oklch(0.279 0.041 260.031);
-  --secondary-foreground: oklch(0.984 0.003 247.858);
-  --muted: oklch(0.279 0.041 260.031);
-  --muted-foreground: oklch(0.704 0.04 256.788);
-  --accent: oklch(0.279 0.041 260.031);
-  --accent-foreground: oklch(0.984 0.003 247.858);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
+  /* Kopitiam Modern — espresso + warm terracotta + jade */
+  --background: oklch(0.22 0.028 50);
+  --foreground: oklch(0.95 0.025 78);
+  --card: oklch(0.28 0.03 50);
+  --card-foreground: oklch(0.95 0.025 78);
+  --popover: oklch(0.28 0.03 50);
+  --popover-foreground: oklch(0.95 0.025 78);
+  --chat: oklch(0.25 0.025 50);
+  --primary: oklch(0.66 0.14 35);
+  --primary-foreground: oklch(0.22 0.028 50);
+  --secondary: oklch(0.50 0.075 88);
+  --secondary-foreground: oklch(0.95 0.025 78);
+  --muted: oklch(0.30 0.025 50);
+  --muted-foreground: oklch(0.70 0.03 60);
+  --ink-faint: oklch(0.55 0.025 55);
+  --accent: oklch(0.60 0.10 168);
+  --accent-foreground: oklch(0.95 0.025 78);
+  --destructive: oklch(0.66 0.18 25);
+  --border: oklch(1 0 0 / 12%);
+  --border-soft: oklch(1 0 0 / 8%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.551 0.027 264.364);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.4542 0.0652 66.59);
-  --sidebar-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.279 0.041 260.031);
-  --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.551 0.027 264.364);
+  --ring: oklch(0.66 0.14 35);
+  --chart-1: oklch(0.66 0.14 35);
+  --chart-2: oklch(0.60 0.10 168);
+  --chart-3: oklch(0.75 0.12 78);
+  --chart-4: oklch(0.50 0.075 88);
+  --chart-5: oklch(0.66 0.18 25);
+  --sidebar: oklch(0.28 0.03 50);
+  --sidebar-foreground: oklch(0.95 0.025 78);
+  --sidebar-primary: oklch(0.66 0.14 35);
+  --sidebar-primary-foreground: oklch(0.22 0.028 50);
+  --sidebar-accent: oklch(0.30 0.025 50);
+  --sidebar-accent-foreground: oklch(0.95 0.025 78);
+  --sidebar-border: oklch(1 0 0 / 12%);
+  --sidebar-ring: oklch(0.66 0.14 35);
+
+  --tertiary: oklch(0.75 0.12 78);
 }
 
 @layer base {
@@ -126,27 +158,29 @@
   }
 }
 
-/* For Webkit-based browsers (Chrome, Safari, Edge) */
+/* Paper grain via SVG feTurbulence noise */
+.paper {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' seed='7'/%3E%3CfeColorMatrix values='0 0 0 0 0.22 0 0 0 0 0.16 0 0 0 0 0.10 0 0 0 0.055 0'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 200px 200px;
+  background-blend-mode: multiply;
+}
+
 ::-webkit-scrollbar {
-  width: 10px;
-  height: 10px; /* For horizontal scrollbars */
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--accent); /* Creamy Off-White for the track */
-  border-radius: 10px; /* Slightly rounded track */
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: var(--primary); /* Warm Brown/Terracotta for the thumb */
-  border-radius: 10px; /* Rounded thumb */
-  border: 2px solid var(--background); /* A small border to separate thumb from track */
+  background-color: var(--border);
+  border-radius: 8px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background-color: oklch(
-    0.3893 0.0595 60.74
-  ); /* A slightly darker brown on hover for interaction */
+  background-color: var(--muted-foreground);
 }
 ol {
   list-style-type: decimal;
@@ -168,10 +202,10 @@ ul li {
 }
 
 ol li::marker {
-  letter-spacing: -0.1em; /* Tighten letter spacing */
+  letter-spacing: -0.1em;
 }
 
 blockquote {
-  border-left: 3px solid var(--color-secondary);
+  border-left: 3px solid var(--accent);
   padding-left: 0.5em;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import AboutPopOver from "@/components/AboutPopOver";
 import { Toaster } from "@/components/ui/sonner";
 import { SessionProvider } from "@/contexts/SessionContext";
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono, Nunito } from "next/font/google";
+import { Fraunces, Inter, Nunito } from "next/font/google";
 import Image from "next/image";
 import "./globals.css";
 
@@ -11,9 +11,10 @@ const fontSans = Inter({
   subsets: ["latin"],
 });
 
-const fontMono = JetBrains_Mono({
-  variable: "--font-var-mono",
+const fontDisplay = Fraunces({
+  variable: "--font-var-display",
   subsets: ["latin"],
+  weight: ["400", "600", "700"],
 });
 
 const fontLogo = Nunito({
@@ -101,7 +102,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`mx-0 mt-0 sm:mx-2 sm:mt-2 md:mx-4 md:mt-4 ${fontSans.variable} ${fontMono.variable} ${fontLogo.variable} antialiased font-sans
+        className={`mx-0 mt-0 sm:mx-2 sm:mt-2 md:mx-4 md:mt-4 ${fontSans.variable} ${fontDisplay.variable} ${fontLogo.variable} antialiased font-sans
 `}
       >
         <SessionProvider>
@@ -113,23 +114,18 @@ export default function RootLayout({
               },
             }}
           />
-          <div className="pb-2 sm:pb-3 pt-2 border-b xl:container mx-auto px-4 flex justify-between items-end">
-            <div>
-              <h1 className="text-2xl md:text-3xl font-bold font-logo flex items-end gap-2 text-primary">
-                <div className="relative w-10 h-10 md:w-12 md:h-12">
-                  <Image
-                    src="/granny-icon.png"
-                    alt="Ask Ah Mah"
-                    fill
-                    className="object-contain"
-                  />
-                </div>
-                Ask Ah Mah
-              </h1>
-              <p className="text-muted-foreground text-xs md:text-sm lg:text-base">
-                Your friendly cooking assistant
-              </p>
-            </div>
+          <div className="pb-2 pt-2 border-b xl:container mx-auto px-4 flex justify-between items-center">
+            <h1 className="text-xl md:text-2xl font-bold font-logo flex items-center gap-2 text-primary">
+              <div className="relative w-8 h-8 md:w-9 md:h-9">
+                <Image
+                  src="/granny-icon.png"
+                  alt="Ask Ah Mah"
+                  fill
+                  className="object-contain"
+                />
+              </div>
+              Ask Ah Mah
+            </h1>
             <AboutPopOver className="hidden lg:flex" />
           </div>
           {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,11 @@
 "use client";
-import AboutPopOver from "@/components/AboutPopOver";
 import { Button } from "@/components/ui/button";
 import {
   Drawer,
   DrawerContent,
   DrawerTitle,
-  DrawerTrigger,
 } from "@/components/ui/drawer";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RecipeProvider, useRecipeContext } from "@/contexts/RecipeContext";
 import ChatWrapper from "@/features/Chat/components/ChatWrapper";
@@ -16,79 +15,68 @@ import RecipeList from "@/features/RecipeList/RecipeList";
 import { useState } from "react";
 
 function HomeContent() {
-  const { selectedRecipe } = useRecipeContext();
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const { selectedRecipe, exitRecipe } = useRecipeContext();
+  const [pantryOpen, setPantryOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState("chat");
 
   return (
     <div className="bg-background">
-      <main className="xl:container mx-auto h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-6.5rem)]  md:h-[calc(100dvh-8rem)] ">
-        <div className="flex gap-4 h-full">
-          <section className="flex-7 min-w-0">
-            {selectedRecipe ? <RecipeDisplay /> : <ChatWrapper />}
-          </section>
-          <aside className="flex-3 min-w-0 pt-4 hidden lg:block lg:relative overflow-y-auto pr-4 mb-4 ">
-            <Tabs defaultValue="inventory">
-              <TabsList>
-                <TabsTrigger value="inventory">Inventory</TabsTrigger>
-                <TabsTrigger value="recipe">Recipe</TabsTrigger>
-              </TabsList>
-              <TabsContent value="inventory">
+      <main className="xl:container mx-auto h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-6.5rem)] md:h-[calc(100dvh-8rem)]">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col pt-2">
+          <TabsList>
+            <TabsTrigger value="chat">Chat</TabsTrigger>
+            <TabsTrigger value="cookbook">Cookbook</TabsTrigger>
+          </TabsList>
+
+          {/* ── Chat tab ── */}
+          <TabsContent value="chat" className="flex-1 min-h-0 mt-0">
+            <div className="flex h-full border border-border rounded-lg overflow-hidden">
+              <section className="flex-7 min-w-0 relative flex flex-col bg-chat border-r border-border paper">
+                <ChatWrapper />
+                {/* Mobile: pantry button above the input */}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="absolute bottom-[72px] right-4 lg:hidden z-10 cursor-pointer gap-1.5"
+                  onClick={() => setPantryOpen(true)}
+                >
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 21V22H7V21C6.46957 21 5.96086 20.7893 5.58579 20.4142C5.21071 20.0391 5 19.5304 5 19V4C5 3.46957 5.21071 2.96086 5.58579 2.58579C5.96086 2.21071 6.46957 2 7 2H17C17.5304 2 18.0391 2.21071 18.4142 2.58579C18.7893 2.96086 19 3.46957 19 4V19C19 19.5304 18.7893 20.0391 18.4142 20.4142C18.0391 20.7893 17.5304 21 17 21V22H15V21H9ZM7 4V9H17V4H7ZM7 19H17V11H7V19ZM8 12H10V15H8V12ZM8 6H10V8H8V6Z" fill="currentColor" />
+                  </svg>
+                  Pantry
+                </Button>
+              </section>
+
+              {/* Desktop: inventory sidebar */}
+              <aside className="flex-3 min-w-0 hidden lg:flex flex-col overflow-y-auto bg-muted paper">
                 <InventoryWrapper />
-              </TabsContent>
-              <TabsContent value="recipe">
-                <RecipeList />
-              </TabsContent>
-            </Tabs>
-          </aside>
-        </div>
+              </aside>
+            </div>
+          </TabsContent>
+
+          {/* ── Cookbook tab ── */}
+          <TabsContent value="cookbook" className="flex-1 min-h-0 mt-0 overflow-hidden border border-border rounded-lg">
+            <RecipeList onChatClick={() => setActiveTab("chat")} />
+          </TabsContent>
+        </Tabs>
       </main>
 
-      <div className="absolute top-7 sm:top-9 md:top-13 right-3 flex items-center gap-2">
-        <AboutPopOver svgSize="18" className="lg:hidden" />
-        <Drawer
-          direction="right"
-          open={isDrawerOpen}
-          onOpenChange={setIsDrawerOpen}
-        >
-          <DrawerTrigger asChild>
-            <Button
-              variant="secondary"
-              className="flex items-center gap-1  cursor-pointer lg:hidden"
-            >
-              <svg
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M9 21V22H7V21C6.46957 21 5.96086 20.7893 5.58579 20.4142C5.21071 20.0391 5 19.5304 5 19V4C5 3.46957 5.21071 2.96086 5.58579 2.58579C5.96086 2.21071 6.46957 2 7 2H17C17.5304 2 18.0391 2.21071 18.4142 2.58579C18.7893 2.96086 19 3.46957 19 4V19C19 19.5304 18.7893 20.0391 18.4142 20.4142C18.0391 20.7893 17.5304 21 17 21V22H15V21H9ZM7 4V9H17V4H7ZM7 19H17V11H7V19ZM8 12H10V15H8V12ZM8 6H10V8H8V6Z"
-                  fill="currentColor"
-                />
-              </svg>
-              Kitchen
-            </Button>
-          </DrawerTrigger>
-          <DrawerContent aria-label="Inventory">
-            <DrawerTitle className="sr-only">Inventory</DrawerTitle>
-            <div className="flex-1 overflow-auto px-4 pt-8">
-              <Tabs defaultValue="inventory">
-                <TabsList>
-                  <TabsTrigger value="inventory">Inventory</TabsTrigger>
-                  <TabsTrigger value="recipe">Recipe</TabsTrigger>
-                </TabsList>
-                <TabsContent value="inventory">
-                  <InventoryWrapper />
-                </TabsContent>
-                <TabsContent value="recipe">
-                  <RecipeList />
-                </TabsContent>
-              </Tabs>
-            </div>
-          </DrawerContent>
-        </Drawer>
-      </div>
+      {/* Mobile: pantry bottom sheet */}
+      <Drawer open={pantryOpen} onOpenChange={setPantryOpen} direction="bottom">
+        <DrawerContent aria-label="Pantry">
+          <DrawerTitle className="sr-only">Pantry</DrawerTitle>
+          <div className="px-4 pt-6 pb-8 overflow-y-auto max-h-[75vh]">
+            <InventoryWrapper />
+          </div>
+        </DrawerContent>
+      </Drawer>
+
+      {/* Recipe detail sheet — triggered from Cookbook tab */}
+      <Sheet open={!!selectedRecipe} onOpenChange={(open) => !open && exitRecipe()}>
+        <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto p-0">
+          <RecipeDisplay />
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -20,7 +20,7 @@ export const Message = ({ className, from, ...props }: MessageProps) => (
 );
 
 const messageContentVariants = cva(
-  "is-user:dark flex flex-col gap-2 overflow-hidden text-sm",
+  "flex flex-col gap-2 overflow-hidden text-sm",
   {
     variants: {
       variant: {

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -20,18 +20,18 @@ export const Message = ({ className, from, ...props }: MessageProps) => (
 );
 
 const messageContentVariants = cva(
-  "is-user:dark flex flex-col gap-2 overflow-hidden rounded-lg text-sm",
+  "is-user:dark flex flex-col gap-2 overflow-hidden text-sm",
   {
     variants: {
       variant: {
         contained: [
-          "max-w-[80%] px-4 py-3",
-          "group-[.is-user]:bg-primary group-[.is-user]:text-primary-foreground",
-          "group-[.is-assistant]:bg-secondary group-[.is-assistant]:text-foreground",
+          "max-w-[80%] px-4 py-3 rounded-lg",
+          "group-[.is-user]:bg-secondary group-[.is-user]:text-secondary-foreground",
+          "group-[.is-assistant]:bg-muted group-[.is-assistant]:text-foreground",
         ],
         flat: [
-          "group-[.is-user]:max-w-[80%] group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
-          "group-[.is-assistant]:text-foreground",
+          "group-[.is-user]:max-w-[80%] group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-2.5 group-[.is-user]:text-secondary-foreground group-[.is-user]:border group-[.is-user]:border-[oklch(0.78_0.10_88)] group-[.is-user]:rounded-tl-[14px] group-[.is-user]:rounded-tr-[14px] group-[.is-user]:rounded-br-[4px] group-[.is-user]:rounded-bl-[14px] group-[.is-user]:shadow-[0_1px_0_oklch(0.78_0.10_88)]",
+          "group-[.is-assistant]:text-foreground group-[.is-assistant]:font-display group-[.is-assistant]:italic",
         ],
       },
     },

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-4 md:gap-6 rounded-xl border py-4 md:py-6  shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-4 md:gap-6 rounded-xl border py-4 md:py-6 shadow-[0_1px_3px_-1px_oklch(0.30_0.04_50/0.08),0_2px_8px_-3px_oklch(0.30_0.04_50/0.06)]",
         className
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { XIcon } from "lucide-react"
-import { Dialog as SheetPrimitive } from "radix-ui"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          side === "right" &&
+            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          side === "left" &&
+            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          side === "top" &&
+            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          side === "bottom" &&
+            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ function Tabs({
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
-      className={cn("flex flex-col gap-2", className)}
+      className={cn("flex flex-col gap-0", className)}
       {...props}
     />
   )
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "relative z-10 flex items-end gap-1 pt-5 px-4",
         className
       )}
       {...props}
@@ -42,7 +42,12 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative px-5 py-2.5 text-sm font-medium cursor-pointer transition-colors whitespace-nowrap -mb-px",
+        "text-ink-faint hover:text-foreground",
+        "border border-transparent rounded-t-xl",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        "disabled:pointer-events-none disabled:opacity-50",
+        "data-[state=active]:bg-chat data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:border-border data-[state=active]:border-b-chat",
         className
       )}
       {...props}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -19,6 +19,8 @@ import { MessageList } from "./components/MessageList";
 import { INITIAL_MESSAGE, LOADING_MESSAGES } from "./constants";
 import { convertToUIMessage, getRandomThinkingMessage } from "./utils";
 
+const SUGGESTIONS = ["What can I cook tonight?", "I just got groceries", "Something quick for one"];
+
 const Chat = () => {
   const { userId } = useSessionContext();
 
@@ -187,8 +189,6 @@ const Chat = () => {
 
   const dayName = new Date().toLocaleDateString("en-US", { weekday: "long" });
   const messageCount = allMessages.length - 1; // exclude initial
-
-  const SUGGESTIONS = ["What can I cook tonight?", "I just got groceries", "Something quick for one"];
 
   return (
     <div className="flex flex-col animate-in fade-in duration-300 h-full">

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -22,7 +22,7 @@ import { convertToUIMessage, getRandomThinkingMessage } from "./utils";
 const Chat = () => {
   const { userId } = useSessionContext();
 
-  const { messages, sendMessage, status, error } = useChat({
+  const { messages, sendMessage, status } = useChat({
     transport: new DefaultChatTransport({
       api: "/api/chat",
       body: {
@@ -185,14 +185,42 @@ const Chat = () => {
     await saveMessage("user", message);
   };
 
+  const dayName = new Date().toLocaleDateString("en-US", { weekday: "long" });
+  const messageCount = allMessages.length - 1; // exclude initial
+
+  const SUGGESTIONS = ["What can I cook tonight?", "I just got groceries", "Something quick for one"];
+
   return (
-    <div className="flex flex-col animate-in fade-in  duration-300 h-full">
+    <div className="flex flex-col animate-in fade-in duration-300 h-full">
+      <div className="hidden sm:flex items-center justify-between px-7 py-3.5 border-b border-dashed border-border shrink-0">
+        <div>
+          <div className="font-display italic font-medium text-[19px] text-foreground leading-tight tracking-tight">
+            {dayName}&rsquo;s kitchen
+          </div>
+          <div className="text-[11.5px] text-ink-faint mt-0.5 tracking-wide">
+            {messageCount > 0 ? `${messageCount} message${messageCount !== 1 ? "s" : ""}` : "Start a conversation"}
+          </div>
+        </div>
+      </div>
       <MessageList
         messages={allMessages}
         status={status}
         userId={userId}
         thinkingMessage={thinkingMessage}
       />
+      {status === "ready" && messageCount === 0 && (
+        <div className="flex gap-2 px-4 pb-1 flex-wrap">
+          {SUGGESTIONS.map((s) => (
+            <button
+              key={s}
+              onClick={() => handleSendMessage(s)}
+              className="px-3 py-1.5 text-[12.5px] text-muted-foreground border border-border rounded-full hover:border-border-soft hover:text-foreground transition-colors cursor-pointer"
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
       <MessageInput
         onSendMessage={handleSendMessage}
         disabled={status !== "ready"}

--- a/src/features/Chat/components/MessageInput.test.tsx
+++ b/src/features/Chat/components/MessageInput.test.tsx
@@ -76,7 +76,7 @@ describe("MessageInput", () => {
 
       const input = screen.getByTestId("input");
       expect(input).toBeInTheDocument();
-      expect(input).toHaveAttribute("placeholder", "Ask Ah Mah a question...");
+      expect(input).toHaveAttribute("placeholder", "Ask Ah Mah a question…");
     });
 
     it("should render submit button with send icon", () => {
@@ -104,7 +104,7 @@ describe("MessageInput", () => {
       expect(form).toBeInTheDocument();
       expect(form).toHaveClass("p-4");
 
-      const flexContainer = form?.querySelector(".flex.gap-2");
+      const flexContainer = form?.querySelector(".flex.gap-1");
       expect(flexContainer).toBeInTheDocument();
     });
 

--- a/src/features/Chat/components/MessageInput.tsx
+++ b/src/features/Chat/components/MessageInput.tsx
@@ -18,33 +18,32 @@ export const MessageInput = ({
       onSubmit={async (e) => {
         e.preventDefault();
         if (input.trim()) {
-          await onSendMessage(input); // Save user message
+          await onSendMessage(input);
           setInput("");
         }
       }}
-      className=" p-4"
+      className="p-4"
     >
-      <div className="flex gap-2">
+      <div className="flex gap-1 items-center bg-muted/50 rounded-xl border border-border/60 px-3 py-1">
         <Input
           value={input}
           onChange={(e) => setInput(e.target.value)}
           disabled={disabled}
-          placeholder={
-            disabled ? `Sending your question...` : `Ask Ah Mah a question...`
-          }
-          className="flex-1"
+          placeholder={disabled ? "Sending your question…" : "Ask Ah Mah a question…"}
+          className="flex-1 border-none shadow-none bg-transparent focus-visible:ring-0 px-0"
         />
         <Button
           type="submit"
+          size="icon"
           aria-label="Send message"
-          className="disabled:cursor-not-allowed"
+          className="shrink-0 disabled:cursor-not-allowed rounded-lg"
           disabled={disabled}
         >
           <svg
             aria-hidden="true"
             focusable="false"
-            width="24"
-            height="24"
+            width="18"
+            height="18"
             viewBox="0 0 24 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"

--- a/src/features/Chat/components/MessageInput.tsx
+++ b/src/features/Chat/components/MessageInput.tsx
@@ -3,7 +3,7 @@ import { Input } from "@/components/ui/input";
 import { useState } from "react";
 
 interface MessageInputProps {
-  onSendMessage: (message: string) => void;
+  onSendMessage: (message: string) => Promise<void>;
   disabled: boolean;
 }
 

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -8,10 +8,19 @@ import {
   InventoryItem,
 } from "@/lib/inventory/schemas";
 import { fetcher } from "@/lib/utils/index";
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
 import { InventoryItemBadge } from "./components/InventoryItemBadge";
+
+const SectionLabel = ({ children, count }: { children: ReactNode; count?: number }) => (
+  <div className="flex items-center justify-between border-b border-dashed border-border pb-2.5 mb-3">
+    <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">{children}</span>
+    {count !== undefined && (
+      <span className="font-mono text-[11px] text-ink-faint tabular-nums">{count}</span>
+    )}
+  </div>
+);
 
 const Inventory = () => {
   const [isAdding, setIsAdding] = useState(false);
@@ -90,38 +99,32 @@ const Inventory = () => {
   );
 
   return (
-    <div className="mt-2 space-y-4 animate-in fade-in duration-300 ">
-      {isAdding || (
-        <div className="flex items-center justify-end">
-          {/* <h2 className="text-2xl font-bold">Inventory</h2> */}
-          <Button
-            className="cursor-pointer w-full"
-            onClick={() => setIsAdding(!isAdding)}
-            variant={isAdding ? "outline" : "secondary"}
-          >
-            {isAdding || (
-              <svg
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M11 13H5V11H11V5H13V11H19V13H13V19H11V13Z"
-                  fill="currentColor"
-                />
-              </svg>
-            )}
-            {isAdding ? "Cancel" : "Add Item"}
-          </Button>
+    <div className="flex flex-col gap-4 animate-in fade-in duration-300 p-5 h-full">
+      {/* Pantry header */}
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="font-display italic font-medium text-[22px] text-foreground leading-tight tracking-tight">
+            Pantry
+          </div>
+          <div className="text-xs text-ink-faint mt-0.5">What&rsquo;s on Ah Mah&rsquo;s shelves</div>
         </div>
-      )}
+        {!isAdding && (
+          <button
+            onClick={() => setIsAdding(true)}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-semibold text-foreground bg-card border border-border rounded-lg shadow-[0_1px_0_oklch(0.82_0.04_70)] hover:bg-background transition-colors cursor-pointer"
+          >
+            <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+              <path d="M6 1.5V10.5M1.5 6H10.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+            </svg>
+            Add
+          </button>
+        )}
+      </div>
 
       {isAdding && (
         <Card>
           <CardHeader>
-            <CardTitle>What did you get?</CardTitle>
+            <CardTitle className="font-display text-xl tracking-tight">What did you get?</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             <textarea
@@ -153,79 +156,40 @@ const Inventory = () => {
           </CardContent>
         </Card>
       )}
-      <Card className="shadow-none">
-        <CardHeader>
-          <CardTitle>Ingredients</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isLoading && <div>Looking in the pantry...</div>}
-          {ingredientsSorted?.length === 0 ? (
-            <p className="text-muted-foreground">No ingredients yet</p>
-          ) : (
-            <div className="flex flex-wrap gap-2">
-              {ingredientsSorted?.map((item: InventoryItem) => (
-                <InventoryItemBadge
-                  key={item.id}
-                  item={item}
-                  onRemove={removeItem}
-                />
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-      <Card className="shadow-none">
-        <CardHeader>
-          <CardTitle>Kitchenware</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isLoading && <div>Rummaging through the cupboards...</div>}
-          {kitchenwareSorted?.length === 0 ? (
-            <p className="text-muted-foreground">No kitchenware yet</p>
-          ) : (
-            <div className="flex flex-wrap gap-2">
-              {kitchenwareSorted?.map((item: InventoryItem) => (
-                // <Badge
-                //   key={item.id}
-                //   variant="outline"
-                //   className="relative pr-6 py-1"
-                // >
-                //   {item.name}
-                //   {item.quantity &&
-                //     item.quantity > 1 &&
-                //     ` (${item.quantity}${item.unit ? ` ${item.unit}` : ""})`}
-                //   {item.quantity === 1 &&
-                //     item.unit &&
-                //     ` (${item.quantity} ${item.unit})`}
-                //   <button
-                //     onClick={() => removeItem(item.name)}
-                //     className="absolute right-1 cursor-pointer"
-                //   >
-                //     <svg
-                //       className="text-gray-400 hover:text-gray-500"
-                //       width="16"
-                //       height="16"
-                //       viewBox="0 0 20 20"
-                //       fill="none"
-                //       xmlns="http://www.w3.org/2000/svg"
-                //     >
-                //       <path
-                //         d="M14.3479 14.8489C14.1228 15.0739 13.8176 15.2003 13.4994 15.2003C13.1811 15.2003 12.8759 15.0739 12.6509 14.8489L9.99989 11.8189L7.34889 14.8479C7.23779 14.9608 7.10544 15.0506 6.95946 15.1121C6.81349 15.1736 6.65677 15.2056 6.49837 15.2063C6.33996 15.2069 6.18299 15.1762 6.03652 15.1159C5.89004 15.0555 5.75696 14.9668 5.64495 14.8548C5.53294 14.7428 5.44421 14.6097 5.38389 14.4632C5.32357 14.3168 5.29285 14.1598 5.29349 14.0014C5.29414 13.843 5.32614 13.6863 5.38765 13.5403C5.44916 13.3943 5.53897 13.262 5.65189 13.1509L8.40989 10.0009L5.65089 6.84887C5.53797 6.73777 5.44816 6.60542 5.38665 6.45944C5.32514 6.31346 5.29314 6.15675 5.29249 5.99834C5.29185 5.83994 5.32257 5.68297 5.38289 5.5365C5.44321 5.39002 5.53194 5.25694 5.64395 5.14493C5.75596 5.03292 5.88905 4.94419 6.03552 4.88387C6.18199 4.82355 6.33896 4.79282 6.49737 4.79347C6.65577 4.79411 6.81249 4.82611 6.95846 4.88763C7.10444 4.94914 7.23679 5.03895 7.34789 5.15187L9.99989 8.18287L12.6509 5.15187C12.762 5.03895 12.8943 4.94914 13.0403 4.88763C13.1863 4.82611 13.343 4.79411 13.5014 4.79347C13.6598 4.79282 13.8168 4.82355 13.9633 4.88387C14.1097 4.94419 14.2428 5.03292 14.3548 5.14493C14.4668 5.25694 14.5556 5.39002 14.6159 5.5365C14.6762 5.68297 14.7069 5.83994 14.7063 5.99834C14.7056 6.15675 14.6736 6.31346 14.6121 6.45944C14.5506 6.60542 14.4608 6.73777 14.3479 6.84887L11.5899 10.0009L14.3479 13.1509C14.4595 13.2623 14.548 13.3947 14.6084 13.5403C14.6688 13.686 14.6998 13.8422 14.6998 13.9999C14.6998 14.1576 14.6688 14.3137 14.6084 14.4594C14.548 14.6051 14.4595 14.7374 14.3479 14.8489Z"
-                //         fill="currentColor"
-                //       />
-                //     </svg>
-                //   </button>
-                // </Badge>
-                <InventoryItemBadge
-                  key={item.id}
-                  item={item}
-                  onRemove={removeItem}
-                />
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+
+      {/* Ingredients card */}
+      <section className="bg-card border border-border rounded-xl p-3.5 shadow-[0_1px_0_oklch(0.87_0.03_72),0_8px_18px_-16px_oklch(0.3_0.05_50/0.4)]">
+        <SectionLabel count={ingredientsSorted?.length ?? 0}>Ingredients</SectionLabel>
+        {isLoading && <p className="text-xs text-muted-foreground font-display italic">Looking in the pantry…</p>}
+        {!isLoading && ingredientsSorted?.length === 0 ? (
+          <p className="text-[13px] font-display italic text-ink-faint leading-snug">
+            Add what&rsquo;s in your fridge — Ah Mah understands &ldquo;a bit of ginger&rdquo;.
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {ingredientsSorted?.map((item: InventoryItem) => (
+              <InventoryItemBadge key={item.id} item={item} onRemove={removeItem} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Equipment card */}
+      <section className="bg-card border border-border rounded-xl p-3.5 shadow-[0_1px_0_oklch(0.87_0.03_72),0_8px_18px_-16px_oklch(0.3_0.05_50/0.4)]">
+        <SectionLabel count={kitchenwareSorted?.length ?? 0}>Equipment</SectionLabel>
+        {isLoading && <p className="text-xs text-muted-foreground font-display italic">Rummaging through the cupboards…</p>}
+        {!isLoading && kitchenwareSorted?.length === 0 ? (
+          <p className="text-[13px] font-display italic text-ink-faint leading-snug">
+            Got a wok? A pressure cooker? Tell Ah Mah what you cook with.
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {kitchenwareSorted?.map((item: InventoryItem) => (
+              <InventoryItemBadge key={item.id} item={item} onRemove={removeItem} />
+            ))}
+          </div>
+        )}
+      </section>
     </div>
   );
 };

--- a/src/features/Inventory/components/InventoryItemBadge.tsx
+++ b/src/features/Inventory/components/InventoryItemBadge.tsx
@@ -11,12 +11,12 @@ export const InventoryItemBadge = ({
   onRemove,
 }: InventoryItemBadgeProps) => {
   return (
-    <Badge key={item.id} variant="outline" className="relative pr-8 pl-3 py-2">
+    <Badge key={item.id} variant="outline" className="relative pr-8 pl-3 py-1.5 bg-background border-border rounded-md shadow-[0_1px_0_oklch(0.82_0.04_70)] text-foreground">
       {item.shelfLife === "short" && (
         <span
           aria-label="Short shelf life"
           title="Short shelf life — use soon"
-          className="mr-1.5 inline-block h-2 w-2 rounded-full bg-amber-500"
+          className="mr-1.5 inline-block h-2 w-2 rounded-full bg-tertiary"
         />
       )}
       {item.name}

--- a/src/features/RecipeDisplay/RecipeDisplay.test.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.test.tsx
@@ -121,10 +121,9 @@ describe("RecipeDisplay", () => {
       expect(screen.getAllByText(/2 tbsp/).length).toBeGreaterThan(0);
     });
 
-    it("renders the copy and exit buttons", () => {
+    it("renders the copy button", () => {
       render(<RecipeDisplay />);
       expect(screen.getByText("Copy")).toBeInTheDocument();
-      expect(screen.getByText("Exit")).toBeInTheDocument();
     });
   });
 
@@ -188,11 +187,4 @@ describe("RecipeDisplay", () => {
     });
   });
 
-  describe("Exit button", () => {
-    it("invokes exitRecipe from context", () => {
-      render(<RecipeDisplay />);
-      fireEvent.click(screen.getByText("Exit"));
-      expect(mockExitRecipe).toHaveBeenCalledTimes(1);
-    });
-  });
 });

--- a/src/features/RecipeDisplay/RecipeDisplay.test.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.test.tsx
@@ -52,14 +52,13 @@ jest.mock("swr", () => ({
   default: jest.fn(() => ({ data: undefined, error: undefined })),
 }));
 
-const mockExitRecipe = jest.fn();
 const mockSelectedRecipe = jest.fn();
 
 jest.mock("@/contexts/RecipeContext", () => ({
   useRecipeContext: () => ({
     selectedRecipe: mockSelectedRecipe(),
     setSelectedRecipe: jest.fn(),
-    exitRecipe: mockExitRecipe,
+    exitRecipe: jest.fn(),
   }),
 }));
 

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -7,6 +7,7 @@ import {
   InventoryItem,
 } from "@/lib/inventory/schemas";
 import { RecipeIngredient } from "@/lib/recipes/schemas";
+import { tagClasses } from "@/lib/recipes/tagColors";
 import { fetcher } from "@/lib/utils/index";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -41,7 +42,7 @@ const computeShortfall = (
 };
 
 export default function RecipeDisplay() {
-  const { selectedRecipe, exitRecipe } = useRecipeContext();
+  const { selectedRecipe } = useRecipeContext();
   const { userId } = useSessionContext();
   const [servings, setServings] = useState<number>(
     selectedRecipe?.baseServings ?? 2,
@@ -77,31 +78,24 @@ export default function RecipeDisplay() {
   const scale = servings / baseServings;
 
   return (
-    <div className="h-full relative">
-      <div className="absolute right-4 top-4 flex gap-2">
+    <div className="flex flex-col h-full">
+      <div className="flex justify-end p-4 pb-0">
         <Button
           variant="outline"
+          size="sm"
           className="cursor-pointer"
           onClick={copyRecipe}
           aria-label="Copy recipe to clipboard"
         >
           Copy
         </Button>
-        <Button
-          variant="outline"
-          className="cursor-pointer gap-1"
-          onClick={exitRecipe}
-        >
-          Exit
-          <span className="hidden md:block">Recipe</span>
-        </Button>
       </div>
 
-      <div className="h-full overflow-y-auto pt-15 xl:pt-4 pb-10 px-4 ">
+      <div className="flex-1 overflow-y-auto pt-4 pb-10 px-4">
         {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-4">
             {selectedRecipe.tags.map((tag: string) => (
-              <Badge key={tag} variant="secondary">
+              <Badge key={tag} variant="outline" className={tagClasses(tag)}>
                 {tag}
               </Badge>
             ))}
@@ -111,7 +105,7 @@ export default function RecipeDisplay() {
         {ingredients.length > 0 && (
           <div className="mb-6 rounded-lg border p-4 space-y-3">
             <div className="flex items-center justify-between">
-              <h3 className="font-semibold">Ingredients</h3>
+              <h3 className="font-display text-xl font-semibold tracking-tight">Ingredients</h3>
               <div className="flex items-center gap-2">
                 <span className="text-sm text-muted-foreground">Servings</span>
                 <Button
@@ -158,7 +152,7 @@ export default function RecipeDisplay() {
                     </span>
                     {short != null && (
                       <span
-                        className="text-xs text-amber-700 bg-amber-100 px-1.5 py-0.5 rounded"
+                        className="text-xs text-destructive bg-destructive/10 border border-destructive/30 px-1.5 py-0.5 rounded"
                         title={`You have ${inv?.quantity}${inv?.unit ? ` ${inv.unit}` : ""}`}
                       >
                         short {formatAmount(short)}

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -27,11 +27,12 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
 
   const deleteRecipe = async (recipeId: string) => {
     try {
-      await fetch(`/api/recipe`, {
+      const res = await fetch(`/api/recipe`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ recipeId }),
       });
+      if (!res.ok) throw new Error("Delete failed");
       mutate(`/api/recipe?userId=${userId}`);
       toast.success("Recipe deleted");
     } catch {

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -1,23 +1,28 @@
-import { Card, CardContent } from "@/components/ui/card";
+"use client";
+
 import { useRecipeContext } from "@/contexts/RecipeContext";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { RecipeWithId } from "@/lib/recipes/schemas";
 import { fetcher } from "@/lib/utils/index";
+import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
-import RecipeButton from "./components/RecipeButton";
+import RecipeCard from "./components/RecipeCard";
 
-export default function RecipeList() {
+interface RecipeListProps {
+  onChatClick?: () => void;
+}
+
+export default function RecipeList({ onChatClick }: RecipeListProps) {
   const { userId } = useSessionContext();
   const { setSelectedRecipe } = useRecipeContext();
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
 
   const { data: recipes, isLoading } = useSWR<RecipeWithId[]>(
     userId ? `/api/recipe?userId=${userId}` : null,
     fetcher,
-    {
-      shouldRetryOnError: true,
-      revalidateOnMount: true,
-    }
+    { shouldRetryOnError: true, revalidateOnMount: true }
   );
 
   const deleteRecipe = async (recipeId: string) => {
@@ -27,34 +32,180 @@ export default function RecipeList() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ recipeId }),
       });
-      // Refresh the recipes list
       mutate(`/api/recipe?userId=${userId}`);
-      toast.success("Recipe deleted successfully");
-    } catch (error) {
-      console.error("Failed to delete recipe:", error);
+      toast.success("Recipe deleted");
+    } catch {
       toast.error("Failed to delete recipe");
     }
   };
 
+  const allRecipes = recipes ?? [];
+  const isEmpty = allRecipes.length === 0 && !isLoading;
+
+  const tagCounts = allRecipes.reduce((acc, r) => {
+    (r.tags ?? []).forEach((t) => { acc[t] = (acc[t] ?? 0) + 1; });
+    return acc;
+  }, {} as Record<string, number>);
+  const tagEntries = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]);
+
+  const filtered = allRecipes
+    .filter((r) => !activeTag || r.tags?.includes(activeTag))
+    .filter((r) => !search || r.name.toLowerCase().includes(search.toLowerCase()));
+
   return (
-    <Card className="shadow-none py-2 md:py-2">
-      <CardContent>
-        {isLoading && <div>Looking for recipes...</div>}
-        {recipes?.length === 0 ? (
-          <p className="text-muted-foreground">No recipes yet</p>
+    <div className="h-full flex flex-col bg-muted">
+      {/* Title strip */}
+      <div className="px-9 pt-6 pb-[18px] border-b border-border flex items-end justify-between gap-6 shrink-0">
+        <div>
+          <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground mb-1.5">
+            Yours, kept
+          </div>
+          <h1 className="font-display font-semibold text-[40px] text-foreground leading-none tracking-tight">
+            My Cookbook
+          </h1>
+          <p className="font-display italic text-[15px] text-muted-foreground mt-2">
+            {isEmpty
+              ? "0 saved recipes — your shelf is waiting."
+              : `${allRecipes.length} saved recipe${allRecipes.length !== 1 ? "s" : ""}`}
+          </p>
+        </div>
+        {!isEmpty && (
+          <label className="hidden sm:flex items-center gap-2 px-3 py-[7px] bg-card border border-border rounded-full min-w-[200px] text-muted-foreground cursor-text shrink-0">
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="shrink-0">
+              <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.4" />
+              <path d="m10.5 10.5 3 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+            </svg>
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search your cookbook…"
+              className="flex-1 bg-transparent border-none outline-none text-[13px] placeholder:text-muted-foreground text-foreground min-w-0"
+            />
+          </label>
+        )}
+      </div>
+
+      {/* Tag filter rail */}
+      {!isEmpty && tagEntries.length > 0 && (
+        <div className="px-9 py-3 border-b border-border flex gap-2 flex-wrap items-center shrink-0">
+          <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground mr-1">
+            Filter
+          </span>
+          <button
+            onClick={() => setActiveTag(null)}
+            className={`px-3 py-1 text-[11px] font-medium rounded-full border transition-colors cursor-pointer ${
+              !activeTag
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-transparent text-muted-foreground border-border hover:text-foreground"
+            }`}
+          >
+            All · {allRecipes.length}
+          </button>
+          {tagEntries.map(([tag, count]) => (
+            <button
+              key={tag}
+              onClick={() => setActiveTag(activeTag === tag ? null : tag)}
+              className={`px-3 py-1 text-[11px] font-medium rounded-full border transition-colors cursor-pointer ${
+                activeTag === tag
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "bg-transparent text-muted-foreground border-border hover:text-foreground"
+              }`}
+            >
+              {tag} · {count}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Grid area */}
+      <div className="flex-1 overflow-y-auto px-9 py-5">
+        {isLoading ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[18px]">
+            {[0, 1, 2].map((i) => <SkeletonCard key={i} />)}
+          </div>
+        ) : isEmpty ? (
+          <CookbookEmpty onChatClick={onChatClick} />
+        ) : filtered.length === 0 ? (
+          <p className="font-display italic text-[14px] text-muted-foreground">
+            No recipes {activeTag ? `tagged "${activeTag}"` : "matching your search"}.
+          </p>
         ) : (
-          <div className="flex flex-wrap gap-2">
-            {recipes?.map((recipe: RecipeWithId) => (
-              <RecipeButton
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[18px]">
+            {filtered.map((recipe, i) => (
+              <RecipeCard
                 key={recipe.id}
                 recipe={recipe}
                 onSelect={setSelectedRecipe}
                 onDelete={deleteRecipe}
+                dogeared={i === 0}
               />
             ))}
           </div>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
+  );
+}
+
+function CookbookEmpty({ onChatClick }: { onChatClick?: () => void }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[18px]">
+      {/* Instructional card — spans 2 rows on desktop */}
+      <div className="bg-card border-[1.5px] border-dashed border-border rounded-lg p-6 lg:row-span-2 flex flex-col gap-3.5 shadow-[0_1px_0_var(--color-border-soft)]">
+        <div className="w-11 h-11 rounded-lg bg-primary flex items-center justify-center text-primary-foreground shrink-0">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+            <path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16l-7-3-7 3z" />
+          </svg>
+        </div>
+        <div>
+          <div className="font-display font-semibold text-[22px] text-foreground leading-tight tracking-tight mb-1.5">
+            Your cookbook is empty.
+          </div>
+          <div className="font-display italic text-sm text-muted-foreground leading-relaxed">
+            When Ah Mah suggests a recipe you like, tap <em>Save to cookbook</em> and it lives here. Saved by you, ready when you need it.
+          </div>
+        </div>
+        <button
+          onClick={onChatClick}
+          className="self-start px-3.5 py-2 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
+        >
+          Ask Ah Mah for a recipe →
+        </button>
+      </div>
+
+      {/* Ghost cards */}
+      {[0, 1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="border-[1.5px] border-dashed border-border rounded-lg overflow-hidden flex flex-col opacity-55"
+        >
+          <div
+            className="h-16 border-b border-border opacity-60"
+            style={{
+              background:
+                "repeating-linear-gradient(135deg, var(--color-border-soft) 0 6px, transparent 6px 12px)",
+            }}
+          />
+          <div className="p-4 flex flex-col gap-2">
+            <div className="h-3 w-[70%] bg-border rounded" />
+            <div className="h-2 w-[90%] bg-border rounded opacity-60" />
+            <div className="h-2 w-[60%] bg-border rounded opacity-60" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div className="bg-card border border-border rounded-lg overflow-hidden animate-pulse">
+      <div className="h-28 bg-muted" />
+      <div className="p-5 flex flex-col gap-2.5">
+        <div className="h-4 w-3/4 bg-muted rounded" />
+        <div className="h-3 w-full bg-muted rounded" />
+        <div className="h-3 w-2/3 bg-muted rounded" />
+      </div>
+    </div>
   );
 }

--- a/src/features/RecipeList/components/RecipeButton.tsx
+++ b/src/features/RecipeList/components/RecipeButton.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RecipeWithId } from "@/lib/recipes/schemas";
+import { tagClasses } from "@/lib/recipes/tagColors";
 import {
   getRandomRecipeProcessingMessage,
   isTempId,
@@ -14,57 +15,59 @@ interface RecipeButtonProps {
 
 const RecipeButton = ({ recipe, onSelect, onDelete }: RecipeButtonProps) => {
   const isOptimistic = isTempId(recipe.id);
+  const ingredients = Array.isArray(recipe.ingredients) ? recipe.ingredients : [];
+  const servings = recipe.baseServings ?? 2;
+
   return (
-    <div className="w-full flex border-b last:border-b-0 py-2">
-      <Button
-        variant="ghost"
-        className="flex-1 items-start text-wrap break-words whitespace-normal h-auto cursor-pointer rounded p-2 flex-col"
+    <div className="w-full flex items-start border-b last:border-b-0 py-4 gap-2">
+      <button
+        className="flex-1 text-left space-y-2 cursor-pointer disabled:opacity-50 disabled:cursor-default px-1"
         onClick={() => onSelect(recipe)}
         disabled={isOptimistic}
       >
-        <div className="font-medium text-left">{recipe.name}</div>
-        {isOptimistic && (
-          <div className="animate-pulse text-sm text-muted-foreground text-left">
+        <div className="font-display font-semibold text-lg leading-snug tracking-tight">{recipe.name}</div>
+
+        {isOptimistic ? (
+          <div className="animate-pulse text-sm text-muted-foreground">
             {getRandomRecipeProcessingMessage()}
           </div>
+        ) : (
+          <div className="text-xs text-muted-foreground">
+            {servings} serving{servings !== 1 ? "s" : ""}
+            {ingredients.length > 0 && ` · ${ingredients.length} ingredients`}
+          </div>
         )}
+
         {recipe.tags && recipe.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-2">
-            {recipe.tags.slice(0, 4).map((tag, index) => (
+          <div className="flex flex-wrap gap-1">
+            {recipe.tags.slice(0, 5).map((tag, index) => (
               <Badge
                 key={index}
-                variant="secondary"
-                className="text-xs px-2 py-0.5 border border-background"
+                variant="outline"
+                className={`text-xs px-2 py-0.5 ${tagClasses(tag)}`}
               >
                 {tag}
               </Badge>
             ))}
-            {recipe.tags.length > 4 && (
-              <Badge variant="secondary" className="text-xs px-2 py-0.5">
-                +{recipe.tags.length - 4}
+            {recipe.tags.length > 5 && (
+              <Badge variant="outline" className="text-xs px-2 py-0.5 bg-muted text-muted-foreground border-border">
+                +{recipe.tags.length - 5}
               </Badge>
             )}
           </div>
         )}
-      </Button>
+      </button>
+
       <Button
         variant="ghost"
-        className="cursor-pointer"
+        size="icon"
+        className="shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
         disabled={isOptimistic}
         onClick={() => onDelete(recipe.id)}
+        aria-label={`Delete ${recipe.name}`}
       >
-        <svg
-          className="text-gray-400 hover:text-gray-500"
-          width="16"
-          height="16"
-          viewBox="0 0 20 20"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M14.3479 14.8489C14.1228 15.0739 13.8176 15.2003 13.4994 15.2003C13.1811 15.2003 12.8759 15.0739 12.6509 14.8489L9.99989 11.8189L7.34889 14.8479C7.23779 14.9608 7.10544 15.0506 6.95946 15.1121C6.81349 15.1736 6.65677 15.2056 6.49837 15.2063C6.33996 15.2069 6.18299 15.1762 6.03652 15.1159C5.89004 15.0555 5.75696 14.9668 5.64495 14.8548C5.53294 14.7428 5.44421 14.6097 5.38389 14.4632C5.32357 14.3168 5.29285 14.1598 5.29349 14.0014C5.29414 13.843 5.32614 13.6863 5.38765 13.5403C5.44916 13.3943 5.53897 13.262 5.65189 13.1509L8.40989 10.0009L5.65089 6.84887C5.53797 6.73777 5.44816 6.60542 5.38665 6.45944C5.32514 6.31346 5.29314 6.15675 5.29249 5.99834C5.29185 5.83994 5.32257 5.68297 5.38289 5.5365C5.44321 5.39002 5.53194 5.25694 5.64395 5.14493C5.75596 5.03292 5.88905 4.94419 6.03552 4.88387C6.18199 4.82355 6.33896 4.79282 6.49737 4.79347C6.65577 4.79411 6.81249 4.82611 6.95846 4.88763C7.10444 4.94914 7.23679 5.03895 7.34789 5.15187L9.99989 8.18287L12.6509 5.15187C12.762 5.03895 12.8943 4.94914 13.0403 4.88763C13.1863 4.82611 13.343 4.79411 13.5014 4.79347C13.6598 4.79282 13.8168 4.82355 13.9633 4.88387C14.1097 4.94419 14.2428 5.03292 14.3548 5.14493C14.4668 5.25694 14.5556 5.39002 14.6159 5.5365C14.6762 5.68297 14.7069 5.83994 14.7063 5.99834C14.7056 6.15675 14.6736 6.31346 14.6121 6.45944C14.5506 6.60542 14.4608 6.73777 14.3479 6.84887L11.5899 10.0009L14.3479 13.1509C14.4595 13.2623 14.548 13.3947 14.6084 13.5403C14.6688 13.686 14.6998 13.8422 14.6998 13.9999C14.6998 14.1576 14.6688 14.3137 14.6084 14.4594C14.548 14.6051 14.4595 14.7374 14.3479 14.8489Z"
-            fill="currentColor"
-          />
+        <svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M14.3479 14.8489C14.1228 15.0739 13.8176 15.2003 13.4994 15.2003C13.1811 15.2003 12.8759 15.0739 12.6509 14.8489L9.99989 11.8189L7.34889 14.8479C7.23779 14.9608 7.10544 15.0506 6.95946 15.1121C6.81349 15.1736 6.65677 15.2056 6.49837 15.2063C6.33996 15.2069 6.18299 15.1762 6.03652 15.1159C5.89004 15.0555 5.75696 14.9668 5.64495 14.8548C5.53294 14.7428 5.44421 14.6097 5.38389 14.4632C5.32357 14.3168 5.29285 14.1598 5.29349 14.0014C5.29414 13.843 5.32614 13.6863 5.38765 13.5403C5.44916 13.3943 5.53897 13.262 5.65189 13.1509L8.40989 10.0009L5.65089 6.84887C5.53797 6.73777 5.44816 6.60542 5.38665 6.45944C5.32514 6.31346 5.29314 6.15675 5.29249 5.99834C5.29185 5.83994 5.32257 5.68297 5.38289 5.5365C5.44321 5.39002 5.53194 5.25694 5.64395 5.14493C5.75596 5.03292 5.88905 4.94419 6.03552 4.88387C6.18199 4.82355 6.33896 4.79282 6.49737 4.79347C6.65577 4.79411 6.81249 4.82611 6.95846 4.88763C7.10444 4.94914 7.23679 5.03895 7.34789 5.15187L9.99989 8.18287L12.6509 5.15187C12.762 5.03895 12.8943 4.94914 13.0403 4.88763C13.1863 4.82611 13.343 4.79411 13.5014 4.79347C13.6598 4.79282 13.8168 4.82355 13.9633 4.88387C14.1097 4.94419 14.2428 5.03292 14.3548 5.14493C14.4668 5.25694 14.5556 5.39002 14.6159 5.5365C14.6762 5.68297 14.7069 5.83994 14.7063 5.99834C14.7056 6.15675 14.6736 6.31346 14.6121 6.45944C14.5506 6.60542 14.4608 6.73777 14.3479 6.84887L11.5899 10.0009L14.3479 13.1509C14.4595 13.2623 14.548 13.3947 14.6084 13.5403C14.6688 13.686 14.6998 13.8422 14.6998 13.9999C14.6998 14.1576 14.6688 14.3137 14.6084 14.4594C14.548 14.6051 14.4595 14.7374 14.3479 14.8489Z" fill="currentColor" />
         </svg>
       </Button>
     </div>

--- a/src/features/RecipeList/components/RecipeButton.tsx
+++ b/src/features/RecipeList/components/RecipeButton.tsx
@@ -5,7 +5,7 @@ import { tagClasses } from "@/lib/recipes/tagColors";
 import {
   getRandomRecipeProcessingMessage,
   isTempId,
-} from "../../Chat/constants";
+} from "@/features/Chat/constants";
 
 interface RecipeButtonProps {
   recipe: RecipeWithId;

--- a/src/features/RecipeList/components/RecipeCard.tsx
+++ b/src/features/RecipeList/components/RecipeCard.tsx
@@ -1,5 +1,5 @@
 import { RecipeWithId } from "@/lib/recipes/schemas";
-import { getRandomRecipeProcessingMessage, isTempId } from "../../Chat/constants";
+import { getRandomRecipeProcessingMessage, isTempId } from "@/features/Chat/constants";
 
 interface RecipeCardProps {
   recipe: RecipeWithId;

--- a/src/features/RecipeList/components/RecipeCard.tsx
+++ b/src/features/RecipeList/components/RecipeCard.tsx
@@ -1,0 +1,99 @@
+import { RecipeWithId } from "@/lib/recipes/schemas";
+import { getRandomRecipeProcessingMessage, isTempId } from "../../Chat/constants";
+
+interface RecipeCardProps {
+  recipe: RecipeWithId;
+  onSelect: (recipe: RecipeWithId) => void;
+  onDelete: (recipeId: string) => void;
+  dogeared?: boolean;
+}
+
+export default function RecipeCard({ recipe, onSelect, onDelete, dogeared }: RecipeCardProps) {
+  const isOptimistic = isTempId(recipe.id);
+  const ingredients = Array.isArray(recipe.ingredients) ? recipe.ingredients as { name: string }[] : [];
+  const servings = recipe.baseServings ?? 2;
+
+  const blurb = ingredients.length > 0
+    ? ingredients.slice(0, 4).map((i) => i.name).join(", ") + (ingredients.length > 4 ? "…" : ".")
+    : `${servings} serving${servings !== 1 ? "s" : ""}.`;
+
+  const meta = `${servings} serving${servings !== 1 ? "s" : ""}${ingredients.length > 0 ? ` · ${ingredients.length} ingredients` : ""}`;
+
+  return (
+    <article
+      className="bg-card border border-border rounded-lg overflow-hidden flex flex-col relative group cursor-pointer shadow-[0_1px_0_var(--color-border-soft),0_18px_28px_-24px_oklch(0.3_0.05_50/0.5)] transition-shadow hover:shadow-[0_1px_0_var(--color-border-soft),0_24px_36px_-24px_oklch(0.3_0.05_50/0.6)]"
+      onClick={() => !isOptimistic && onSelect(recipe)}
+    >
+      {/* Dog-ear fold in top-right corner */}
+      {dogeared && (
+        <div
+          className="absolute top-0 right-0 w-[22px] h-[22px] z-10"
+          style={{
+            background: `linear-gradient(225deg, var(--color-muted) 50%, transparent 50%)`,
+            borderTopRightRadius: 10,
+            borderBottom: `1px solid var(--color-border)`,
+            borderLeft: `1px solid var(--color-border)`,
+          }}
+        />
+      )}
+
+      {/* Delete button — revealed on hover */}
+      <button
+        className="absolute top-2 right-2 z-20 p-1.5 rounded-md bg-card border border-border opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer text-muted-foreground hover:text-foreground"
+        style={{ display: dogeared ? 'none' : undefined }}
+        onClick={(e) => { e.stopPropagation(); onDelete(recipe.id); }}
+        aria-label={`Delete ${recipe.name}`}
+      >
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+          <path d="M3 3l10 10M13 3L3 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
+
+      {/* Image strip */}
+      <div
+        className="h-28 border-b border-border flex items-center justify-center shrink-0"
+        style={{
+          background:
+            "repeating-linear-gradient(135deg, oklch(0.84 0.05 60) 0 8px, oklch(0.80 0.05 60) 8px 16px)",
+        }}
+      >
+        {isOptimistic && (
+          <span className="font-mono text-[10px] tracking-widest text-foreground/40 uppercase">
+            Saving…
+          </span>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex flex-col flex-1 p-5 gap-2.5">
+        {isOptimistic ? (
+          <div className="animate-pulse font-display italic text-sm text-muted-foreground">
+            {getRandomRecipeProcessingMessage()}
+          </div>
+        ) : (
+          <>
+            <div className="font-display font-semibold text-xl text-foreground leading-tight tracking-tight group-hover:text-primary transition-colors line-clamp-2">
+              {recipe.name}
+            </div>
+            <div className="font-display italic text-[13.5px] text-muted-foreground leading-[1.45] line-clamp-2">
+              {blurb}
+            </div>
+          </>
+        )}
+
+        {/* Footer */}
+        <div className="mt-auto pt-2.5 border-t border-dashed border-border flex items-center gap-2.5 flex-wrap">
+          <span className="font-mono text-[11px] text-ink-faint">{meta}</span>
+          {recipe.tags?.slice(0, 3).map((tag) => (
+            <span
+              key={tag}
+              className="text-[11px] font-medium px-2 py-0.5 border border-border rounded-full text-muted-foreground"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/lib/recipes/recipeProcessor.ts
+++ b/src/lib/recipes/recipeProcessor.ts
@@ -1,6 +1,7 @@
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { z } from "zod";
+import { TAG_SETS } from "./tagColors";
 
 // Extract metadata from a recipe. We don't ask the model to re-emit the
 // recipe text — passing raw instructions through is more reliable and the
@@ -46,15 +47,9 @@ const RecipeMetadataSchema = z.object({
 
 export type RecipeMetadata = z.infer<typeof RecipeMetadataSchema>;
 
-const TAG_CATEGORIES = `
-CUISINE: italian, chinese, japanese, mexican, indian, thai, french, mediterranean, american, korean, vietnamese, middle-eastern, greek, spanish, moroccan, malaysian, singaporean
-PROTEIN: chicken, beef, pork, fish, seafood, vegetarian, vegan, eggs, tofu, beans, lentils
-METHOD: baked, fried, grilled, steamed, boiled, roasted, sauteed, stir-fried, braised, slow-cooked, pressure-cooked, air-fried, no-cook, raw, marinated, fermented, pickled
-MEAL: breakfast, lunch, dinner, snack, appetizer, dessert, side-dish, main-course, soup, salad, beverage, condiment
-DIFFICULTY: beginner, easy, intermediate, advanced, quick (under 30 min), one-pot, make-ahead
-STYLE: crispy, creamy, spicy, sweet, savory, tangy, hearty, light, refreshing, warming
-EQUIPMENT: wok, instant-pot, cast-iron, slow-cooker, blender, oven-free, grill
-`;
+const TAG_CATEGORIES = Object.entries(TAG_SETS)
+  .map(([cat, tags]) => `${cat.toUpperCase()}: ${tags.join(", ")}`)
+  .join("\n");
 
 export async function processRecipe(
   recipeName: string,

--- a/src/lib/recipes/tagColors.ts
+++ b/src/lib/recipes/tagColors.ts
@@ -1,0 +1,66 @@
+// Single source of truth for recipe-tag categorization.
+// Used by tagClasses (UI color coding) and recipeProcessor (LLM tag prompt).
+
+export type TagCategory =
+  | "cuisine"
+  | "protein"
+  | "method"
+  | "meal"
+  | "difficulty"
+  | "style"
+  | "equipment"
+  | "other";
+
+export const TAG_SETS: Record<Exclude<TagCategory, "other">, readonly string[]> = {
+  cuisine: [
+    "italian", "chinese", "japanese", "mexican", "indian", "thai", "french",
+    "mediterranean", "american", "korean", "vietnamese", "middle-eastern",
+    "greek", "spanish", "moroccan", "malaysian", "singaporean",
+  ],
+  protein: [
+    "chicken", "beef", "pork", "fish", "seafood", "vegetarian", "vegan",
+    "eggs", "tofu", "beans", "lentils",
+  ],
+  method: [
+    "baked", "fried", "grilled", "steamed", "boiled", "roasted", "sauteed",
+    "stir-fried", "braised", "slow-cooked", "pressure-cooked", "air-fried",
+    "no-cook", "raw", "marinated", "fermented", "pickled",
+  ],
+  meal: [
+    "breakfast", "lunch", "dinner", "snack", "appetizer", "dessert",
+    "side-dish", "main-course", "soup", "salad", "beverage", "condiment",
+  ],
+  difficulty: [
+    "beginner", "easy", "intermediate", "advanced", "quick (under 30 min)",
+    "one-pot", "make-ahead",
+  ],
+  style: [
+    "crispy", "creamy", "spicy", "sweet", "savory", "tangy", "hearty",
+    "light", "refreshing", "warming",
+  ],
+  equipment: [
+    "wok", "instant-pot", "cast-iron", "slow-cooker", "blender", "oven-free",
+    "grill",
+  ],
+};
+
+const LOOKUP: Map<string, TagCategory> = (() => {
+  const m = new Map<string, TagCategory>();
+  for (const [cat, tags] of Object.entries(TAG_SETS)) {
+    for (const tag of tags) m.set(tag, cat as TagCategory);
+  }
+  return m;
+})();
+
+export function getTagCategory(tag: string): TagCategory {
+  return LOOKUP.get(tag.toLowerCase()) ?? "other";
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function tagClasses(_tag: string): string {
+  return "bg-muted/60 text-muted-foreground border-border";
+}
+
+export function tagActiveClasses(): string {
+  return "bg-primary text-primary-foreground border-primary";
+}


### PR DESCRIPTION
Full visual overhaul based on Claude Design output. OKLCH color system (aged newsprint bg, kraft tray, lightest chat surface, inverted card contrast). SVG feTurbulence paper texture on chat + inventory. Folder-tab pattern with z-10 TabsList covering content frame border-t. Chat header replaced with contextual day/session strip. Inventory redesigned with Fraunces italic heading and card-boxed sections. Cookbook rebuilt as 3-col grid — diagonal-stripe image cards, serif blurb, dashed footer, dog-ear fold, empty state with ghost cards. All arbitrary Tailwind values replaced with design-system tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Equipment-aware recipe adaptation and improved initial inventory seeding.
  * Tabbed layout with separate Chat and Cookbook modes; cookbook adds search, tag filters, and a shelf-style list.

* **UX Improvements**
  * Day-based chat header, suggestion prompts for new conversations, revised inventory and recipe layouts, simplified recipe actions (copy-focused).

* **Style**
  * "Kopitiam Modern" visual refresh: OKLCH color palette, paper-grain background, refined typography, scrollbar and component polish.

* **Documentation**
  * Added design reference and progress notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->