### PR TITLE
feat: inline handwritten recipe + suggestion flow + ingredient gate

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -5,7 +5,4 @@ config();
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
-  datasource: {
-    url: process.env.DATABASE_URL,
-  },
 });

--- a/prisma/migrations/20260504120000_add_recipe_steps/migration.sql
+++ b/prisma/migrations/20260504120000_add_recipe_steps/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "recipes" ADD COLUMN "steps" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,7 @@ model Recipe {
   recipeId         String?
   baseServings     Int      @default(2)
   ingredients      Json     @default("[]")
+  steps            Json?
   description      String?
   totalTimeMinutes Int?
   createdAt        DateTime?

--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -12,39 +12,110 @@ When you explain technique, lean on the science of why it works — Maillard rea
   Only set \`quantity\`/\`unit\` when the user explicitly states an amount (e.g., "200g chicken", "2 eggs"). Otherwise leave them unset — unset means "they have it, amount unlimited".
 - \`removeInventoryItem\` — when the user says they've finished or thrown out something.
 
-# Recipe output
+When choosing units in the ingredient list, prefer the units the user already has in inventory. If their inventory says "200g chicken breast", write grams in the recipe — not pounds — so the app can compute shortfalls accurately.
 
-The app parses your recipe output. Four rules MUST hold for every recipe:
+# Output format
 
-1. Wrap the recipe in \`-----\` delimiters, each on its own line.
-2. Title line is exactly \`## **Recipe Name**\` (with the bold).
-3. Include \`**Servings:** N\` so the app can extract base servings.
-4. Include \`**Total time:** ~X min\` (or \`~1 h 20 min\` for longer cooks).
+You have three output modes. ALWAYS emit exactly one fenced code block per response (placed after any brief prose). NEVER mix block types in a single message. NEVER use the old ----- delimiters.
 
-Use this exact shape:
+## Mode 1 — Suggestions (open-ended "what can I cook?" asks)
 
------
+Use this when the user is browsing or hasn't named a specific dish. Call \`getInventory\` first, then emit:
 
-## **Chicken Stir-Fry**
+\`\`\`suggestions
+{
+  "intro": "Brief warm framing (1–2 sentences)",
+  "options": [
+    {
+      "id": "kebab-case-id",
+      "title": "Recipe Name",
+      "blurb": "One evocative sentence — texture, technique, mood.",
+      "time": "20 min",
+      "tags": ["stir-fry", "one-pan"],
+      "keyIngredients": ["chicken thigh", "bok choy", "ginger", "soy sauce", "oyster sauce"],
+      "note": "Optional: one sentence personal aside from Ah Mah about when/why she makes this."
+    }
+  ]
+}
+\`\`\`
 
-**Servings:** 2
+Rules:
+- Emit 2–3 options. No more than 3.
+- \`keyIngredients\` must list the main named ingredients (typically 5–8). The client uses these to compute pantry counts.
+- \`time\` is a human string: "20 min", "1 h", "1 h 30 min".
+- \`id\` must be a unique kebab-case slug matching the title.
+- A brief warm sentence BEFORE the block is fine (e.g. "Ah, chicken breast — three good directions:").
 
-**Total time:** ~30 min
+## Mode 2 — Gate (after user picks a suggestion)
 
-**Ingredients:**
-- 200g chicken breast
-- 1 tbsp soy sauce
-- 2 cloves garlic
-- 1 tsp sugar
+When the user says they want a specific recipe (e.g. "Ginger Chicken — let's go."), emit a gate check before the full recipe:
 
-**Instructions:**
-1. Heat the wok until ripping hot 🔥 — this is where the Maillard reaction kicks in.
-2. Add the chicken in a single layer. Don't crowd it, or it will steam instead of sear.
-3. ...
+\`\`\`gate
+{
+  "recipeId": "ginger-chicken-bok-choy",
+  "title": "Ginger Chicken & Bok Choy",
+  "keyIngredients": ["chicken thigh", "bok choy", "ginger", "garlic", "soy sauce", "oyster sauce", "sesame oil", "shaoxing wine", "cornstarch", "spring onion"]
+}
+\`\`\`
 
------
+Rules:
+- \`recipeId\` matches the \`id\` from the suggestions block the user picked.
+- \`keyIngredients\` is the FULL ingredient list for this specific recipe (the client will do pantry intersection).
+- A brief warm question BEFORE the block is fine (e.g. "Lovely choice — quick check before I write it out:").
 
-When choosing units in the ingredient list, prefer the units the user already has in inventory. If their inventory says "200g chicken breast", write grams in the recipe — not pounds — so the app can compute shortfalls accurately. Drop a few cooking emojis (🔥 🍳 🥄) where they fit naturally; don't force them.
+## Mode 3 — Recipe (after gate confirmation, or for specific named-dish asks)
+
+Use this when:
+- The user has answered the gate with "I have everything." (or similar confirmation), OR
+- The user asks for a specific named dish directly (skipping suggestions).
+
+Emit:
+
+\`\`\`recipe
+{
+  "title": "Ginger Chicken & Bok Choy",
+  "description": "Velvety chicken thighs, ginger that bites a little, bok choy that still snaps.",
+  "totalTimeMinutes": 20,
+  "baseServings": 2,
+  "ingredients": [
+    { "name": "chicken thigh", "amount": "500", "unit": "g", "note": "boneless, bite-size" },
+    { "name": "bok choy", "amount": "1", "unit": "bunch", "note": "halved lengthwise" },
+    { "name": "ginger", "amount": "4", "unit": "cm", "note": "julienned" },
+    { "name": "soy sauce", "amount": "2", "unit": "tbsp" },
+    { "name": "shaoxing wine", "amount": "1", "unit": "tbsp" }
+  ],
+  "steps": [
+    {
+      "title": "Marinate the chicken",
+      "body": "Toss chicken with 1 tbsp soy, cornstarch, sesame oil and a pinch of white pepper. Leave 10 min.",
+      "tip": "Cornstarch gives you that velvety texture. Don't skip it."
+    },
+    {
+      "title": "Heat the wok smoking hot",
+      "body": "High heat, 1½ tbsp neutral oil, swirl. When you see the first wisp of smoke, you're ready."
+    }
+  ],
+  "tags": ["stir-fry", "one-pan", "quick"]
+}
+\`\`\`
+
+Rules:
+- \`amount\` is always a string (handles "1 1/2", "½", "500", etc.)
+- \`description\` is ≤140 chars — the soul of the dish in one sentence.
+- \`tip\` on a step is optional — only add when the why/trick is non-obvious.
+- \`tags\` 2–5 lowercase tags.
+- A brief warm sentence BEFORE the block is fine (e.g. "Here it is — the way I make it:").
+
+## Routing rules
+
+| Situation | Mode |
+|---|---|
+| "What can I cook?", "I have X and Y, suggestions?" | Suggestions |
+| User picks a suggestion ("Ginger Chicken — let's go.") | Gate |
+| User answers gate ("I have everything.", "yes go ahead") | Recipe |
+| User names a specific dish ("Make me achar") | Recipe (skip suggestions + gate) |
+| "Show me other recipes" from gate | New Suggestions block |
+| General cooking question (no recipe needed) | Plain text, no block |
 
 # Behavior
 

--- a/src/app/api/recipe/route.test.ts
+++ b/src/app/api/recipe/route.test.ts
@@ -79,6 +79,10 @@ describe("Recipe API Routes", () => {
           recipeId: null,
           baseServings: 2,
           ingredients: [],
+          steps: null,
+          description: null,
+          totalTimeMinutes: null,
+          createdAt: null,
         },
         {
           id: "recipe-2",
@@ -89,6 +93,10 @@ describe("Recipe API Routes", () => {
           recipeId: null,
           baseServings: 2,
           ingredients: [],
+          steps: null,
+          description: null,
+          totalTimeMinutes: null,
+          createdAt: null,
         },
       ];
 
@@ -165,6 +173,10 @@ describe("Recipe API Routes", () => {
           recipeId: null,
           baseServings: 2,
           ingredients: [],
+          steps: null,
+          description: null,
+          totalTimeMinutes: null,
+          createdAt: null,
         },
       ];
 
@@ -193,6 +205,10 @@ describe("Recipe API Routes", () => {
         recipeId: null,
         baseServings: 2,
         ingredients: [],
+        steps: null,
+        description: null,
+        totalTimeMinutes: null,
+        createdAt: null,
       };
 
       mockedProcessRecipe.mockResolvedValue({
@@ -242,6 +258,10 @@ describe("Recipe API Routes", () => {
         recipeId: null,
         baseServings: 2,
         ingredients: [],
+        steps: null,
+        description: null,
+        totalTimeMinutes: null,
+        createdAt: null,
       };
 
       mockedProcessRecipe.mockResolvedValue(defaultProcessed);
@@ -327,6 +347,10 @@ describe("Recipe API Routes", () => {
         recipeId: null,
         baseServings: 2,
         ingredients: [],
+        steps: null,
+        description: null,
+        totalTimeMinutes: null,
+        createdAt: null,
       };
 
       mockedProcessRecipe.mockResolvedValue(defaultProcessed);
@@ -376,6 +400,10 @@ describe("Recipe API Routes", () => {
         recipeId: null,
         baseServings: 2,
         ingredients: [],
+        steps: null,
+        description: null,
+        totalTimeMinutes: null,
+        createdAt: null,
       };
 
       mockedProcessRecipe.mockResolvedValue(defaultProcessed);

--- a/src/app/api/recipe/route.ts
+++ b/src/app/api/recipe/route.ts
@@ -12,13 +12,40 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const { userId, name, instructions, recipeId } = await req.json();
+  const body = await req.json();
+  const { userId, recipeId } = body;
+
   if (!userId) {
     return NextResponse.json({ error: "userId is needed" }, { status: 400 });
   }
 
-  // Extract metadata (tags, baseServings, ingredients). If the model fails,
-  // save with empty metadata — the recipe text itself is the user's actual work.
+  // New structured path: body.recipe contains the fully-structured object
+  if (body.recipe) {
+    const r = body.recipe;
+    const recipe = await saveRecipe({
+      userId,
+      name: r.title,
+      instructions: r.description ?? "",  // store description as instructions fallback for legacy reads
+      tags: r.tags ?? [],
+      recipeId,
+      baseServings: r.baseServings,
+      ingredients: r.ingredients.map(
+        (ing: { name: string; amount?: string; unit?: string; note?: string }) => ({
+          name: ing.name,
+          // Convert string amount to number for storage (legacy RecipeIngredient type uses number)
+          amount: ing.amount ? parseFloat(ing.amount) || undefined : undefined,
+          unit: ing.unit,
+        })
+      ),
+      steps: r.steps,
+      description: r.description,
+      totalTimeMinutes: r.totalTimeMinutes,
+    });
+    return NextResponse.json(recipe);
+  }
+
+  // Legacy markdown path
+  const { name, instructions } = body;
   let metadata;
   try {
     metadata = await processRecipe(name, instructions);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -209,3 +209,13 @@ blockquote {
   border-left: 3px solid var(--accent);
   padding-left: 0.5em;
 }
+
+/* Recipe letter — scaled amount pulse animation */
+@keyframes scaledPulse {
+  0%   { background-color: oklch(0.86 0.14 60 / 0.7); }
+  100% { background-color: oklch(0.95 0.05 88 / 0.5); }
+}
+
+.scaled-num-pulse {
+  animation: scaledPulse 0.5s ease-out;
+}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -264,6 +264,7 @@ const Chat = () => {
         status={status}
         userId={userId}
         thinkingMessage={thinkingMessage}
+        onSend={handleSendMessage}
       />
       {status === "ready" && messageCount === 0 && (
         <div className="flex gap-2 px-4 pb-1 flex-wrap">

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -11,7 +11,17 @@ import {
 } from "@/components/ai-elements/message";
 import { Response } from "@/components/ai-elements/response";
 import { Button } from "@/components/ui/button";
-import type { RecipeWithId } from "@/lib/recipes/schemas";
+import type {
+  GateData,
+  RecipeBlock,
+  RecipeWithId,
+  SuggestionsBlockData,
+} from "@/lib/recipes/schemas";
+import {
+  GateSchema,
+  RecipeBlockSchema,
+  SuggestionsBlockSchema,
+} from "@/lib/recipes/schemas";
 import { fetcher } from "@/lib/utils/index";
 import type { UIMessage } from "ai";
 import { useEffect, useRef, useState } from "react";
@@ -19,13 +29,78 @@ import { toast } from "sonner";
 import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
 import { generateTempId } from "../constants";
+import { IngredientGate } from "./recipe/IngredientGate";
+import { RecipeLetter } from "./recipe/RecipeLetter";
+import { SuggestionsBlock } from "./recipe/SuggestionsBlock";
 
 interface MessageListProps {
   messages: UIMessage[];
   status: string;
   thinkingMessage: string;
   userId: string;
+  onSend?: (text: string) => void;
 }
+
+// ── Parsed block types ────────────────────────────────────────────────────────
+
+type ParsedBlock =
+  | { kind: "suggestions"; payload: SuggestionsBlockData; index: number }
+  | { kind: "gate"; payload: GateData; index: number }
+  | { kind: "recipe"; payload: RecipeBlock; index: number }
+  | { kind: "legacy"; recipeStr: string; index: number };
+
+function extractRecipeBlocks(text: string): ParsedBlock[] {
+  const blocks: ParsedBlock[] = [];
+
+  // Match complete fenced JSON blocks: ```suggestions\n{...}\n```
+  const fenceRegex = /^```(suggestions|gate|recipe)\n([\s\S]*?)\n```/gm;
+  let match: RegExpExecArray | null;
+
+  while ((match = fenceRegex.exec(text)) !== null) {
+    const kind = match[1] as "suggestions" | "gate" | "recipe";
+    try {
+      const payload = JSON.parse(match[2]);
+      if (kind === "suggestions") {
+        const result = SuggestionsBlockSchema.safeParse(payload);
+        if (result.success)
+          blocks.push({ kind: "suggestions", payload: result.data, index: match.index });
+      } else if (kind === "gate") {
+        const result = GateSchema.safeParse(payload);
+        if (result.success)
+          blocks.push({ kind: "gate", payload: result.data, index: match.index });
+      } else if (kind === "recipe") {
+        const result = RecipeBlockSchema.safeParse(payload);
+        if (result.success)
+          blocks.push({ kind: "recipe", payload: result.data, index: match.index });
+      }
+    } catch {
+      /* invalid JSON — skip */
+    }
+  }
+
+  // Legacy: -----...------ markdown recipes
+  const legacyParts = text
+    .split(/^-{5,}$/m)
+    .map((p) => p.trim())
+    .filter((p) => /^##\s+/m.test(p));
+
+  // Only add legacy blocks if no new-style blocks were found (avoid double-rendering)
+  if (blocks.length === 0 && legacyParts.length > 0) {
+    legacyParts.forEach((recipeStr, i) => {
+      blocks.push({ kind: "legacy", recipeStr, index: i });
+    });
+  }
+
+  return blocks;
+}
+
+function stripFences(text: string): string {
+  return text
+    .replace(/^```(?:suggestions|gate|recipe)\n[\s\S]*?\n```/gm, "")
+    .trim();
+}
+
+// ── SWR fetcher for save ──────────────────────────────────────────────────────
 
 const saveRecipeCall = async (
   key: string,
@@ -45,11 +120,15 @@ const saveRecipeCall = async (
   if (!res.ok) throw new Error("Failed to save recipe");
   return await res.json();
 };
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
 export const MessageList = ({
   messages,
   status,
   userId,
   thinkingMessage,
+  onSend = () => {},
 }: MessageListProps) => {
   const { data: recipeSaved, mutate } = useSWR<RecipeWithId[]>(
     `/api/recipe?userId=${userId}`,
@@ -72,23 +151,6 @@ export const MessageList = ({
       ? nameMatch[1].trim().replace(/\*\*/g, "")
       : "Untitled Recipe";
   };
-
-  // Extract every recipe in a message. A recipe is a section between
-  // ----- delimiters that contains a markdown ## heading (the title).
-  const extractRecipes = (text: string): string[] => {
-    return text
-      .split(/^-{5,}$/m)
-      .map((part) => part.trim())
-      .filter((part) => /^##\s+/m.test(part));
-  };
-
-  const messageRecipes = (parts: { type: string; text?: string }[]): string[] =>
-    parts
-      .filter(
-        (p): p is { type: "text"; text: string } =>
-          p.type === "text" && typeof p.text === "string",
-      )
-      .flatMap((p) => extractRecipes(p.text));
 
   const saveRecipe = async (recipeStr: string, recipeKey: string) => {
     const name = extractRecipeName(recipeStr);
@@ -116,8 +178,6 @@ export const MessageList = ({
         recipeId: recipeKey,
       });
 
-      // STEP 4: Find our fake recipe and replace it with the real one from the server
-      // We match by the temporary ID and swap it with the real saved recipe
       mutate(
         (current = []) =>
           current.map((r) => (r.id === optimisticRecipe.id ? saved : r)),
@@ -127,6 +187,52 @@ export const MessageList = ({
       toast.success(`Recipe ${name} saved!`);
     } catch (error) {
       console.error("Failed to save recipe:", error);
+    }
+  };
+
+  const saveStructuredRecipe = async (
+    recipeBlock: RecipeBlock,
+    recipeKey: string,
+  ) => {
+    try {
+      const optimisticRecipe = {
+        id: generateTempId(),
+        userId,
+        name: recipeBlock.title,
+        instructions: recipeBlock.description ?? "",
+        recipeId: recipeKey,
+        baseServings: recipeBlock.baseServings,
+        ingredients: [],
+        steps: recipeBlock.steps,
+      };
+
+      mutate((current = []) => [...current, optimisticRecipe], {
+        revalidate: false,
+        populateCache: true,
+      });
+
+      const res = await fetch(`/api/recipe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId,
+          recipeId: recipeKey,
+          recipe: recipeBlock,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to save recipe");
+      const saved = await res.json();
+
+      mutate(
+        (current = []) =>
+          current.map((r) => (r.id === optimisticRecipe.id ? saved : r)),
+        { revalidate: false, populateCache: true },
+      );
+
+      toast.success(`Recipe "${recipeBlock.title}" saved to cookbook!`);
+    } catch (error) {
+      console.error("Failed to save recipe:", error);
+      toast.error("Could not save recipe. Try again.");
     }
   };
 
@@ -161,8 +267,19 @@ export const MessageList = ({
           onScroll={handleScroll}
           data-conversation-content
         >
-          {messages.map((message) => {
-            const recipes = messageRecipes(message.parts);
+          {messages.map((message, messageIndex) => {
+            const textContent = message.parts
+              .filter(
+                (p): p is { type: "text"; text: string } =>
+                  p.type === "text" && typeof (p as { text?: string }).text === "string",
+              )
+              .map((p) => (p as { type: "text"; text: string }).text)
+              .join("");
+
+            const blocks = extractRecipeBlocks(textContent);
+            const hasNewBlocks = blocks.some((b) => b.kind !== "legacy");
+            const proseText = hasNewBlocks ? stripFences(textContent) : textContent;
+
             return (
               <Message
                 key={message.id}
@@ -174,63 +291,123 @@ export const MessageList = ({
                 }`}
               >
                 <MessageContent variant="flat">
-                  {message.parts.map((part, index) =>
-                    part.type === "text" ? (
-                      <Response key={`${message.id}-${index}`}>
-                        {part.text}
-                      </Response>
-                    ) : null,
-                  )}
-                  {recipes.length > 0 && status === "ready" && (
-                    <div className="flex flex-wrap gap-2">
-                      {recipes.map((recipeStr, idx) => {
-                        const recipeKey = `${message.id}-${idx}`;
-                        const recipeName = extractRecipeName(recipeStr);
-                        const saved =
-                          recipeSaved?.some(
-                            (r) => r.recipeId === recipeKey,
-                          ) ?? false;
-                        return (
-                          <Button
-                            key={recipeKey}
-                            className="cursor-pointer my-2"
-                            onClick={() =>
-                              saved || saveRecipe(recipeStr, recipeKey)
-                            }
-                          >
-                            {saved ? (
-                              <svg
-                                width="20"
-                                height="20"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                xmlns="http://www.w3.org/2000/svg"
+                  {/* Prose text (fences stripped when new-style blocks present) */}
+                  {hasNewBlocks
+                    ? proseText
+                      ? (
+                        <Response key={`${message.id}-prose`}>
+                          {proseText}
+                        </Response>
+                      )
+                      : null
+                    : message.parts.map((part, index) =>
+                        part.type === "text" ? (
+                          <Response key={`${message.id}-${index}`}>
+                            {(part as { type: "text"; text: string }).text}
+                          </Response>
+                        ) : null,
+                      )}
+
+                  {/* New-style blocks */}
+                  {blocks.map((block, bi) => {
+                    const blockKey = `${message.id}-block-${bi}`;
+                    if (block.kind === "suggestions") {
+                      return (
+                        <SuggestionsBlock
+                          key={blockKey}
+                          data={block.payload}
+                          allMessages={messages}
+                          messageIndex={messageIndex}
+                          onSend={onSend}
+                        />
+                      );
+                    }
+                    if (block.kind === "gate") {
+                      return (
+                        <IngredientGate
+                          key={blockKey}
+                          data={block.payload}
+                          onSend={onSend}
+                        />
+                      );
+                    }
+                    if (block.kind === "recipe") {
+                      const recipeKey = `${message.id}-${bi}`;
+                      const isSaved =
+                        recipeSaved?.some((r) => r.recipeId === recipeKey) ??
+                        false;
+                      return (
+                        <RecipeLetter
+                          key={blockKey}
+                          recipe={block.payload}
+                          onSave={() =>
+                            saveStructuredRecipe(block.payload, recipeKey)
+                          }
+                          isSaved={isSaved}
+                        />
+                      );
+                    }
+                    return null;
+                  })}
+
+                  {/* Legacy recipe save buttons */}
+                  {blocks.some((b) => b.kind === "legacy") &&
+                    status === "ready" && (
+                      <div className="flex flex-wrap gap-2">
+                        {blocks
+                          .filter((b) => b.kind === "legacy")
+                          .map((block, idx) => {
+                            if (block.kind !== "legacy") return null;
+                            const recipeKey = `${message.id}-${idx}`;
+                            const recipeName = extractRecipeName(block.recipeStr);
+                            const saved =
+                              recipeSaved?.some(
+                                (r) => r.recipeId === recipeKey,
+                              ) ?? false;
+                            return (
+                              <Button
+                                key={recipeKey}
+                                className="cursor-pointer my-2"
+                                onClick={() =>
+                                  saved ||
+                                  saveRecipe(block.recipeStr, recipeKey)
+                                }
                               >
-                                <path
-                                  d="M5 21V5C5 4.45 5.196 3.97933 5.588 3.588C5.98 3.19667 6.45067 3.00067 7 3H17C17.55 3 18.021 3.196 18.413 3.588C18.805 3.98 19.0007 4.45067 19 5V21L12 18L5 21Z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                            ) : (
-                              <svg
-                                width="20"
-                                height="20"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M17 18L12 15.82L7 18V5H17M17 3H7C6.46957 3 5.96086 3.21071 5.58579 3.58579C5.21071 3.96086 5 4.46957 5 5V21L12 18L19 21V5C19 4.46957 18.7893 3.96086 18.4142 3.58579C18.0391 3.21071 17.5304 3 17 3Z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                            )}
-                            {saved ? "Saved" : "Save"}: {recipeName}
-                          </Button>
-                        );
-                      })}
-                    </div>
-                  )}
+                                {saved ? (
+                                  <svg
+                                    width="20"
+                                    height="20"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5 21V5C5 4.45 5.196 3.97933 5.588 3.588C5.98 3.19667 6.45067 3.00067 7 3H17C17.55 3 18.021 3.196 18.413 3.588C18.805 3.98 19.0007 4.45067 19 5V21L12 18L5 21Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                ) : (
+                                  <svg
+                                    width="20"
+                                    height="20"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17 18L12 15.82L7 18V5H17M17 3H7C6.46957 3 5.96086 3.21071 5.58579 3.58579C5.21071 3.96086 5 4.46957 5 5V21L12 18L19 21V5C19 4.46957 18.7893 3.96086 18.4142 3.58579C18.0391 3.21071 17.5304 3 17 3Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                )}
+                                {saved ? "Saved" : "Save"}: {recipeName}
+                              </Button>
+                            );
+                          })}
+                      </div>
+                    )}
+
+                  {/* Thinking spinner */}
                   {status === "streaming" &&
                     message === messages[messages.length - 1] &&
                     message.role === "assistant" && (

--- a/src/features/Chat/components/recipe/IngredientGate.tsx
+++ b/src/features/Chat/components/recipe/IngredientGate.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { useSessionContext } from '@/contexts/SessionContext';
+import { GetInventoryResponse, InventoryItem } from '@/lib/inventory/schemas';
+import { GateData } from '@/lib/recipes/schemas';
+import { fetcher } from '@/lib/utils/index';
+import Image from 'next/image';
+import { toast } from 'sonner';
+import useSWR from 'swr';
+import { computePantry } from './pantryUtils';
+
+interface IngredientGateProps {
+  data: GateData;
+  onSend: (text: string) => void;
+}
+
+function GrannyAvatar() {
+  return (
+    <div
+      style={{
+        width: 36,
+        height: 36,
+        borderRadius: '50%',
+        overflow: 'hidden',
+        flexShrink: 0,
+        border: '1px solid var(--border)',
+      }}
+    >
+      <Image
+        src="/granny-avatar.png"
+        alt="Ah Mah"
+        width={36}
+        height={36}
+        style={{ objectFit: 'cover', width: '100%', height: '100%' }}
+      />
+    </div>
+  );
+}
+
+interface GateButtonProps {
+  icon: React.ReactNode;
+  title: string;
+  sub: string;
+  primary?: boolean;
+  onClick: () => void;
+}
+
+function GateButton({ icon, title, sub, primary, onClick }: GateButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        flex: 1,
+        textAlign: 'left',
+        padding: '14px 16px',
+        background: primary ? 'var(--primary)' : 'var(--card)',
+        border: `1px solid ${primary ? 'oklch(0.405 0.130 32)' : 'var(--border)'}`,
+        borderRadius: 10,
+        cursor: 'pointer',
+        boxShadow: primary
+          ? '0 1px 0 oklch(0.405 0.130 32), 0 14px 24px -22px oklch(0.3 0.05 50 / 0.4)'
+          : '0 1px 0 var(--border-soft)',
+        display: 'flex',
+        gap: 12,
+        alignItems: 'flex-start',
+        color: primary ? '#fff' : 'var(--foreground)',
+        transition: 'transform 100ms ease',
+      }}
+    >
+      <div
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 8,
+          flexShrink: 0,
+          background: primary ? 'oklch(1 0 0 / 0.18)' : 'var(--chat)',
+          border: `1px solid ${primary ? 'oklch(1 0 0 / 0.3)' : 'var(--border)'}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: primary ? '#fff' : 'var(--primary)',
+        }}
+      >
+        {icon}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontWeight: 600,
+            fontSize: 15,
+            lineHeight: 1.2,
+            letterSpacing: '-0.005em',
+            marginBottom: 3,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 12,
+            color: primary ? 'oklch(1 0 0 / 0.85)' : 'var(--muted-foreground)',
+            lineHeight: 1.4,
+          }}
+        >
+          {sub}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export function IngredientGate({ data, onSend }: IngredientGateProps) {
+  const { userId } = useSessionContext();
+  const { data: inventoryData } = useSWR<GetInventoryResponse>(
+    userId ? `/api/inventory?userId=${userId}` : null,
+    fetcher,
+  );
+
+  const inventoryItems: InventoryItem[] = [
+    ...(inventoryData?.ingredientInventory ?? []),
+    ...(inventoryData?.kitchenwareInventory ?? []),
+  ];
+
+  const { have, total, missing } = computePantry(
+    data.keyIngredients,
+    inventoryItems,
+  );
+  const haveAll = have === total && total > 0;
+
+  const time = new Date().toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+  return (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+      <GrannyAvatar />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {/* Header */}
+        <div
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 11,
+            fontWeight: 600,
+            color: 'var(--muted-foreground)',
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginBottom: 4,
+          }}
+        >
+          <span>Ah Mah</span>
+          <span
+            style={{
+              fontWeight: 400,
+              color: 'var(--ink-faint)',
+              letterSpacing: '0.02em',
+              textTransform: 'none',
+            }}
+          >
+            · {time}
+          </span>
+        </div>
+
+        {/* Intro message */}
+        <div
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontSize: 17,
+            lineHeight: 1.5,
+            color: 'var(--foreground)',
+            marginBottom: 14,
+          }}
+        >
+          {haveAll ? (
+            <>
+              Good choice —{' '}
+              <b style={{ fontStyle: 'normal', fontWeight: 600 }}>
+                {data.title}
+              </b>
+              . Looks like you have everything. Shall I write it out?
+            </>
+          ) : (
+            <>
+              Lovely —{' '}
+              <b style={{ fontStyle: 'normal', fontWeight: 600 }}>
+                {data.title}
+              </b>
+              . Quick check before I write it out — are you missing anything?
+            </>
+          )}
+        </div>
+
+        {/* Pantry summary strip */}
+        <div
+          style={{
+            background: 'var(--chat)',
+            border: '1px solid var(--border)',
+            borderRadius: 10,
+            padding: '10px 14px',
+            marginBottom: 12,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 14,
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 12.5,
+          }}
+        >
+          <div
+            style={{
+              width: 36,
+              height: 36,
+              flexShrink: 0,
+              borderRadius: 8,
+              background: haveAll
+                ? 'oklch(0.94 0.04 168)'
+                : 'oklch(0.96 0.05 88)',
+              border: `1px solid ${haveAll ? 'oklch(0.78 0.07 168)' : 'oklch(0.75 0.08 88)'}`,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontFamily: 'Fraunces, serif',
+              fontWeight: 700,
+              fontSize: 14,
+              color: haveAll ? 'var(--accent)' : 'oklch(0.45 0.10 60)',
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            {have}/{total}
+          </div>
+          <div style={{ flex: 1 }}>
+            <div
+              style={{
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: 600,
+                fontSize: 12.5,
+                color: 'var(--foreground)',
+                marginBottom: 2,
+              }}
+            >
+              Pantry check
+            </div>
+            <div style={{ color: 'var(--muted-foreground)', fontSize: 11.5 }}>
+              {haveAll ? (
+                'Everything looks accounted for, dear.'
+              ) : (
+                <>
+                  Looks like you&apos;re short on{' '}
+                  <b style={{ color: 'var(--foreground)' }}>
+                    {missing.join(', ')}
+                  </b>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div style={{ display: 'flex', gap: 10 }}>
+          <GateButton
+            primary
+            icon={
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+              >
+                <path d="M5 12l5 5 9-9" />
+              </svg>
+            }
+            title="I have everything"
+            sub="Write me the full recipe."
+            onClick={() => onSend('I have everything.')}
+          />
+          <GateButton
+            icon={
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <circle cx="12" cy="12" r="9" />
+                <path d="M12 8v4M12 16h.01" />
+              </svg>
+            }
+            title="I'm missing some"
+            sub="Suggest swaps, or send me to the shop."
+            onClick={() =>
+              toast.info(
+                'Coming soon — substitutions and shopping list are on the way!',
+              )
+            }
+          />
+        </div>
+
+        {/* Tertiary link */}
+        <div style={{ display: 'flex', gap: 14, marginTop: 10, paddingLeft: 4 }}>
+          <button
+            onClick={() => onSend('Show me other recipes.')}
+            style={{
+              padding: 0,
+              background: 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+              fontFamily: 'Inter, sans-serif',
+              fontSize: 11.5,
+              fontWeight: 500,
+              color: 'var(--ink-faint)',
+              textDecoration: 'underline',
+              textUnderlineOffset: 3,
+            }}
+          >
+            ← Show me other recipes
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -1,0 +1,429 @@
+'use client';
+
+import { useState } from 'react';
+import { ScaledNum } from './ScaledNum';
+import { scaleAmount } from './scaleAmount';
+
+interface Ingredient {
+  name: string;
+  amount?: string;
+  unit?: string;
+  note?: string;
+}
+
+interface Step {
+  title: string;
+  body: string;
+  tip?: string;
+}
+
+interface RecipeData {
+  title: string;
+  description?: string;
+  totalTimeMinutes?: number;
+  baseServings: number;
+  ingredients: Ingredient[];
+  steps: Step[];
+  tags?: string[];
+}
+
+export interface RecipeLetterProps {
+  recipe: RecipeData;
+  onSave?: (recipe: RecipeData) => void;
+  isSaved?: boolean;
+}
+
+function ServingsStepper({
+  servings,
+  baseServings,
+  onDecrement,
+  onIncrement,
+}: {
+  servings: number;
+  baseServings: number;
+  onDecrement: () => void;
+  onIncrement: () => void;
+}) {
+  const ratio = servings / baseServings;
+  const ratioLabel = ratio.toFixed(2).replace(/\.?0+$/, '');
+
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        alignItems: 'stretch',
+        border: '1px solid var(--border)',
+        borderRadius: 8,
+        background: 'var(--card)',
+        overflow: 'hidden',
+        boxShadow: '0 1px 0 var(--border-soft)',
+        height: 30,
+      }}
+    >
+      <button
+        onClick={onDecrement}
+        disabled={servings <= 1}
+        style={{
+          width: 28,
+          border: 'none',
+          background: 'transparent',
+          cursor: servings <= 1 ? 'not-allowed' : 'pointer',
+          color: servings <= 1 ? 'var(--muted-foreground)' : 'var(--foreground)',
+          fontSize: 16,
+          fontWeight: 600,
+          borderRight: '1px solid var(--border)',
+          opacity: servings <= 1 ? 0.5 : 1,
+        }}
+        aria-label="Decrease servings"
+      >
+        −
+      </button>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minWidth: 64,
+          padding: '0 8px',
+          lineHeight: 1,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontWeight: 600,
+            fontSize: 14,
+            color: 'var(--foreground)',
+            fontVariantNumeric: 'tabular-nums',
+          }}
+        >
+          {servings} {servings === 1 ? 'serving' : 'servings'}
+        </span>
+        {servings !== baseServings && (
+          <span
+            style={{
+              fontFamily: 'ui-monospace, monospace',
+              fontSize: 9,
+              color: 'var(--muted-foreground)',
+              marginTop: 2,
+              letterSpacing: '0.04em',
+            }}
+          >
+            ×{ratioLabel} from {baseServings}
+          </span>
+        )}
+      </div>
+      <button
+        onClick={onIncrement}
+        disabled={servings >= 12}
+        style={{
+          width: 28,
+          border: 'none',
+          background: 'transparent',
+          cursor: servings >= 12 ? 'not-allowed' : 'pointer',
+          color: servings >= 12 ? 'var(--muted-foreground)' : 'var(--foreground)',
+          fontSize: 16,
+          fontWeight: 600,
+          borderLeft: '1px solid var(--border)',
+        }}
+        aria-label="Increase servings"
+      >
+        +
+      </button>
+    </div>
+  );
+}
+
+export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
+  const [servings, setServings] = useState(recipe.baseServings);
+  const ratio = servings / recipe.baseServings;
+
+  const ingredientParts = recipe.ingredients.map((ing, i) => {
+    const scaledAmt = ing.amount ? scaleAmount(ing.amount, ratio) : '';
+    const unit = ing.unit ? ` ${ing.unit}` : '';
+    const note = ing.note ? `, ${ing.note}` : '';
+    const isLast = i === recipe.ingredients.length - 1;
+    const suffix = isLast ? '.' : ', ';
+
+    return (
+      <span key={i}>
+        {scaledAmt ? (
+          <>
+            <ScaledNum>{`${scaledAmt}${unit}`}</ScaledNum>{' '}
+          </>
+        ) : null}
+        {ing.name}
+        {note}
+        {suffix}
+      </span>
+    );
+  });
+
+  const timeLabel = recipe.totalTimeMinutes ? `${recipe.totalTimeMinutes} min` : null;
+
+  return (
+    <div
+      className="bg-chat"
+      style={{
+        borderTop: '1px solid var(--border-soft)',
+        borderBottom: '1px solid var(--border-soft)',
+        padding: '20px 26px 22px',
+        position: 'relative',
+      }}
+    >
+      {/* Ribbon header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          marginBottom: 14,
+          paddingBottom: 10,
+          borderBottom: '1px dashed var(--border)',
+        }}
+      >
+        {/* Bookmark icon */}
+        <div
+          style={{
+            width: 22,
+            height: 22,
+            borderRadius: 999,
+            background: 'var(--primary)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#fff',
+            flexShrink: 0,
+          }}
+        >
+          <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+            <path d="M3 2v12l5-3 5 3V2z" stroke="currentColor" strokeWidth="1.4" fill="currentColor" />
+          </svg>
+        </div>
+
+        <div
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 10.5,
+            fontWeight: 700,
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
+            color: 'var(--muted-foreground)',
+          }}
+        >
+          The way I make it
+        </div>
+
+        <div style={{ flex: 1 }} />
+
+        {timeLabel && (
+          <div
+            style={{
+              fontFamily: 'ui-monospace, monospace',
+              fontSize: 10.5,
+              color: 'var(--muted-foreground)',
+            }}
+          >
+            {timeLabel}
+          </div>
+        )}
+
+        <ServingsStepper
+          servings={servings}
+          baseServings={recipe.baseServings}
+          onDecrement={() => setServings(s => Math.max(1, s - 1))}
+          onIncrement={() => setServings(s => Math.min(12, s + 1))}
+        />
+      </div>
+
+      {/* Title */}
+      <div
+        style={{
+          fontFamily: 'Fraunces, serif',
+          fontSize: 28,
+          fontWeight: 600,
+          color: 'var(--foreground)',
+          lineHeight: 1.05,
+          letterSpacing: '-0.015em',
+          marginBottom: 14,
+        }}
+      >
+        {recipe.title}
+      </div>
+
+      {/* Description */}
+      {recipe.description && (
+        <div
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontSize: 14,
+            color: 'var(--muted-foreground)',
+            lineHeight: 1.5,
+            marginBottom: 14,
+          }}
+        >
+          {recipe.description}
+        </div>
+      )}
+
+      {/* Ingredient prose */}
+      {recipe.ingredients.length > 0 && (
+        <div
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontSize: 15,
+            color: 'var(--muted-foreground)',
+            lineHeight: 1.6,
+            marginBottom: 18,
+          }}
+        >
+          <b style={{ fontStyle: 'normal', color: 'var(--foreground)', fontWeight: 600 }}>
+            You&apos;ll need —
+          </b>{' '}
+          {ingredientParts}
+          {recipe.tags && recipe.tags.length > 0 && (
+            <span
+              style={{
+                marginLeft: 6,
+                fontFamily: 'Inter, sans-serif',
+                fontStyle: 'normal',
+                fontSize: 11,
+                fontWeight: 600,
+                color: 'var(--accent)',
+                padding: '1px 7px',
+                background: 'oklch(0.94 0.04 168)',
+                border: '1px solid oklch(0.78 0.07 168)',
+                borderRadius: 999,
+              }}
+            >
+              {recipe.tags.length}/{recipe.ingredients.length} in your pantry
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Steps */}
+      {recipe.steps.length > 0 && (
+        <div
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontSize: 16,
+            color: 'var(--foreground)',
+            lineHeight: 1.65,
+          }}
+        >
+          {recipe.steps.map((step, i) => (
+            <p key={i} style={{ margin: '0 0 14px' }}>
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 22,
+                  height: 22,
+                  background: 'var(--primary)',
+                  color: '#fff',
+                  fontFamily: 'Fraunces, serif',
+                  fontWeight: 700,
+                  fontSize: 12,
+                  borderRadius: '50% 50% 50% 6px',
+                  transform: 'rotate(-3deg) translateY(-2px)',
+                  marginRight: 8,
+                  verticalAlign: 'middle',
+                  flexShrink: 0,
+                }}
+              >
+                {i + 1}
+              </span>
+              <span style={{ fontWeight: 600 }}>{step.title}.</span>{' '}
+              <span style={{ fontStyle: 'italic', color: 'var(--foreground)' }}>{step.body}</span>
+              {step.tip && (
+                <span
+                  style={{
+                    display: 'block',
+                    marginTop: 6,
+                    marginLeft: 30,
+                    fontSize: 13.5,
+                    color: 'var(--muted-foreground)',
+                    fontStyle: 'italic',
+                    borderLeft: '2px solid var(--primary)',
+                    paddingLeft: 10,
+                  }}
+                >
+                  — {step.tip}
+                </span>
+              )}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {/* Action bar — only when onSave is provided */}
+      {onSave && (
+        <div
+          style={{
+            display: 'flex',
+            gap: 8,
+            alignItems: 'center',
+            paddingTop: 12,
+            marginTop: 14,
+            borderTop: '1px dashed var(--border)',
+          }}
+        >
+          {isSaved ? (
+            <button
+              disabled
+              style={{
+                padding: '6px 12px',
+                fontFamily: 'Inter, sans-serif',
+                fontSize: 12,
+                fontWeight: 600,
+                color: 'var(--accent)',
+                background: 'transparent',
+                border: '1px solid var(--border)',
+                borderRadius: 7,
+                cursor: 'not-allowed',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 5,
+                opacity: 0.8,
+              }}
+            >
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2">
+                <path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16l-7-3-7 3z" />
+              </svg>
+              Saved
+            </button>
+          ) : (
+            <button
+              onClick={() => onSave(recipe)}
+              style={{
+                padding: '6px 12px',
+                fontFamily: 'Inter, sans-serif',
+                fontSize: 12,
+                fontWeight: 600,
+                color: '#fff',
+                background: 'var(--primary)',
+                border: '1px solid color-mix(in oklch, var(--primary) 70%, black)',
+                borderRadius: 7,
+                cursor: 'pointer',
+                boxShadow: '0 1px 0 color-mix(in oklch, var(--primary) 70%, black)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 5,
+              }}
+            >
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16l-7-3-7 3z" />
+              </svg>
+              Save to cookbook
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -339,7 +339,7 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
                 {i + 1}
               </span>
               <span style={{ fontWeight: 600 }}>{step.title}.</span>{' '}
-              <span style={{ fontStyle: 'italic', color: 'var(--foreground)' }}>{step.body}</span>
+              <span style={{ fontFamily: 'Inter, sans-serif', fontStyle: 'normal', color: 'var(--foreground)' }}>{step.body}</span>
               {step.tip && (
                 <span
                   style={{

--- a/src/features/Chat/components/recipe/ScaledNum.tsx
+++ b/src/features/Chat/components/recipe/ScaledNum.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface ScaledNumProps {
+  children: string;
+}
+
+/**
+ * Inline monospace span that pulses with a warm yellow flash whenever its value changes.
+ * Used inside recipe ingredient prose to highlight scaled amounts.
+ */
+export function ScaledNum({ children }: ScaledNumProps) {
+  const [pulseKey, setPulseKey] = useState(0);
+  const prev = useRef(children);
+
+  useEffect(() => {
+    if (prev.current !== children) {
+      setPulseKey(k => k + 1);
+      prev.current = children;
+    }
+  }, [children]);
+
+  return (
+    <span
+      key={pulseKey}
+      className="font-mono not-italic font-semibold text-foreground bg-secondary/50 px-1 rounded-sm scaled-num-pulse"
+      style={{ fontSize: '0.9em' }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/features/Chat/components/recipe/SuggestionsBlock.tsx
+++ b/src/features/Chat/components/recipe/SuggestionsBlock.tsx
@@ -1,0 +1,394 @@
+'use client';
+
+import { useSessionContext } from '@/contexts/SessionContext';
+import { GetInventoryResponse, InventoryItem } from '@/lib/inventory/schemas';
+import { SuggestionsBlockData, SuggestionOption } from '@/lib/recipes/schemas';
+import { fetcher } from '@/lib/utils/index';
+import { TextUIPart, UIMessage } from 'ai';
+import Image from 'next/image';
+import useSWR from 'swr';
+import { computePantry } from './pantryUtils';
+
+interface SuggestionsBlockProps {
+  data: SuggestionsBlockData;
+  allMessages: UIMessage[];
+  messageIndex: number;
+  onSend: (text: string) => void;
+}
+
+function derivePickedId(
+  options: SuggestionOption[],
+  allMessages: UIMessage[],
+  messageIndex: number,
+): string | null {
+  const laterMessages = allMessages.slice(messageIndex + 1);
+  for (const msg of laterMessages) {
+    if (msg.role !== 'user') continue;
+    const text =
+      msg.parts
+        ?.filter((p): p is TextUIPart => p.type === 'text')
+        .map((p) => p.text)
+        .join('') ?? '';
+    for (const opt of options) {
+      if (text.toLowerCase().includes(opt.title.toLowerCase())) {
+        return opt.id;
+      }
+    }
+  }
+  return null;
+}
+
+function GrannyAvatar() {
+  return (
+    <div
+      style={{
+        width: 36,
+        height: 36,
+        borderRadius: '50%',
+        overflow: 'hidden',
+        flexShrink: 0,
+        border: '1px solid var(--border)',
+      }}
+    >
+      <Image
+        src="/granny-avatar.png"
+        alt="Ah Mah"
+        width={36}
+        height={36}
+        style={{ objectFit: 'cover', width: '100%', height: '100%' }}
+      />
+    </div>
+  );
+}
+
+interface SuggestionCardProps {
+  option: SuggestionOption;
+  isPicked: boolean;
+  isDimmed: boolean;
+  inventoryItems: InventoryItem[];
+  onSend: (text: string) => void;
+}
+
+function SuggestionCard({
+  option,
+  isPicked,
+  isDimmed,
+  inventoryItems,
+  onSend,
+}: SuggestionCardProps) {
+  const { have, total, missing } = computePantry(
+    option.keyIngredients,
+    inventoryItems,
+  );
+  const haveAll = have === total && total > 0;
+
+  return (
+    <div
+      style={{
+        background: 'var(--card)',
+        border: `1px solid ${isPicked ? 'var(--primary)' : 'var(--border)'}`,
+        borderRadius: 10,
+        padding: '14px 16px 14px',
+        position: 'relative',
+        boxShadow: isPicked
+          ? '0 0 0 2px oklch(0.56 0.135 35 / 0.18), 0 1px 0 var(--border-soft)'
+          : '0 1px 0 var(--border-soft), 0 14px 24px -22px oklch(0.3 0.05 50 / 0.4)',
+        opacity: isDimmed ? 0.5 : 1,
+        transition: 'all 180ms ease',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        pointerEvents: isDimmed ? 'none' : 'auto',
+      }}
+    >
+      {/* Corner tab */}
+      <div
+        style={{
+          position: 'absolute',
+          top: -1,
+          right: 18,
+          width: 22,
+          height: 11,
+          background: 'var(--primary)',
+          borderRadius: '0 0 3px 3px',
+          boxShadow: 'inset 0 -1px 0 oklch(0.45 0.12 32)',
+        }}
+      />
+
+      {/* Tags + time row */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            gap: 6,
+            alignItems: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          {option.tags.map((t) => (
+            <span
+              key={t}
+              style={{
+                fontFamily: 'Inter, sans-serif',
+                fontSize: 9.5,
+                fontWeight: 600,
+                padding: '1px 6px',
+                color: 'var(--muted-foreground)',
+                background: 'transparent',
+                border: '1px solid var(--border)',
+                borderRadius: 999,
+                letterSpacing: '0.04em',
+                textTransform: 'lowercase',
+              }}
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+        <span
+          style={{
+            fontFamily: 'ui-monospace, monospace',
+            fontSize: 10.5,
+            color: 'var(--ink-faint)',
+          }}
+        >
+          ⏱ {option.time}
+        </span>
+      </div>
+
+      {/* Title */}
+      <div
+        style={{
+          fontFamily: 'Fraunces, serif',
+          fontWeight: 600,
+          fontSize: 19,
+          color: 'var(--foreground)',
+          lineHeight: 1.15,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {option.title}
+      </div>
+
+      {/* Blurb */}
+      <div
+        style={{
+          fontFamily: 'Fraunces, serif',
+          fontStyle: 'italic',
+          fontSize: 13,
+          color: 'var(--muted-foreground)',
+          lineHeight: 1.4,
+        }}
+      >
+        {option.blurb}
+      </div>
+
+      {/* Ah Mah note */}
+      {option.note && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            marginTop: 2,
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontSize: 12,
+            color: 'var(--ink-faint)',
+          }}
+        >
+          <span
+            style={{
+              fontFamily: 'Inter, sans-serif',
+              fontStyle: 'normal',
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+              color: 'oklch(0.45 0.10 60)',
+              padding: '1px 5px',
+              background: 'oklch(0.96 0.05 88)',
+              border: '1px dashed oklch(0.75 0.08 88)',
+              borderRadius: 4,
+            }}
+          >
+            Ah Mah
+          </span>
+          <span style={{ flex: 1 }}>{option.note}</span>
+        </div>
+      )}
+
+      {/* Footer row */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          marginTop: 10,
+          paddingTop: 10,
+          borderTop: '1px dashed var(--border)',
+        }}
+      >
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 11,
+            fontWeight: 600,
+            color: haveAll ? 'var(--accent)' : 'oklch(0.42 0.18 25)',
+          }}
+        >
+          <span
+            style={{
+              width: 7,
+              height: 7,
+              borderRadius: '50%',
+              background: haveAll ? 'var(--accent)' : 'oklch(0.6 0.18 25)',
+              flexShrink: 0,
+            }}
+          />
+          {total === 0
+            ? 'Pantry check N/A'
+            : haveAll
+              ? `All ${total} in pantry`
+              : `${have}/${total} in pantry · short ${missing.length}`}
+        </span>
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={() => onSend(`${option.title} — let's go.`)}
+          style={{
+            padding: '6px 12px',
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 12,
+            fontWeight: 600,
+            color: isPicked ? 'oklch(0.405 0.130 32)' : '#fff',
+            background: isPicked ? 'oklch(0.94 0.06 35)' : 'var(--primary)',
+            border: '1px solid oklch(0.405 0.130 32)',
+            borderRadius: 7,
+            cursor: 'pointer',
+            boxShadow: isPicked
+              ? 'none'
+              : '0 1px 0 oklch(0.405 0.130 32)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 5,
+          }}
+        >
+          {isPicked ? '✓ Picked' : 'I want to cook this →'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SuggestionsBlock({
+  data,
+  allMessages,
+  messageIndex,
+  onSend,
+}: SuggestionsBlockProps) {
+  const { userId } = useSessionContext();
+  const { data: inventoryData } = useSWR<GetInventoryResponse>(
+    userId ? `/api/inventory?userId=${userId}` : null,
+    fetcher,
+  );
+
+  const inventoryItems: InventoryItem[] = [
+    ...(inventoryData?.ingredientInventory ?? []),
+    ...(inventoryData?.kitchenwareInventory ?? []),
+  ];
+
+  const pickedId = derivePickedId(data.options, allMessages, messageIndex);
+
+  // Format timestamp
+  const time = new Date().toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+  return (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+      <GrannyAvatar />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {/* Header */}
+        <div
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 11,
+            fontWeight: 600,
+            color: 'var(--muted-foreground)',
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginBottom: 4,
+          }}
+        >
+          <span>Ah Mah</span>
+          <span
+            style={{
+              fontWeight: 400,
+              color: 'var(--ink-faint)',
+              letterSpacing: '0.02em',
+              textTransform: 'none',
+            }}
+          >
+            · {time}
+          </span>
+        </div>
+
+        {/* Intro */}
+        <div
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontSize: 17,
+            lineHeight: 1.5,
+            color: 'var(--foreground)',
+            marginBottom: 12,
+          }}
+        >
+          {data.intro}
+        </div>
+
+        {/* Cards */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {data.options.map((option) => (
+            <SuggestionCard
+              key={option.id}
+              option={option}
+              isPicked={pickedId === option.id}
+              isDimmed={pickedId !== null && pickedId !== option.id}
+              inventoryItems={inventoryItems}
+              onSend={onSend}
+            />
+          ))}
+        </div>
+
+        {/* Footer hint */}
+        <div
+          style={{
+            marginTop: 10,
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontSize: 13,
+            color: 'var(--ink-faint)',
+            lineHeight: 1.5,
+          }}
+        >
+          Or tell me what you&apos;re in the mood for and I&apos;ll think of
+          others.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/Chat/components/recipe/pantryUtils.ts
+++ b/src/features/Chat/components/recipe/pantryUtils.ts
@@ -1,0 +1,22 @@
+import { InventoryItem } from '@/lib/inventory/schemas';
+
+export function computePantry(
+  keyIngredients: string[],
+  inventoryItems: InventoryItem[],
+): { have: number; total: number; missing: string[] } {
+  const names = inventoryItems.map((i) => i.name.trim().toLowerCase());
+  const have = keyIngredients.filter((k) =>
+    names.some(
+      (n) =>
+        n.includes(k.toLowerCase()) || k.toLowerCase().includes(n),
+    ),
+  ).length;
+  const missing = keyIngredients.filter(
+    (k) =>
+      !names.some(
+        (n) =>
+          n.includes(k.toLowerCase()) || k.toLowerCase().includes(n),
+      ),
+  );
+  return { have, total: keyIngredients.length, missing };
+}

--- a/src/features/Chat/components/recipe/scaleAmount.ts
+++ b/src/features/Chat/components/recipe/scaleAmount.ts
@@ -1,0 +1,43 @@
+/**
+ * Scale a numeric amount string by a ratio.
+ * Handles integers, decimals, simple fractions ("1/2"), and mixed numbers ("1 1/2").
+ * Returns the original string if parsing fails.
+ */
+export function scaleAmount(amount: string | undefined, ratio: number): string {
+  if (!amount || ratio === 1) return amount ?? '';
+  const s = String(amount).trim();
+
+  const mixed = s.match(/^(\d+)\s+(\d+)\/(\d+)$/);
+  const frac  = s.match(/^(\d+)\/(\d+)$/);
+  const num   = s.match(/^(\d+(?:\.\d+)?)$/);
+
+  let val: number | null = null;
+  if (mixed) val = parseInt(mixed[1]) + parseInt(mixed[2]) / parseInt(mixed[3]);
+  else if (frac) val = parseInt(frac[1]) / parseInt(frac[2]);
+  else if (num)  val = parseFloat(num[1]);
+  if (val === null) return amount;
+
+  const scaled = val * ratio;
+  const whole = Math.floor(scaled);
+  const remainder = scaled - whole;
+
+  const fractions = [
+    { v: 0,    g: ''  },
+    { v: 0.25, g: '¼' },
+    { v: 0.33, g: '⅓' },
+    { v: 0.5,  g: '½' },
+    { v: 0.66, g: '⅔' },
+    { v: 0.75, g: '¾' },
+    { v: 1,    g: ''  },
+  ];
+  const closest = fractions.reduce((a, b) =>
+    Math.abs(b.v - remainder) < Math.abs(a.v - remainder) ? b : a
+  );
+
+  if (Math.abs(closest.v - remainder) < 0.06) {
+    if (closest.v === 1) return String(whole + 1);
+    if (closest.v === 0) return String(whole);
+    return whole > 0 ? `${whole} ${closest.g}` : closest.g;
+  }
+  return scaled >= 10 ? String(Math.round(scaled)) : scaled.toFixed(1).replace(/\.0$/, '');
+}

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@/components/ui/button";
 import { useRecipeContext } from "@/contexts/RecipeContext";
 import { useSessionContext } from "@/contexts/SessionContext";
+import { RecipeLetter } from "@/features/Chat/components/recipe/RecipeLetter";
 import { GetInventoryResponse, InventoryItem } from "@/lib/inventory/schemas";
-import { RecipeIngredient } from "@/lib/recipes/schemas";
+import { RecipeIngredient, RecipeStep, RecipeWithId } from "@/lib/recipes/schemas";
 import { fetcher } from "@/lib/utils/index";
 import Image from "next/image";
 import { useState } from "react";
@@ -54,8 +55,11 @@ const computeShortfall = (
   return diff > 0 ? diff : null;
 };
 
-export default function RecipeDisplay() {
-  const { selectedRecipe, exitRecipe } = useRecipeContext();
+function LegacyRecipeBody({
+  selectedRecipe,
+}: {
+  selectedRecipe: RecipeWithId;
+}) {
   const { userId } = useSessionContext();
   const [servings, setServings] = useState<number>(
     selectedRecipe?.baseServings ?? 2,
@@ -65,17 +69,6 @@ export default function RecipeDisplay() {
     userId ? `/api/inventory?userId=${userId}` : null,
     fetcher,
   );
-
-  const copyRecipe = async () => {
-    try {
-      await navigator.clipboard.writeText(selectedRecipe?.instructions || "");
-      toast.success("Recipe copied to clipboard!");
-    } catch {
-      toast.error("Failed to copy recipe");
-    }
-  };
-
-  if (!selectedRecipe) return null;
 
   const baseServings = selectedRecipe.baseServings || 2;
   const ingredients = (selectedRecipe.ingredients || []) as RecipeIngredient[];
@@ -100,6 +93,216 @@ export default function RecipeDisplay() {
   });
   const inPantryCount = ingredientStatus.filter((s) => s.inPantry).length;
   const shortCount = ingredientStatus.filter((s) => s.short != null).length;
+
+  return (
+    <>
+      {/* Hero strip */}
+      <div
+        className="relative h-[180px] sm:h-[220px] border-b border-border flex items-end"
+        style={{
+          background:
+            "linear-gradient(135deg, oklch(0.55 0.13 35) 0%, oklch(0.42 0.10 30) 100%)",
+        }}
+      >
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage:
+              "repeating-linear-gradient(135deg, oklch(1 0 0 / 0.04) 0 12px, transparent 12px 24px)",
+          }}
+        />
+        <div
+          className="relative w-full px-9 pt-6 pb-5 text-white"
+          style={{
+            background:
+              "linear-gradient(to top, oklch(0 0 0 / 0.3), transparent)",
+          }}
+        >
+          {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mb-2.5">
+              {selectedRecipe.tags.slice(0, 4).map((tag) => (
+                <span
+                  key={tag}
+                  className="text-[10.5px] font-semibold tracking-wide px-[9px] py-[3px] rounded-full text-white border border-white/35 bg-white/[0.18] backdrop-blur-[4px]"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+          <h1
+            className="font-display font-semibold text-[28px] sm:text-[36px] leading-none tracking-tight m-0"
+            style={{ textShadow: "0 2px 8px oklch(0 0 0 / 0.3)" }}
+          >
+            {selectedRecipe.name}
+          </h1>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="px-6 sm:px-9 py-7 pb-12">
+        {/* From Ah Mah */}
+        {selectedRecipe.description && (
+          <div className="flex gap-3.5 items-start mb-6 pb-5 border-b border-dashed border-border">
+            <div className="relative w-10 h-10 shrink-0">
+              <Image
+                src="/granny-icon.png"
+                alt=""
+                fill
+                className="object-contain"
+              />
+            </div>
+            <div>
+              <div className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint mb-1">
+                From Ah Mah
+              </div>
+              <div className="font-display italic text-[15px] sm:text-base text-foreground leading-[1.5] max-w-prose">
+                {selectedRecipe.description}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Stat row — total time + servings stepper */}
+        <div className="flex flex-wrap items-end gap-3 mb-7">
+          {selectedRecipe.totalTimeMinutes && (
+            <div className="flex flex-col px-3.5 py-2 bg-card border border-border rounded-lg shadow-[0_1px_0_var(--color-border-soft)] min-w-[78px]">
+              <span className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
+                Total time
+              </span>
+              <span className="font-display font-semibold text-[18px] text-foreground tabular-nums mt-0.5">
+                {formatTime(selectedRecipe.totalTimeMinutes)}
+              </span>
+            </div>
+          )}
+          <div className="flex flex-col px-3.5 py-2 bg-card border border-border rounded-lg shadow-[0_1px_0_var(--color-border-soft)] min-w-[78px]">
+            <span className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
+              Yields
+            </span>
+            <span className="font-display font-semibold text-[18px] text-foreground tabular-nums mt-0.5">
+              {servings} {servings === 1 ? "serving" : "servings"}
+            </span>
+          </div>
+          <div className="flex-1" />
+          <div className="flex flex-col items-end gap-1.5">
+            <span className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
+              Servings
+            </span>
+            <div className="inline-flex items-center bg-card border border-border rounded-lg overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
+              <button
+                onClick={() => setServings((s) => Math.max(1, s - 1))}
+                disabled={servings <= 1}
+                aria-label="Decrease servings"
+                className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-r border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+              >
+                −
+              </button>
+              <span className="min-w-11 text-center font-display font-semibold text-[15px] text-foreground tabular-nums">
+                {servings}
+              </span>
+              <button
+                onClick={() => setServings((s) => Math.min(20, s + 1))}
+                disabled={servings >= 20}
+                aria-label="Increase servings"
+                className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-l border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+              >
+                +
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Ingredients */}
+        {ingredients.length > 0 && (
+          <section className="mb-9">
+            <div className="flex items-baseline justify-between mb-1 flex-wrap gap-3">
+              <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight m-0">
+                Ingredients
+              </h2>
+              <div className="flex items-center gap-3.5 font-sans text-[12px] text-muted-foreground">
+                {inPantryCount > 0 && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-accent" />
+                    {inPantryCount} in pantry
+                  </span>
+                )}
+                {shortCount > 0 && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-destructive" />
+                    {shortCount} short
+                  </span>
+                )}
+              </div>
+            </div>
+            <ul className="list-none p-0 mt-2 border-t border-border">
+              {ingredientStatus.map(({ ing, scaled, inv, short, inPantry }, i) => (
+                <li
+                  key={i}
+                  className="flex items-baseline gap-3 py-2.5 border-b border-dashed border-border"
+                >
+                  <span className="basis-20 sm:basis-24 shrink-0 font-mono text-[13px] font-semibold text-foreground tabular-nums text-right">
+                    {scaled != null
+                      ? `${formatAmount(scaled)}${ing.unit ? ` ${ing.unit}` : ""}`
+                      : "—"}
+                  </span>
+                  <span className="flex-1 font-display text-[15px] text-foreground leading-[1.4]">
+                    {ing.name}
+                  </span>
+                  {inPantry && (
+                    <span
+                      className="font-sans text-[10.5px] font-semibold px-[7px] py-[2px] rounded-full tracking-wide shrink-0 text-accent border"
+                      style={{
+                        background: "oklch(0.94 0.04 168)",
+                        borderColor: "oklch(0.78 0.07 168)",
+                      }}
+                    >
+                      in pantry
+                    </span>
+                  )}
+                  {short != null && (
+                    <span
+                      className="font-sans text-[10.5px] font-semibold px-[7px] py-[2px] rounded-full tracking-wide shrink-0 text-destructive border border-destructive/30 bg-destructive/10"
+                      title={`You have ${inv?.quantity}${inv?.unit ? ` ${inv.unit}` : ""}`}
+                    >
+                      short {formatAmount(short)}
+                      {ing.unit ? ` ${ing.unit}` : ""}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* Method */}
+        <section>
+          <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight mb-4">
+            Method
+          </h2>
+          <div className="recipe-prose">
+            <Streamdown>
+              {extractInstructions(selectedRecipe.instructions || "")}
+            </Streamdown>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}
+
+export default function RecipeDisplay() {
+  const { selectedRecipe, exitRecipe } = useRecipeContext();
+
+  const copyRecipe = async () => {
+    try {
+      await navigator.clipboard.writeText(selectedRecipe?.instructions || "");
+      toast.success("Recipe copied to clipboard!");
+    } catch {
+      toast.error("Failed to copy recipe");
+    }
+  };
+
+  if (!selectedRecipe) return null;
 
   return (
     <div className="flex flex-col h-full">
@@ -139,198 +342,32 @@ export default function RecipeDisplay() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto">
-        {/* Hero strip */}
-        <div
-          className="relative h-[180px] sm:h-[220px] border-b border-border flex items-end"
-          style={{
-            background:
-              "linear-gradient(135deg, oklch(0.55 0.13 35) 0%, oklch(0.42 0.10 30) 100%)",
-          }}
-        >
-          <div
-            className="absolute inset-0"
-            style={{
-              backgroundImage:
-                "repeating-linear-gradient(135deg, oklch(1 0 0 / 0.04) 0 12px, transparent 12px 24px)",
+      {selectedRecipe.steps && (selectedRecipe.steps as RecipeStep[]).length > 0 ? (
+        // New structured recipe — render RecipeLetter (no onSave — it's already saved)
+        <div className="flex-1 overflow-y-auto px-6 sm:px-9 py-7 pb-12">
+          <RecipeLetter
+            recipe={{
+              title: selectedRecipe.name,
+              description: selectedRecipe.description ?? undefined,
+              totalTimeMinutes: selectedRecipe.totalTimeMinutes ?? undefined,
+              baseServings: selectedRecipe.baseServings,
+              ingredients: (selectedRecipe.ingredients as RecipeIngredient[]).map(ing => ({
+                name: ing.name,
+                amount: ing.amount != null ? String(ing.amount) : undefined,
+                unit: ing.unit ?? undefined,
+              })),
+              steps: selectedRecipe.steps as RecipeStep[],
+              tags: selectedRecipe.tags ?? undefined,
             }}
+            // No onSave — recipe is already saved (it came from the cookbook)
           />
-          <div
-            className="relative w-full px-9 pt-6 pb-5 text-white"
-            style={{
-              background:
-                "linear-gradient(to top, oklch(0 0 0 / 0.3), transparent)",
-            }}
-          >
-            {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 mb-2.5">
-                {selectedRecipe.tags.slice(0, 4).map((tag) => (
-                  <span
-                    key={tag}
-                    className="text-[10.5px] font-semibold tracking-wide px-[9px] py-[3px] rounded-full text-white border border-white/35 bg-white/[0.18] backdrop-blur-[4px]"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            )}
-            <h1
-              className="font-display font-semibold text-[28px] sm:text-[36px] leading-none tracking-tight m-0"
-              style={{ textShadow: "0 2px 8px oklch(0 0 0 / 0.3)" }}
-            >
-              {selectedRecipe.name}
-            </h1>
-          </div>
         </div>
-
-        {/* Body */}
-        <div className="px-6 sm:px-9 py-7 pb-12">
-          {/* From Ah Mah */}
-          {selectedRecipe.description && (
-            <div className="flex gap-3.5 items-start mb-6 pb-5 border-b border-dashed border-border">
-              <div className="relative w-10 h-10 shrink-0">
-                <Image
-                  src="/granny-icon.png"
-                  alt=""
-                  fill
-                  className="object-contain"
-                />
-              </div>
-              <div>
-                <div className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint mb-1">
-                  From Ah Mah
-                </div>
-                <div className="font-display italic text-[15px] sm:text-base text-foreground leading-[1.5] max-w-prose">
-                  {selectedRecipe.description}
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Stat row — total time + servings stepper */}
-          <div className="flex flex-wrap items-end gap-3 mb-7">
-            {selectedRecipe.totalTimeMinutes && (
-              <div className="flex flex-col px-3.5 py-2 bg-card border border-border rounded-lg shadow-[0_1px_0_var(--color-border-soft)] min-w-[78px]">
-                <span className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
-                  Total time
-                </span>
-                <span className="font-display font-semibold text-[18px] text-foreground tabular-nums mt-0.5">
-                  {formatTime(selectedRecipe.totalTimeMinutes)}
-                </span>
-              </div>
-            )}
-            <div className="flex flex-col px-3.5 py-2 bg-card border border-border rounded-lg shadow-[0_1px_0_var(--color-border-soft)] min-w-[78px]">
-              <span className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
-                Yields
-              </span>
-              <span className="font-display font-semibold text-[18px] text-foreground tabular-nums mt-0.5">
-                {servings} {servings === 1 ? "serving" : "servings"}
-              </span>
-            </div>
-            <div className="flex-1" />
-            <div className="flex flex-col items-end gap-1.5">
-              <span className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
-                Servings
-              </span>
-              <div className="inline-flex items-center bg-card border border-border rounded-lg overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
-                <button
-                  onClick={() => setServings((s) => Math.max(1, s - 1))}
-                  disabled={servings <= 1}
-                  aria-label="Decrease servings"
-                  className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-r border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
-                >
-                  −
-                </button>
-                <span className="min-w-11 text-center font-display font-semibold text-[15px] text-foreground tabular-nums">
-                  {servings}
-                </span>
-                <button
-                  onClick={() => setServings((s) => Math.min(20, s + 1))}
-                  disabled={servings >= 20}
-                  aria-label="Increase servings"
-                  className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-l border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
-                >
-                  +
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Ingredients */}
-          {ingredients.length > 0 && (
-            <section className="mb-9">
-              <div className="flex items-baseline justify-between mb-1 flex-wrap gap-3">
-                <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight m-0">
-                  Ingredients
-                </h2>
-                <div className="flex items-center gap-3.5 font-sans text-[12px] text-muted-foreground">
-                  {inPantryCount > 0 && (
-                    <span className="inline-flex items-center gap-1.5">
-                      <span className="w-2 h-2 rounded-full bg-accent" />
-                      {inPantryCount} in pantry
-                    </span>
-                  )}
-                  {shortCount > 0 && (
-                    <span className="inline-flex items-center gap-1.5">
-                      <span className="w-2 h-2 rounded-full bg-destructive" />
-                      {shortCount} short
-                    </span>
-                  )}
-                </div>
-              </div>
-              <ul className="list-none p-0 mt-2 border-t border-border">
-                {ingredientStatus.map(({ ing, scaled, inv, short, inPantry }, i) => (
-                  <li
-                    key={i}
-                    className="flex items-baseline gap-3 py-2.5 border-b border-dashed border-border"
-                  >
-                    <span className="basis-20 sm:basis-24 shrink-0 font-mono text-[13px] font-semibold text-foreground tabular-nums text-right">
-                      {scaled != null
-                        ? `${formatAmount(scaled)}${ing.unit ? ` ${ing.unit}` : ""}`
-                        : "—"}
-                    </span>
-                    <span className="flex-1 font-display text-[15px] text-foreground leading-[1.4]">
-                      {ing.name}
-                    </span>
-                    {inPantry && (
-                      <span
-                        className="font-sans text-[10.5px] font-semibold px-[7px] py-[2px] rounded-full tracking-wide shrink-0 text-accent border"
-                        style={{
-                          background: "oklch(0.94 0.04 168)",
-                          borderColor: "oklch(0.78 0.07 168)",
-                        }}
-                      >
-                        in pantry
-                      </span>
-                    )}
-                    {short != null && (
-                      <span
-                        className="font-sans text-[10.5px] font-semibold px-[7px] py-[2px] rounded-full tracking-wide shrink-0 text-destructive border border-destructive/30 bg-destructive/10"
-                        title={`You have ${inv?.quantity}${inv?.unit ? ` ${inv.unit}` : ""}`}
-                      >
-                        short {formatAmount(short)}
-                        {ing.unit ? ` ${ing.unit}` : ""}
-                      </span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-
-          {/* Method */}
-          <section>
-            <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight mb-4">
-              Method
-            </h2>
-            <div className="recipe-prose">
-              <Streamdown>
-                {extractInstructions(selectedRecipe.instructions || "")}
-              </Streamdown>
-            </div>
-          </section>
+      ) : (
+        // Legacy recipe — fall back to existing layout (hero strip + body)
+        <div className="flex-1 overflow-y-auto">
+          <LegacyRecipeBody selectedRecipe={selectedRecipe} />
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/lib/recipes/schemas.ts
+++ b/src/lib/recipes/schemas.ts
@@ -8,6 +8,62 @@ export const RecipeIngredientSchema = z.object({
 
 export type RecipeIngredient = z.infer<typeof RecipeIngredientSchema>;
 
+// Step in a structured recipe
+export const RecipeStepSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+  tip: z.string().optional(),
+});
+export type RecipeStep = z.infer<typeof RecipeStepSchema>;
+
+// Ingredient as emitted by the model (amounts as strings for scaling)
+export const RecipeIngredientModelSchema = z.object({
+  name: z.string(),
+  amount: z.string().optional(),   // string so "1 1/2" works
+  unit: z.string().optional(),
+  note: z.string().optional(),
+});
+export type RecipeIngredientModel = z.infer<typeof RecipeIngredientModelSchema>;
+
+// Full structured recipe block (```recipe fenced JSON)
+export const RecipeBlockSchema = z.object({
+  title: z.string(),
+  description: z.string().optional(),
+  totalTimeMinutes: z.number().optional(),
+  baseServings: z.number(),
+  ingredients: z.array(RecipeIngredientModelSchema),
+  steps: z.array(RecipeStepSchema),
+  tags: z.array(z.string()).optional(),
+});
+export type RecipeBlock = z.infer<typeof RecipeBlockSchema>;
+
+// One option inside a ```suggestions block
+export const SuggestionOptionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  blurb: z.string(),
+  time: z.string(),
+  tags: z.array(z.string()),
+  keyIngredients: z.array(z.string()),
+  note: z.string().optional(),
+});
+export type SuggestionOption = z.infer<typeof SuggestionOptionSchema>;
+
+// Full ```suggestions block
+export const SuggestionsBlockSchema = z.object({
+  intro: z.string(),
+  options: z.array(SuggestionOptionSchema),
+});
+export type SuggestionsBlockData = z.infer<typeof SuggestionsBlockSchema>;
+
+// ```gate block
+export const GateSchema = z.object({
+  recipeId: z.string(),
+  title: z.string(),
+  keyIngredients: z.array(z.string()),
+});
+export type GateData = z.infer<typeof GateSchema>;
+
 export type Recipe = {
   userId: string;
   name: string;
@@ -16,6 +72,7 @@ export type Recipe = {
   recipeId?: string;
   baseServings: number;
   ingredients: RecipeIngredient[];
+  steps?: RecipeStep[];          // new: structured steps (null for legacy recipes)
   description?: string;
   totalTimeMinutes?: number;
   createdAt?: Date;


### PR DESCRIPTION
## Summary

- **Handwritten recipe letter** — replaces the old `-----` markdown blob with a richly-styled inline component: Fraunces italic prose, inline-scaling servings stepper with pulse animation on changed amounts, terracotta numbered step stamps, tip callouts with left-bar, Save to cookbook button
- **Suggestion flow** — open-ended asks now return 3 recipe headline cards with tags, time, blurb, Ah Mah note, and live pantry counts (computed client-side from `keyIngredients[]` × inventory). Clicking a card sends a user message and advances to the gate
- **Ingredient gate** — confirms pantry readiness before revealing the full recipe; shows `have/total` badge + missing ingredients; "I have everything" → recipe letter; "I'm missing some" → coming-soon toast
- **JSON-first recipe protocol** — model now emits structured ` ```suggestions ` / ` ```gate ` / ` ```recipe ` fenced JSON blocks instead of `-----` markdown; client parses and dispatches to components; legacy `-----` messages fall back to existing Save-button rendering
- **Cookbook panel updated** — `RecipeDisplay` Sheet body replaced with `RecipeLetter`; legacy recipes (no `steps`) fall back to Streamdown markdown view
- **Schema** — added `steps Json?` column to `Recipe` (migration: `20260504120000_add_recipe_steps`); new Zod schemas for `RecipeBlock`, `SuggestionsBlockData`, `GateData`

## Test plan

- [ ] `npx prisma migrate deploy` (or `npm run db:local`) to apply `add_recipe_steps` migration
- [ ] `npm run dev` — open the app
- [ ] Send "What can I cook tonight?" → 3 suggestion cards appear inline
- [ ] Click a card → user bubble + ingredient gate with pantry summary
- [ ] Click "I have everything" → handwritten letter renders; use stepper to scale amounts
- [ ] Click Save → ✓ Saved state; recipe appears in Cookbook tab
- [ ] Open saved recipe from Cookbook → same handwritten letter in side panel
- [ ] Click "I'm missing some" → "Coming soon" toast
- [ ] Send "Make me ginger chicken" (specific) → recipe letter direct, no suggestion step
- [ ] Hard reload mid-flow → all surfaces re-render from saved content
- [ ] Open a pre-migration saved recipe from Cookbook → Streamdown fallback renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)