### PR TITLE
feat(chat): replace gate fenced-block with proposeRecipe tool

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -51,6 +51,15 @@ The persistent-kitchen MVP. Highlights:
 - [x] Established styling guardrails in `CLAUDE.md` to prefer tokens over inline styles.
 - [x] Mapped arbitrary values to standard Tailwind tokens for improved maintainability.
 
+### proposeRecipe tool — eliminate prose clarifying questions (May 2026)
+- [x] Replaced `\`\`\`gate` fenced-block convention with a `proposeRecipe` tool call (no `execute`) registered in `/api/chat/route.ts`.
+- [x] Gate card (`IngredientGate`) now renders from `tool-proposeRecipe` message part instead of parsed fenced text.
+- [x] Removed `gate` branch from `extractRecipeBlocks` and `stripFences`; parser extracted to `src/lib/recipes/parseBlocks.ts`.
+- [x] System prompt routing updated: named dish + ≥80% pantry coverage → `\`\`\`recipe` directly; otherwise → `proposeRecipe` tool.
+- [x] Prompt rule: model must call `proposeRecipe` or emit `\`\`\`recipe` — never ask "do you have X?" in prose.
+- [x] Unit tests added for `parseBlocks.ts` (14 cases including regression guard for removed gate path).
+- [x] `MessageList.test.tsx` extended with 4 cases covering tool-part rendering and absence of legacy gate path.
+
 ### Decrement-on-cook
 - [ ] Add `Cooked This` button in `RecipeDisplay` for saved recipes.
 - [ ] Add explicit confirmation flow for inferred "I cooked X" messages (`yes / no / edit`).

--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -5,7 +5,7 @@ When you explain technique, lean on the science of why it works — Maillard rea
 # Tools
 
 - \`getInventory\` — call this before suggesting recipes or answering "what can I cook". If empty, ask the user what they have rather than guess blind. Do NOT call it for general cooking knowledge questions (e.g., "what's the difference between baking soda and baking powder"). When the inventory includes equipment (wok, pressure cooker, air fryer, slow cooker, etc.), always adapt the recipe method to that equipment — adjust timing, technique, and instructions accordingly without waiting to be asked.
-- \`addInventoryItem\` — when the user mentions buying or having something, add it. **After you emit a \`gate\`, if the user replies "I have everything" (or similar), call \`addInventoryItem\` for each item in the gate's \`keyIngredients\` before emitting the recipe. If the user replies "I'm missing some" (or similar), do NOT call \`addInventoryItem\` — write the recipe with substitution notes instead.** Always set \`shelfLife\` for every item:
+- \`addInventoryItem\` — when the user mentions buying or having something, add it. **After you call \`proposeRecipe\`, if the user replies "I have everything" (or similar), call \`addInventoryItem\` for each item in the \`keyIngredients\` before emitting the recipe. If the user replies "I'm missing some" (or similar), do NOT call \`addInventoryItem\` — write the recipe with substitution notes instead.** Always set \`shelfLife\` for every item:
   - "short" — leafy greens, herbs, seafood, dairy, cooked leftovers, mushrooms
   - "medium" — most meat, most fresh produce, eggs, tofu, bread
   - "long" — oils, dry goods (rice, pasta, flour), spices, sauces, canned/bottled goods, kitchenware
@@ -16,7 +16,7 @@ When choosing units in the ingredient list, prefer the units the user already ha
 
 # Output format
 
-You have three output modes. ALWAYS emit exactly one fenced code block per response (placed after any brief prose). NEVER mix block types in a single message. NEVER use the old ----- delimiters.
+You have three output modes. ALWAYS emit exactly one action per response (a fenced block or a tool call, placed after any brief prose). NEVER mix modes in a single message. NEVER use the old ----- delimiters.
 
 ## Mode 1 — Suggestions (open-ended "what can I cook?" asks)
 
@@ -46,22 +46,19 @@ Rules:
 - \`id\` must be a unique kebab-case slug matching the title.
 - A brief warm sentence BEFORE the block is fine (e.g. "Ah, chicken breast — three good directions:").
 
-## Mode 2 — Gate (after user picks a suggestion)
+## Mode 2 — Gate (user names a specific dish, pantry coverage < ~80%)
 
-When the user says they want a specific recipe (e.g. "Ginger Chicken — let's go."), emit a gate check before the full recipe:
+When the user names a specific dish or picks from suggestions, call \`getInventory\` first, then decide:
 
-\`\`\`gate
-{
-  "recipeId": "ginger-chicken-bok-choy",
-  "title": "Ginger Chicken & Bok Choy",
-  "keyIngredients": ["chicken thigh", "bok choy", "ginger", "garlic", "soy sauce", "oyster sauce", "sesame oil", "shaoxing wine", "cornstarch", "spring onion"]
-}
-\`\`\`
+- If **≥80% of the key ingredients** are already in inventory → skip the gate and emit a \`\`\`recipe block directly (Mode 3). Use the \`note\` field on any missing 1–2 ingredients to flag them ("not in pantry — grab next shop" or suggest a swap).
+- If **coverage is below ~80%** → call the \`proposeRecipe\` tool with:
+  - \`recipeId\`: kebab-case slug for the dish
+  - \`title\`: display name
+  - \`keyIngredients\`: FULL ingredient list for this recipe (the client does pantry intersection)
 
-Rules:
-- \`recipeId\` matches the \`id\` from the suggestions block the user picked.
-- \`keyIngredients\` is the FULL ingredient list for this specific recipe (the client will do pantry intersection).
-- A brief warm question BEFORE the block is fine (e.g. "Lovely choice — quick check before I write it out:").
+**You MUST call \`proposeRecipe\` or emit \`\`\`recipe — NEVER ask "do you have X?" in prose.** The tool call IS that question.
+
+A brief warm sentence BEFORE the tool call is fine (e.g. "Lovely choice — quick check before I write it out:").
 
 ## Mode 3 — Recipe (after gate confirmation)
 
@@ -108,15 +105,14 @@ Rules:
 
 ## Routing rules
 
-| Situation | Mode |
+| Situation | Action |
 |---|---|
-| "What can I cook?", "I have X and Y, suggestions?" | Suggestions |
-| User picks a suggestion ("Ginger Chicken — let's go.") | Gate |
-| User answers gate ("I have everything.", "yes go ahead") | addInventoryItem(keyIngredients) → Recipe |
-| User answers gate ("I'm missing some.") | Recipe with sub notes (no addInventoryItem) |
-| User names a specific dish ("Make me achar") | Gate |
-| Ambiguous specific-dish ask (e.g. "basil rice" — multiple legit interpretations) | Suggestions block with variants |
-| "Show me other recipes" from gate | New Suggestions block |
+| "What can I cook?", "I have X and Y, suggestions?" | getInventory → \`\`\`suggestions block |
+| User names a specific dish ("Make me guacamole") or picks a suggestion | getInventory → if ≥80% coverage: \`\`\`recipe directly; else: call \`proposeRecipe\` tool |
+| User answers gate ("I have everything.", "yes go ahead") | addInventoryItem(keyIngredients) → \`\`\`recipe |
+| User answers gate ("I'm missing some.") | \`\`\`recipe with sub notes (no addInventoryItem) |
+| Ambiguous specific-dish ask (e.g. "basil rice" — multiple legit interpretations) | getInventory → \`\`\`suggestions block with variants |
+| "Show me other recipes" from gate | getInventory → \`\`\`suggestions block |
 | General cooking question (no recipe needed) | Plain text, no block |
 
 # Behavior
@@ -125,5 +121,5 @@ Rules:
 - If a recipe needs something the user doesn't have, suggest a realistic substitute or note it as something to grab next shop. Don't dwell on what's missing.
 - For "what can I cook" on an empty inventory, ask warmly what they have rather than recommending blind.
 - Keep responses tight and conversational — short sentences, not lectures. End with a small encouraging nudge or question when it fits.
-- **Never ask "do you have X?" in prose.** The gate IS that question — emit it instead. If the dish name is ambiguous (e.g. "basil rice" could be Thai or Italian), emit a Suggestions block with variants so the user can pick by clicking, not typing.
+- **Never ask "do you have X?" in prose.** Call \`proposeRecipe\` or emit \`\`\`recipe instead. If the dish name is ambiguous (e.g. "basil rice" could be Thai or Italian), emit a \`\`\`suggestions block with variants so the user can pick by clicking, not typing.
 `;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -7,10 +7,12 @@ import {
   AddInventoryItemSchemaObj,
   RemoveInventoryItemSchemaObj,
 } from "@/lib/inventory/schemas";
+import { GateSchema } from "@/lib/recipes/schemas";
 import { getMessages } from "@/lib/messages";
 import { openai } from "@ai-sdk/openai";
 import {
   convertToModelMessages,
+  hasToolCall,
   stepCountIs,
   streamText,
   UIMessage,
@@ -52,7 +54,7 @@ export async function POST(req: NextRequest) {
       model,
       messages: convertToModelMessages(validatedMessages),
       system: CHAT_SYSTEM_PROMPT,
-      stopWhen: stepCountIs(5),
+      stopWhen: [stepCountIs(5), hasToolCall("proposeRecipe")],
       tools: {
         addInventoryItem: {
           description: `Add items to the user's inventory. Required: name (string), type ("ingredient" or "kitchenware"), and shelfLife ("short" | "medium" | "long" — infer from the item: leafy greens/seafood/dairy = short; meat/most produce = medium; oils/dry goods/spices/kitchenware = long). Optional: quantity (number) and unit (string) — only set quantity if the user explicitly states one.`,
@@ -88,6 +90,12 @@ export async function POST(req: NextRequest) {
               content: "Items removed from inventory",
             };
           },
+        },
+        proposeRecipe: {
+          description:
+            "Propose a specific recipe to the user as a pantry-check gate card. Call this when the user names a dish and pantry coverage is below ~80% of key ingredients. The client renders an interactive card from the input — do NOT call this when coverage is ≥80%; emit a ```recipe block directly instead.",
+          inputSchema: GateSchema,
+          execute: async () => ({ status: "awaiting_user_confirmation" }),
         },
       },
     });

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -195,14 +195,18 @@ const Chat = () => {
   }
 
   const savedMessages = (data || []).map(convertToUIMessage);
-  const currentMessages = messages.filter((currentMsg) => {
-    const currentContent = currentMsg.parts
+
+  // Prefer the rich useChat version (which may have tool parts) over the text-only saved version.
+  // Filter savedMessages to exclude any message whose text is already represented in the
+  // live useChat messages — avoids duplicates while keeping tool-call parts visible.
+  const savedMessagesFiltered = savedMessages.filter((savedMsg) => {
+    const savedContent = savedMsg.parts
       .filter((part) => part.type === "text")
       .map((part) => part.text)
       .join("");
 
-    return !savedMessages.some((savedMsg) => {
-      const savedContent = savedMsg.parts
+    return !messages.some((currentMsg) => {
+      const currentContent = currentMsg.parts
         .filter((part) => part.type === "text")
         .map((part) => part.text)
         .join("");
@@ -213,7 +217,7 @@ const Chat = () => {
     });
   });
 
-  const allMessages = [INITIAL_MESSAGE, ...savedMessages, ...currentMessages];
+  const allMessages = [INITIAL_MESSAGE, ...savedMessagesFiltered, ...messages];
   const messageCount = allMessages.length - 1; // exclude initial
 
   const startedAt = activeConversation?.createdAt

--- a/src/features/Chat/components/MessageList.test.tsx
+++ b/src/features/Chat/components/MessageList.test.tsx
@@ -47,6 +47,14 @@ jest.mock("@/lib/utils/index", () => ({
   fetcher: jest.fn(),
 }));
 
+jest.mock("./recipe/IngredientGate", () => ({
+  IngredientGate: ({ data }: { data: { title: string; keyIngredients: string[] } }) => (
+    <div data-testid="ingredient-gate" data-title={data.title}>
+      {data.keyIngredients.join(",")}
+    </div>
+  ),
+}));
+
 // Mock AI Elements components
 jest.mock("@/components/ai-elements/conversation", () => ({
   Conversation: ({ children }: { children: React.ReactNode }) => (
@@ -698,6 +706,91 @@ describe("MessageList", () => {
       // The component actually shows the save button if it finds a single -----
       // since it splits on ----- and checks if the second part exists
       expect(screen.getByTestId("button")).toBeInTheDocument();
+    });
+  });
+
+  describe("proposeRecipe tool rendering", () => {
+    it("renders IngredientGate when message contains a proposeRecipe tool part in input-available state", () => {
+      const toolMessage = createMockMessage({
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Quick check before I write it out:" },
+          {
+            type: "tool-proposeRecipe",
+            toolCallId: "call-123",
+            state: "input-available",
+            input: {
+              recipeId: "guacamole",
+              title: "Guacamole",
+              keyIngredients: ["avocado", "lime", "onion", "cilantro", "jalapeño"],
+            },
+          } as unknown as { type: "text"; text: string },
+        ],
+      });
+
+      render(<MessageList {...defaultProps} messages={[toolMessage]} />);
+
+      const gate = screen.getByTestId("ingredient-gate");
+      expect(gate).toBeInTheDocument();
+      expect(gate).toHaveAttribute("data-title", "Guacamole");
+      expect(gate).toHaveTextContent("avocado");
+    });
+
+    it("does NOT render IngredientGate for a gate fenced block (gate path removed)", () => {
+      const gateBlockMessage = createMockMessage({
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "```gate\n{\"recipeId\":\"guacamole\",\"title\":\"Guacamole\",\"keyIngredients\":[\"avocado\"]}\n```",
+          },
+        ],
+      });
+
+      render(<MessageList {...defaultProps} messages={[gateBlockMessage]} />);
+
+      expect(screen.queryByTestId("ingredient-gate")).not.toBeInTheDocument();
+    });
+
+    it("renders IngredientGate when tool state is output-available", () => {
+      const toolMessage = createMockMessage({
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-proposeRecipe",
+            toolCallId: "call-456",
+            state: "output-available",
+            input: {
+              recipeId: "fried-rice",
+              title: "Fried Rice",
+              keyIngredients: ["rice", "egg"],
+            },
+            output: null,
+          } as unknown as { type: "text"; text: string },
+        ],
+      });
+
+      render(<MessageList {...defaultProps} messages={[toolMessage]} />);
+
+      expect(screen.getByTestId("ingredient-gate")).toHaveAttribute("data-title", "Fried Rice");
+    });
+
+    it("does not render IngredientGate when tool state is input-streaming", () => {
+      const toolMessage = createMockMessage({
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-proposeRecipe",
+            toolCallId: "call-789",
+            state: "input-streaming",
+            input: undefined,
+          } as unknown as { type: "text"; text: string },
+        ],
+      });
+
+      render(<MessageList {...defaultProps} messages={[toolMessage]} />);
+
+      expect(screen.queryByTestId("ingredient-gate")).not.toBeInTheDocument();
     });
   });
 

--- a/src/features/Chat/components/MessageList.test.tsx
+++ b/src/features/Chat/components/MessageList.test.tsx
@@ -55,6 +55,10 @@ jest.mock("./recipe/IngredientGate", () => ({
   ),
 }));
 
+jest.mock("./recipe/SuggestionsBlock", () => ({
+  SuggestionsBlock: () => <div data-testid="suggestions-block" />,
+}));
+
 // Mock AI Elements components
 jest.mock("@/components/ai-elements/conversation", () => ({
   Conversation: ({ children }: { children: React.ReactNode }) => (
@@ -144,6 +148,7 @@ describe("MessageList", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(console, "warn").mockImplementation(() => {});
 
     // Default SWR mock
     mockUseSWR.mockReturnValue({
@@ -156,6 +161,10 @@ describe("MessageList", () => {
 
     // Mock scrollIntoView
     Element.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe("Basic Rendering", () => {
@@ -487,7 +496,7 @@ describe("MessageList", () => {
       );
 
       expect(screen.getByTestId("loader-ghost")).toBeInTheDocument();
-      expect(screen.getByText("Ah Mah is writing it out")).toBeInTheDocument();
+      expect(screen.getByText("Ah Mah · just a moment")).toBeInTheDocument();
       expect(screen.getByText("Let me write the whole thing out for you —")).toBeInTheDocument();
     });
   });
@@ -665,6 +674,23 @@ describe("MessageList", () => {
       expect(screen.queryByTestId("response")).not.toBeInTheDocument();
     });
 
+    it("should not render response for whitespace-only text after stripping fences", () => {
+      const message = createMockMessage({
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "```suggestions\n{\"intro\":\"x\",\"options\":[]}\n```\n\n",
+          },
+        ],
+      });
+
+      render(<MessageList {...defaultProps} messages={[message]} />);
+
+      expect(screen.getByTestId("message")).toBeInTheDocument();
+      expect(screen.queryByTestId("response")).not.toBeInTheDocument();
+    });
+
     it("should handle very long messages", () => {
       const longText = "a".repeat(10000);
       const longMessage = createMockMessage({
@@ -790,6 +816,40 @@ describe("MessageList", () => {
 
       render(<MessageList {...defaultProps} messages={[toolMessage]} />);
 
+      expect(screen.queryByTestId("ingredient-gate")).not.toBeInTheDocument();
+    });
+
+    it("warns when proposeRecipe tool is ignored because message also has new blocks", () => {
+      const toolAndBlockMessage = createMockMessage({
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "```suggestions\n{\"intro\":\"Ideas\",\"options\":[{\"id\":\"fried-rice\",\"title\":\"Fried Rice\",\"blurb\":\"Quick one-pan.\",\"time\":\"15 min\",\"tags\":[\"quick\"],\"keyIngredients\":[\"rice\",\"egg\"]}]}\n```",
+          },
+          {
+            type: "tool-proposeRecipe",
+            toolCallId: "call-999",
+            state: "input-available",
+            input: {
+              recipeId: "fried-rice",
+              title: "Fried Rice",
+              keyIngredients: ["rice", "egg"],
+            },
+          } as unknown as { type: "text"; text: string },
+        ],
+      });
+
+      render(<MessageList {...defaultProps} messages={[toolAndBlockMessage]} />);
+
+      expect(console.warn).toHaveBeenCalledWith(
+        "[MessageList] proposeRecipe tool part ignored due to fence/block mode",
+        expect.objectContaining({
+          messageId: toolAndBlockMessage.id,
+          messageIndex: 0,
+          hasNewBlocks: true,
+        }),
+      );
       expect(screen.queryByTestId("ingredient-gate")).not.toBeInTheDocument();
     });
   });

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -11,15 +11,12 @@ import {
 } from "@/components/ai-elements/message";
 import { Response } from "@/components/ai-elements/response";
 import { Button } from "@/components/ui/button";
-import type {
-  RecipeBlock,
-  RecipeWithId,
-} from "@/lib/recipes/schemas";
 import {
   extractRecipeBlocks,
   getOpenRecipeFenceIdx,
   stripFences,
 } from "@/lib/recipes/parseBlocks";
+import type { RecipeBlock, RecipeWithId } from "@/lib/recipes/schemas";
 import { fetcher } from "@/lib/utils/index";
 import type { UIMessage } from "ai";
 import { useEffect, useRef, useState } from "react";
@@ -236,14 +233,17 @@ export const MessageList = ({
             const textContent = message.parts
               .filter(
                 (p): p is { type: "text"; text: string } =>
-                  p.type === "text" && typeof (p as { text?: string }).text === "string",
+                  p.type === "text" &&
+                  typeof (p as { text?: string }).text === "string",
               )
               .map((p) => (p as { type: "text"; text: string }).text)
               .join("");
 
             const isLastMsg = message === messages[messages.length - 1];
             const isStreamingLast =
-              status === "streaming" && isLastMsg && message.role === "assistant";
+              status === "streaming" &&
+              isLastMsg &&
+              message.role === "assistant";
             const openFenceIdx = isStreamingLast
               ? getOpenRecipeFenceIdx(textContent)
               : -1;
@@ -256,7 +256,28 @@ export const MessageList = ({
               : textContent;
             const blocks = extractRecipeBlocks(prefixText);
             const hasNewBlocks = blocks.some((b) => b.kind !== "legacy");
-            const proseText = hasNewBlocks ? stripFences(prefixText) : prefixText;
+            const proseText = hasNewBlocks
+              ? stripFences(prefixText)
+              : prefixText;
+            const hasProposeRecipeToolPart = message.parts.some(
+              (part) => part.type === "tool-proposeRecipe",
+            );
+
+            if (
+              process.env.NODE_ENV !== "production" &&
+              hasProposeRecipeToolPart &&
+              (hasNewBlocks || hasOpenFence)
+            ) {
+              console.warn(
+                "[MessageList] proposeRecipe tool part ignored due to fence/block mode",
+                {
+                  messageId: message.id,
+                  messageIndex,
+                  hasNewBlocks,
+                  hasOpenFence,
+                },
+              );
+            }
 
             return (
               <Message
@@ -271,43 +292,58 @@ export const MessageList = ({
                 <MessageContent variant="flat">
                   {/* Prose — strip completed fences when new-style blocks present;
                       when an open fence is detected, prefixText is already trimmed */}
-                  {hasNewBlocks
-                    ? proseText
-                      ? <Response key={`${message.id}-prose`}>{proseText}</Response>
-                      : null
-                    : hasOpenFence
-                      ? proseText
-                        ? <Response key={`${message.id}-prose`}>{proseText}</Response>
-                        : null
-                      : message.parts.map((part, index) => {
-                          if (part.type === "text") {
-                            const stripped = stripFences((part as { type: "text"; text: string }).text);
-                            if (!stripped) return null;
-                            return (
-                              <Response key={`${message.id}-${index}`}>
-                                {stripped}
-                              </Response>
-                            );
-                          }
-                          if (part.type === "tool-proposeRecipe") {
-                            const toolPart = part as unknown as {
-                              type: "tool-proposeRecipe";
-                              state: string;
-                              input: { recipeId: string; title: string; keyIngredients: string[] };
-                            };
-                            if (toolPart.state === "input-available" || toolPart.state === "output-available") {
-                              return (
-                                <IngredientGate
-                                  key={`${message.id}-${index}`}
-                                  data={toolPart.input}
-                                  onSend={onSend}
-                                  onExpectRecipe={onExpectRecipe}
-                                />
-                              );
-                            }
-                          }
-                          return null;
-                        })}
+                  {hasNewBlocks ? (
+                    proseText ? (
+                      <Response key={`${message.id}-prose`}>
+                        {proseText}
+                      </Response>
+                    ) : null
+                  ) : hasOpenFence ? (
+                    proseText ? (
+                      <Response key={`${message.id}-prose`}>
+                        {proseText}
+                      </Response>
+                    ) : null
+                  ) : (
+                    message.parts.map((part, index) => {
+                      if (part.type === "text") {
+                        const stripped = stripFences(
+                          (part as { type: "text"; text: string }).text,
+                        ).trim();
+                        if (!stripped) return null;
+                        return (
+                          <Response key={`${message.id}-${index}`}>
+                            {stripped}
+                          </Response>
+                        );
+                      }
+                      if (part.type === "tool-proposeRecipe") {
+                        const toolPart = part as unknown as {
+                          type: "tool-proposeRecipe";
+                          state: string;
+                          input: {
+                            recipeId: string;
+                            title: string;
+                            keyIngredients: string[];
+                          };
+                        };
+                        if (
+                          toolPart.state === "input-available" ||
+                          toolPart.state === "output-available"
+                        ) {
+                          return (
+                            <IngredientGate
+                              key={`${message.id}-${index}`}
+                              data={toolPart.input}
+                              onSend={onSend}
+                              onExpectRecipe={onExpectRecipe}
+                            />
+                          );
+                        }
+                      }
+                      return null;
+                    })
+                  )}
 
                   {/* Parsed blocks (prefix text when fence open, full text otherwise) */}
                   {blocks.map((block, bi) => {
@@ -326,12 +362,15 @@ export const MessageList = ({
                     if (block.kind === "recipe") {
                       const recipeKey = `${message.id}-${bi}`;
                       const isSaved =
-                        recipeSaved?.some((r) => r.recipeId === recipeKey) ?? false;
+                        recipeSaved?.some((r) => r.recipeId === recipeKey) ??
+                        false;
                       return (
                         <RecipeLetter
                           key={blockKey}
                           recipe={block.payload}
-                          onSave={() => saveStructuredRecipe(block.payload, recipeKey)}
+                          onSave={() =>
+                            saveStructuredRecipe(block.payload, recipeKey)
+                          }
                           isSaved={isSaved}
                         />
                       );
@@ -352,24 +391,41 @@ export const MessageList = ({
                           .map((block, idx) => {
                             if (block.kind !== "legacy") return null;
                             const recipeKey = `${message.id}-${idx}`;
-                            const recipeName = extractRecipeName(block.recipeStr);
+                            const recipeName = extractRecipeName(
+                              block.recipeStr,
+                            );
                             const saved =
-                              recipeSaved?.some((r) => r.recipeId === recipeKey) ?? false;
+                              recipeSaved?.some(
+                                (r) => r.recipeId === recipeKey,
+                              ) ?? false;
                             return (
                               <Button
                                 key={recipeKey}
                                 className="cursor-pointer my-2"
-                                onClick={() => saved || saveRecipe(block.recipeStr, recipeKey)}
+                                onClick={() =>
+                                  saved ||
+                                  saveRecipe(block.recipeStr, recipeKey)
+                                }
                               >
                                 {saved ? (
-                                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                                  <svg
+                                    width="20"
+                                    height="20"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                  >
                                     <path
                                       d="M5 21V5C5 4.45 5.196 3.97933 5.588 3.588C5.98 3.19667 6.45067 3.00067 7 3H17C17.55 3 18.021 3.196 18.413 3.588C18.805 3.98 19.0007 4.45067 19 5V21L12 18L5 21Z"
                                       fill="currentColor"
                                     />
                                   </svg>
                                 ) : (
-                                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                                  <svg
+                                    width="20"
+                                    height="20"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                  >
                                     <path
                                       d="M17 18L12 15.82L7 18V5H17M17 3H7C6.46957 3 5.96086 3.21071 5.58579 3.58579C5.21071 3.96086 5 4.46957 5 5V21L12 18L19 21V5C19 4.46957 18.7893 3.96086 18.4142 3.58579C18.0391 3.21071 17.5304 3 17 3Z"
                                       fill="currentColor"
@@ -398,7 +454,10 @@ export const MessageList = ({
           {/* Ghost loader bubble — visible only during submitted state */}
           {status === "submitted" && (
             <div className="py-4">
-              <ChatLoader submittedAt={submittedAt} expectingRecipe={expectingRecipe} />
+              <ChatLoader
+                submittedAt={submittedAt}
+                expectingRecipe={expectingRecipe}
+              />
             </div>
           )}
 

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -12,16 +12,14 @@ import {
 import { Response } from "@/components/ai-elements/response";
 import { Button } from "@/components/ui/button";
 import type {
-  GateData,
   RecipeBlock,
   RecipeWithId,
-  SuggestionsBlockData,
 } from "@/lib/recipes/schemas";
 import {
-  GateSchema,
-  RecipeBlockSchema,
-  SuggestionsBlockSchema,
-} from "@/lib/recipes/schemas";
+  extractRecipeBlocks,
+  getOpenRecipeFenceIdx,
+  stripFences,
+} from "@/lib/recipes/parseBlocks";
 import { fetcher } from "@/lib/utils/index";
 import type { UIMessage } from "ai";
 import { useEffect, useRef, useState } from "react";
@@ -46,72 +44,6 @@ interface MessageListProps {
 }
 
 // ── Parsed block types ────────────────────────────────────────────────────────
-
-type ParsedBlock =
-  | { kind: "suggestions"; payload: SuggestionsBlockData; index: number }
-  | { kind: "gate"; payload: GateData; index: number }
-  | { kind: "recipe"; payload: RecipeBlock; index: number }
-  | { kind: "legacy"; recipeStr: string; index: number };
-
-function extractRecipeBlocks(text: string): ParsedBlock[] {
-  const blocks: ParsedBlock[] = [];
-
-  // Match complete fenced JSON blocks: ```suggestions\n{...}\n```
-  const fenceRegex = /^```(suggestions|gate|recipe)\n([\s\S]*?)\n```/gm;
-  let match: RegExpExecArray | null;
-
-  while ((match = fenceRegex.exec(text)) !== null) {
-    const kind = match[1] as "suggestions" | "gate" | "recipe";
-    try {
-      const payload = JSON.parse(match[2]);
-      if (kind === "suggestions") {
-        const result = SuggestionsBlockSchema.safeParse(payload);
-        if (result.success)
-          blocks.push({ kind: "suggestions", payload: result.data, index: match.index });
-      } else if (kind === "gate") {
-        const result = GateSchema.safeParse(payload);
-        if (result.success)
-          blocks.push({ kind: "gate", payload: result.data, index: match.index });
-      } else if (kind === "recipe") {
-        const result = RecipeBlockSchema.safeParse(payload);
-        if (result.success)
-          blocks.push({ kind: "recipe", payload: result.data, index: match.index });
-      }
-    } catch {
-      /* invalid JSON — skip */
-    }
-  }
-
-  // Legacy: -----...------ markdown recipes
-  const legacyParts = text
-    .split(/^-{5,}$/m)
-    .map((p) => p.trim())
-    .filter((p) => /^##\s+/m.test(p));
-
-  // Only add legacy blocks if no new-style blocks were found (avoid double-rendering)
-  if (blocks.length === 0 && legacyParts.length > 0) {
-    legacyParts.forEach((recipeStr, i) => {
-      blocks.push({ kind: "legacy", recipeStr, index: i });
-    });
-  }
-
-  return blocks;
-}
-
-function stripFences(text: string): string {
-  return text
-    .replace(/^```(?:suggestions|gate|recipe)\n[\s\S]*?\n```/gm, "")
-    .trim();
-}
-
-// Returns the index of an unclosed ```recipe\n fence, or -1 if none.
-function getOpenRecipeFenceIdx(text: string): number {
-  const marker = '```recipe\n';
-  const openIdx = text.lastIndexOf(marker);
-  if (openIdx === -1) return -1;
-  const afterOpen = text.slice(openIdx + marker.length);
-  return afterOpen.includes('\n```') ? -1 : openIdx;
-}
 
 // ── SWR fetcher for save ──────────────────────────────────────────────────────
 
@@ -318,7 +250,7 @@ export const MessageList = ({
             const hasOpenFence = openFenceIdx !== -1;
 
             // For the open-fence case, parse the prefix so any completed blocks
-            // (e.g. a closed ```gate```) still render as interactive components.
+            // (e.g. a closed ```suggestions```) still render as interactive components.
             const prefixText = hasOpenFence
               ? textContent.slice(0, openFenceIdx)
               : textContent;
@@ -347,13 +279,35 @@ export const MessageList = ({
                       ? proseText
                         ? <Response key={`${message.id}-prose`}>{proseText}</Response>
                         : null
-                      : message.parts.map((part, index) =>
-                          part.type === "text" ? (
-                            <Response key={`${message.id}-${index}`}>
-                              {(part as { type: "text"; text: string }).text}
-                            </Response>
-                          ) : null,
-                        )}
+                      : message.parts.map((part, index) => {
+                          if (part.type === "text") {
+                            const stripped = stripFences((part as { type: "text"; text: string }).text);
+                            if (!stripped) return null;
+                            return (
+                              <Response key={`${message.id}-${index}`}>
+                                {stripped}
+                              </Response>
+                            );
+                          }
+                          if (part.type === "tool-proposeRecipe") {
+                            const toolPart = part as unknown as {
+                              type: "tool-proposeRecipe";
+                              state: string;
+                              input: { recipeId: string; title: string; keyIngredients: string[] };
+                            };
+                            if (toolPart.state === "input-available" || toolPart.state === "output-available") {
+                              return (
+                                <IngredientGate
+                                  key={`${message.id}-${index}`}
+                                  data={toolPart.input}
+                                  onSend={onSend}
+                                  onExpectRecipe={onExpectRecipe}
+                                />
+                              );
+                            }
+                          }
+                          return null;
+                        })}
 
                   {/* Parsed blocks (prefix text when fence open, full text otherwise) */}
                   {blocks.map((block, bi) => {
@@ -366,16 +320,6 @@ export const MessageList = ({
                           allMessages={messages}
                           messageIndex={messageIndex}
                           onSend={onSend}
-                        />
-                      );
-                    }
-                    if (block.kind === "gate") {
-                      return (
-                        <IngredientGate
-                          key={blockKey}
-                          data={block.payload}
-                          onSend={onSend}
-                          onExpectRecipe={onExpectRecipe}
                         />
                       );
                     }

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -1,13 +1,13 @@
-'use client';
+"use client";
 
-import { useSessionContext } from '@/contexts/SessionContext';
-import { GetInventoryResponse, InventoryItem } from '@/lib/inventory/schemas';
-import { cn } from '@/lib/utils';
-import { fetcher } from '@/lib/utils/index';
-import { useState } from 'react';
-import useSWR from 'swr';
-import { ScaledNum } from './ScaledNum';
-import { scaleAmount } from './scaleAmount';
+import { useSessionContext } from "@/contexts/SessionContext";
+import { GetInventoryResponse, InventoryItem } from "@/lib/inventory/schemas";
+import { cn } from "@/lib/utils";
+import { fetcher } from "@/lib/utils/index";
+import { useState } from "react";
+import useSWR from "swr";
+import { ScaledNum } from "./ScaledNum";
+import { scaleAmount } from "./scaleAmount";
 
 interface Ingredient {
   name: string;
@@ -49,14 +49,17 @@ function ServingsStepper({
   onIncrement: () => void;
 }) {
   const BUTTON_BASE =
-    'w-7 border-none bg-transparent cursor-pointer text-foreground text-[16px] font-semibold disabled:cursor-not-allowed disabled:text-muted-foreground';
+    "w-7 border-none bg-transparent cursor-pointer text-foreground text-[16px] font-semibold disabled:cursor-not-allowed disabled:text-muted-foreground";
 
   return (
     <div className="inline-flex items-stretch border border-border rounded-lg bg-card overflow-hidden shadow-[0_1px_0_var(--border-soft)] h-[30px]">
       <button
         onClick={onDecrement}
         disabled={servings <= 1}
-        className={cn(BUTTON_BASE, 'border-r border-border disabled:opacity-50')}
+        className={cn(
+          BUTTON_BASE,
+          "border-r border-border disabled:opacity-50",
+        )}
         aria-label="Decrease servings"
       >
         −
@@ -69,7 +72,7 @@ function ServingsStepper({
       <button
         onClick={onIncrement}
         disabled={servings >= 12}
-        className={cn(BUTTON_BASE, 'border-l border-border')}
+        className={cn(BUTTON_BASE, "border-l border-border")}
         aria-label="Increase servings"
       >
         +
@@ -80,13 +83,13 @@ function ServingsStepper({
 
 function HaveTag({ have }: { have: boolean }) {
   const BASE =
-    'font-sans text-[9.5px] font-bold px-1.5 py-0.5 rounded-full tracking-wider shrink-0';
+    "font-sans text-[9.5px] font-bold px-1.5 py-0.5 rounded-full tracking-wider shrink-0";
   if (have) {
     return (
       <span
         className={cn(
           BASE,
-          'text-accent bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)]'
+          "text-accent bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)]",
         )}
       >
         HAVE
@@ -94,7 +97,12 @@ function HaveTag({ have }: { have: boolean }) {
     );
   }
   return (
-    <span className={cn(BASE, 'text-muted-foreground bg-transparent border border-border')}>
+    <span
+      className={cn(
+        BASE,
+        "text-muted-foreground bg-transparent border border-border",
+      )}
+    >
       NEED
     </span>
   );
@@ -102,7 +110,7 @@ function HaveTag({ have }: { have: boolean }) {
 
 function ingredientHave(name: string, inventoryNames: string[]): boolean {
   const n = name.trim().toLowerCase();
-  return inventoryNames.some(inv => inv.includes(n) || n.includes(inv));
+  return inventoryNames.some((inv) => inv.includes(n) || n.includes(inv));
 }
 
 export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
@@ -111,24 +119,27 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
   const { userId } = useSessionContext();
   const { data: inventoryData } = useSWR<GetInventoryResponse>(
     userId ? `/api/inventory?userId=${userId}` : null,
-    fetcher
+    fetcher,
   );
 
   const inventoryItems: InventoryItem[] = [
     ...(inventoryData?.ingredientInventory ?? []),
     ...(inventoryData?.kitchenwareInventory ?? []),
   ];
-  const inventoryNames = inventoryItems.map(i => i.name.trim().toLowerCase());
+  const inventoryNames = inventoryItems.map((i) => i.name.trim().toLowerCase());
 
-  const haveCount = recipe.ingredients.filter(ing =>
-    ingredientHave(ing.name, inventoryNames)
+  const haveCount = recipe.ingredients.filter((ing) =>
+    ingredientHave(ing.name, inventoryNames),
   ).length;
 
-  const timeLabel = recipe.totalTimeMinutes ? `${recipe.totalTimeMinutes} min` : null;
-  const EYEBROW_BASE = 'font-sans text-[10px] font-bold tracking-widest uppercase';
+  const timeLabel = recipe.totalTimeMinutes
+    ? `${recipe.totalTimeMinutes} min`
+    : null;
+  const EYEBROW_BASE =
+    "font-sans text-[10px] font-bold tracking-widest uppercase";
 
   return (
-    <div className="bg-chat border-y border-border-soft p-[20px_26px_22px] relative">
+    <div className=" border-y border-border-soft p-[20px_26px_22px] relative">
       {/* Ribbon header */}
       <div className="flex items-center gap-2.5 mb-3.5 pb-2.5 border-b border-dashed border-border">
         <div className="size-5.5 rounded-full bg-primary flex items-center justify-center text-white shrink-0">
@@ -142,17 +153,23 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
           </svg>
         </div>
 
-        <div className={cn(EYEBROW_BASE, 'text-muted-foreground')}>The way I make it</div>
+        <div className={cn(EYEBROW_BASE, "text-muted-foreground")}>
+          The way I make it
+        </div>
 
         <div className="flex-1" />
 
-        {timeLabel && <div className="font-mono text-[10px] text-muted-foreground">{timeLabel}</div>}
+        {timeLabel && (
+          <div className="font-mono text-[10px] text-muted-foreground">
+            {timeLabel}
+          </div>
+        )}
 
         <ServingsStepper
           servings={servings}
           baseServings={recipe.baseServings}
-          onDecrement={() => setServings(s => Math.max(1, s - 1))}
-          onIncrement={() => setServings(s => Math.min(12, s + 1))}
+          onDecrement={() => setServings((s) => Math.max(1, s - 1))}
+          onIncrement={() => setServings((s) => Math.min(12, s + 1))}
         />
       </div>
 
@@ -171,7 +188,12 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
       {/* Ingredients — neat 2-column grid card */}
       {recipe.ingredients.length > 0 && (
         <div className="mb-5.5">
-          <div className={cn(EYEBROW_BASE, 'text-muted-foreground mb-2 flex items-baseline gap-2.5')}>
+          <div
+            className={cn(
+              EYEBROW_BASE,
+              "text-muted-foreground mb-2 flex items-baseline gap-2.5",
+            )}
+          >
             <span>What to gather</span>
             {userId && inventoryItems.length > 0 && (
               <span className="font-sans italic-normal text-[10px] font-semibold text-accent px-1.5 py-0.25 bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)] rounded-full tracking-normal normal-case">
@@ -181,20 +203,24 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
           </div>
           <div className="bg-card border border-border rounded-xl p-3.5 grid grid-cols-1 sm:grid-cols-2 gap-x-4.5 gap-y-1 shadow-[0_1px_0_var(--border-soft)]">
             {recipe.ingredients.map((ing, i) => {
-              const scaledAmt = ing.amount ? scaleAmount(ing.amount, ratio) : '';
-              const amountLabel = scaledAmt ? `${scaledAmt}${ing.unit ? ' ' + ing.unit : ''}` : '';
+              const scaledAmt = ing.amount
+                ? scaleAmount(ing.amount, ratio)
+                : "";
+              const amountLabel = scaledAmt
+                ? `${scaledAmt}${ing.unit ? " " + ing.unit : ""}`
+                : "";
               const have = ingredientHave(ing.name, inventoryNames);
               const isLastTwo = i >= recipe.ingredients.length - 2;
               return (
                 <div
                   key={i}
                   className={cn(
-                    'flex items-baseline gap-2 py-1.5 border-b border-dashed border-border',
-                    isLastTwo && 'border-none'
+                    "flex items-baseline gap-2 py-1.5 border-b border-dashed border-border",
+                    isLastTwo && "border-none",
                   )}
                 >
                   <span className="flex-[0_0_64px] font-mono text-xs font-semibold text-foreground text-right tabular-nums">
-                    {amountLabel ? <ScaledNum>{amountLabel}</ScaledNum> : ''}
+                    {amountLabel ? <ScaledNum>{amountLabel}</ScaledNum> : ""}
                   </span>
                   <span className="flex-1 font-display text-sm text-foreground leading-tight">
                     {ing.name}
@@ -204,7 +230,9 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
                       </span>
                     )}
                   </span>
-                  {userId && inventoryItems.length > 0 && <HaveTag have={have} />}
+                  {userId && inventoryItems.length > 0 && (
+                    <HaveTag have={have} />
+                  )}
                 </div>
               );
             })}

--- a/src/features/Inventory/components/PantryDrawer.tsx
+++ b/src/features/Inventory/components/PantryDrawer.tsx
@@ -22,7 +22,7 @@ export function PantryDrawer() {
 
   const { data } = useSWR<GetInventoryResponse>(
     userId ? `/api/inventory?userId=${userId}` : null,
-    fetcher
+    fetcher,
   );
 
   const count =
@@ -35,7 +35,7 @@ export function PantryDrawer() {
       <div
         className="hidden lg:flex flex-col items-center justify-start pt-3.5 w-9 shrink-0 bg-muted paper border-l border-border relative"
         style={{ cursor: open ? "default" : "pointer" }}
-        onClick={() => !open && setOpen(true)}
+        onClick={() => setOpen(!open)}
       >
         <span
           className="text-[9.5px] font-bold uppercase tracking-[0.18em] text-ink-faint select-none"

--- a/src/features/Inventory/components/PantryDrawer.tsx
+++ b/src/features/Inventory/components/PantryDrawer.tsx
@@ -32,10 +32,13 @@ export function PantryDrawer() {
   return (
     <>
       {/* Collapsed tab — always mounted so right edge doesn't jump */}
-      <div
+      <button
+        type="button"
         className="hidden lg:flex flex-col items-center justify-start pt-3.5 w-9 shrink-0 bg-muted paper border-l border-border relative"
         style={{ cursor: open ? "default" : "pointer" }}
-        onClick={() => setOpen(!open)}
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        aria-label={open ? "Close pantry drawer" : "Open pantry drawer"}
       >
         <span
           className="text-[9.5px] font-bold uppercase tracking-[0.18em] text-ink-faint select-none"
@@ -43,7 +46,7 @@ export function PantryDrawer() {
         >
           Pantry · {count} ›
         </span>
-      </div>
+      </button>
 
       {/* Open overlay — absolute over chat */}
       {open && (

--- a/src/lib/recipes/parseBlocks.test.ts
+++ b/src/lib/recipes/parseBlocks.test.ts
@@ -1,0 +1,192 @@
+import {
+  extractRecipeBlocks,
+  getOpenRecipeFenceIdx,
+  stripFences,
+} from "./parseBlocks";
+
+describe("extractRecipeBlocks", () => {
+  it("parses a valid suggestions block", () => {
+    const text = `Here are some ideas:
+\`\`\`suggestions
+{
+  "intro": "A few things you can make:",
+  "options": [
+    {
+      "id": "fried-rice",
+      "title": "Fried Rice",
+      "blurb": "Quick one-pan comfort.",
+      "time": "15 min",
+      "tags": ["stir-fry"],
+      "keyIngredients": ["rice", "egg", "soy sauce"]
+    }
+  ]
+}
+\`\`\``;
+
+    const blocks = extractRecipeBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].kind).toBe("suggestions");
+    if (blocks[0].kind === "suggestions") {
+      expect(blocks[0].payload.intro).toBe("A few things you can make:");
+      expect(blocks[0].payload.options[0].id).toBe("fried-rice");
+    }
+  });
+
+  it("parses a valid recipe block", () => {
+    const text = `Here it is:
+\`\`\`recipe
+{
+  "title": "Scrambled Eggs",
+  "description": "Simple, buttery, perfect.",
+  "totalTimeMinutes": 5,
+  "baseServings": 1,
+  "ingredients": [
+    { "name": "egg", "amount": "2", "unit": "pcs" }
+  ],
+  "steps": [
+    { "title": "Beat eggs", "body": "Whisk with a pinch of salt." }
+  ],
+  "tags": ["quick"]
+}
+\`\`\``;
+
+    const blocks = extractRecipeBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].kind).toBe("recipe");
+    if (blocks[0].kind === "recipe") {
+      expect(blocks[0].payload.title).toBe("Scrambled Eggs");
+      expect(blocks[0].payload.baseServings).toBe(1);
+    }
+  });
+
+  it("does NOT parse a gate fenced block (gate path removed)", () => {
+    const text = `Quick check:
+\`\`\`gate
+{
+  "recipeId": "guacamole",
+  "title": "Guacamole",
+  "keyIngredients": ["avocado", "lime", "onion"]
+}
+\`\`\``;
+
+    const blocks = extractRecipeBlocks(text);
+    expect(blocks).toHaveLength(0);
+  });
+
+  it("parses legacy dashed-separator recipes when no new-style blocks present", () => {
+    const text = `Here you go:\n-----\n## Sambal Belacan\nSpicy paste.\n-----\nEnjoy!`;
+
+    const blocks = extractRecipeBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].kind).toBe("legacy");
+  });
+
+  it("does not parse legacy blocks when a new-style block is present", () => {
+    const text = `-----\n## Old Recipe\n-----\n\`\`\`recipe
+{
+  "title": "New Recipe",
+  "baseServings": 2,
+  "ingredients": [],
+  "steps": [],
+  "tags": []
+}
+\`\`\``;
+
+    const blocks = extractRecipeBlocks(text);
+    expect(blocks.every((b) => b.kind !== "legacy")).toBe(true);
+    expect(blocks.some((b) => b.kind === "recipe")).toBe(true);
+  });
+
+  it("silently skips a fenced block with invalid JSON", () => {
+    const text = `\`\`\`recipe
+not valid json at all
+\`\`\``;
+
+    const blocks = extractRecipeBlocks(text);
+    expect(blocks).toHaveLength(0);
+  });
+
+  it("silently skips a block that fails schema validation", () => {
+    // Missing required 'baseServings' field
+    const text = `\`\`\`recipe
+{ "title": "Oops", "ingredients": [], "steps": [], "tags": [] }
+\`\`\``;
+
+    const blocks = extractRecipeBlocks(text);
+    expect(blocks).toHaveLength(0);
+  });
+
+  it("returns multiple blocks from a single string", () => {
+    const text = `\`\`\`recipe
+{
+  "title": "Recipe A",
+  "baseServings": 2,
+  "ingredients": [],
+  "steps": [],
+  "tags": []
+}
+\`\`\`
+Some prose.
+\`\`\`recipe
+{
+  "title": "Recipe B",
+  "baseServings": 4,
+  "ingredients": [],
+  "steps": [],
+  "tags": []
+}
+\`\`\``;
+
+    const blocks = extractRecipeBlocks(text);
+    expect(blocks.filter((b) => b.kind === "recipe")).toHaveLength(2);
+  });
+});
+
+describe("getOpenRecipeFenceIdx", () => {
+  it("returns -1 when no recipe fence is present", () => {
+    expect(getOpenRecipeFenceIdx("just some text")).toBe(-1);
+  });
+
+  it("returns -1 when recipe fence is closed", () => {
+    const text = "```recipe\n{}\n```";
+    expect(getOpenRecipeFenceIdx(text)).toBe(-1);
+  });
+
+  it("returns the index of an unclosed recipe fence", () => {
+    const text = "Some prose\n```recipe\n{ partial json";
+    const idx = getOpenRecipeFenceIdx(text);
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(text.slice(idx)).toContain("```recipe");
+  });
+});
+
+describe("stripFences", () => {
+  it("strips suggestions and recipe fences, leaving prose", () => {
+    const text = `Here are ideas:\n\`\`\`suggestions\n{"intro":"hi","options":[]}\n\`\`\`\nMore prose.`;
+    const result = stripFences(text);
+    expect(result).toContain("Here are ideas:");
+    expect(result).toContain("More prose.");
+    expect(result).not.toContain("```suggestions");
+  });
+
+  it("strips recipe fences", () => {
+    const text = `Cook time:\n\`\`\`recipe\n{"title":"X","baseServings":2,"ingredients":[],"steps":[],"tags":[]}\n\`\`\``;
+    const result = stripFences(text);
+    expect(result).not.toContain("```recipe");
+    expect(result).toContain("Cook time:");
+  });
+
+  it("strips legacy gate fenced blocks (prevents Shiki crash on unknown language)", () => {
+    const text = `Quick check:\n\`\`\`gate\n{"recipeId":"guac","title":"Guacamole","keyIngredients":["avocado"]}\n\`\`\`\nMore text.`;
+    const result = stripFences(text);
+    expect(result).not.toContain("```gate");
+    expect(result).not.toContain("recipeId");
+    expect(result).toContain("Quick check:");
+    expect(result).toContain("More text.");
+  });
+
+  it("leaves plain prose untouched", () => {
+    const text = "Just a normal message with no fences.";
+    expect(stripFences(text)).toBe(text);
+  });
+});

--- a/src/lib/recipes/parseBlocks.ts
+++ b/src/lib/recipes/parseBlocks.ts
@@ -1,17 +1,14 @@
 import {
-  GateSchema,
   RecipeBlockSchema,
   SuggestionsBlockSchema,
 } from "@/lib/recipes/schemas";
 import type {
-  GateData,
   RecipeBlock,
   SuggestionsBlockData,
 } from "@/lib/recipes/schemas";
 
 export type ParsedBlock =
   | { kind: "suggestions"; payload: SuggestionsBlockData; index: number }
-  | { kind: "gate"; payload: GateData; index: number }
   | { kind: "recipe"; payload: RecipeBlock; index: number }
   | { kind: "legacy"; recipeStr: string; index: number };
 
@@ -55,6 +52,8 @@ export function extractRecipeBlocks(text: string): ParsedBlock[] {
 
 export function stripFences(text: string): string {
   return text
+    // Keep stripping legacy `gate` fences for backward-compat and to avoid
+    // rendering unsupported fenced-language blocks from older messages.
     .replace(/^```(?:suggestions|gate|recipe)\n[\s\S]*?\n```/gm, "")
     .trim();
 }
@@ -66,6 +65,3 @@ export function getOpenRecipeFenceIdx(text: string): number {
   const afterOpen = text.slice(openIdx + marker.length);
   return afterOpen.includes("\n```") ? -1 : openIdx;
 }
-
-// GateSchema re-exported so callers of old extractRecipeBlocks can use the gate schema for the proposeRecipe tool
-export { GateSchema };

--- a/src/lib/recipes/parseBlocks.ts
+++ b/src/lib/recipes/parseBlocks.ts
@@ -1,0 +1,71 @@
+import {
+  GateSchema,
+  RecipeBlockSchema,
+  SuggestionsBlockSchema,
+} from "@/lib/recipes/schemas";
+import type {
+  GateData,
+  RecipeBlock,
+  SuggestionsBlockData,
+} from "@/lib/recipes/schemas";
+
+export type ParsedBlock =
+  | { kind: "suggestions"; payload: SuggestionsBlockData; index: number }
+  | { kind: "gate"; payload: GateData; index: number }
+  | { kind: "recipe"; payload: RecipeBlock; index: number }
+  | { kind: "legacy"; recipeStr: string; index: number };
+
+export function extractRecipeBlocks(text: string): ParsedBlock[] {
+  const blocks: ParsedBlock[] = [];
+
+  const fenceRegex = /^```(suggestions|recipe)\n([\s\S]*?)\n```/gm;
+  let match: RegExpExecArray | null;
+
+  while ((match = fenceRegex.exec(text)) !== null) {
+    const kind = match[1] as "suggestions" | "recipe";
+    try {
+      const payload = JSON.parse(match[2]);
+      if (kind === "suggestions") {
+        const result = SuggestionsBlockSchema.safeParse(payload);
+        if (result.success)
+          blocks.push({ kind: "suggestions", payload: result.data, index: match.index });
+      } else if (kind === "recipe") {
+        const result = RecipeBlockSchema.safeParse(payload);
+        if (result.success)
+          blocks.push({ kind: "recipe", payload: result.data, index: match.index });
+      }
+    } catch {
+      /* invalid JSON — skip */
+    }
+  }
+
+  const legacyParts = text
+    .split(/^-{5,}$/m)
+    .map((p) => p.trim())
+    .filter((p) => /^##\s+/m.test(p));
+
+  if (blocks.length === 0 && legacyParts.length > 0) {
+    legacyParts.forEach((recipeStr, i) => {
+      blocks.push({ kind: "legacy", recipeStr, index: i });
+    });
+  }
+
+  return blocks;
+}
+
+export function stripFences(text: string): string {
+  return text
+    .replace(/^```(?:suggestions|gate|recipe)\n[\s\S]*?\n```/gm, "")
+    .trim();
+}
+
+export function getOpenRecipeFenceIdx(text: string): number {
+  const marker = "```recipe\n";
+  const openIdx = text.lastIndexOf(marker);
+  if (openIdx === -1) return -1;
+  const afterOpen = text.slice(openIdx + marker.length);
+  return afterOpen.includes("\n```") ? -1 : openIdx;
+}
+
+// GateSchema re-exported so callers of old extractRecipeBlocks can use the gate schema for the proposeRecipe tool
+export { GateSchema };


### PR DESCRIPTION
## Summary

Implements issue #73: replaces the gate fenced-block convention with a real `proposeRecipe` model tool and adds a coverage shortcut to skip the gate when ≥80% of key ingredients are in inventory.

**Key changes:**
- New `proposeRecipe` tool in chat API (halts model loop on call)
- Block parser extracted to `src/lib/recipes/parseBlocks.ts` with unit tests
- MessageList renders tool calls as `IngredientGate` components
- Removed all gate fenced-block parsing and rendering
- System prompt routes named dishes to either tool call or direct recipe
- Progress.md updated

**User flows preserved:**
- Empty/sparse pantry → gate card via tool call (no prose questions)
- ≥80% coverage → recipe streams directly with missing items flagged
- Gate interactions (I have everything, I'm missing some, Show other recipes) unchanged

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated progress docs to reflect the new pantry/workflow and routing guidance.

* **New Features**
  * Replaced legacy prose “gate” with a dedicated tool-driven pantry-check flow for recipe suggestions and routing.

* **Bug Fixes**
  * Fixed pantry drawer toggle behavior and eliminated duplicate saved/live messages in chat.

* **Refactor**
  * Centralized recipe/block parsing into a shared parser used by message rendering.

* **Tests**
  * Added/expanded tests for recipe parsing, open-fence handling, and message rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->