### PR TITLE
feat(conversations): replace archive with hard delete + confirmation …

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -15,18 +15,18 @@ The persistent-kitchen MVP. Highlights:
 ## V2 — In Progress
 
 ### Multi-conversation backend (Slice 1) (May 2026)
-- [x] `Conversation` Prisma model added (`id`, `userId`, `title?`, `archived`, `createdAt`, `updatedAt`).
+- [x] `Conversation` Prisma model added (`id`, `userId`, `title?`, `createdAt`, `updatedAt`).
 - [x] `Message` model updated: `conversationId` FK added (cascades on delete); old `userId`-only scoping replaced.
 - [x] Migration `20260504000000_add_conversations` includes backfill for existing messages.
-- [x] `src/lib/conversations/conversations.ts`: `listConversations`, `getOrCreateActiveConversation`, `createConversation`, `renameConversation`, `archiveConversation`, `autoTitleConversation`.
+- [x] `src/lib/conversations/conversations.ts`: `listConversations`, `getOrCreateActiveConversation`, `getOrCreateEmptyConversation`, `createConversation`, `renameConversation`, `deleteConversation`, `autoTitleConversation`.
 - [x] `getMessages` / `createMessage` now scoped to `conversationId` (userId still stored for convenience).
 - [x] `POST /api/chat` accepts `conversationId`; fires `autoTitleConversation` non-blocking after first exchange.
-- [x] `GET|POST /api/conversation` for listing/creating conversations.
-- [x] `PATCH /api/conversation/[id]` for rename/archive.
+- [x] `GET|POST /api/conversation` for listing/creating conversations, with POST reusing the canonical empty thread instead of creating duplicate empty rows.
+- [x] `PATCH|DELETE /api/conversation/[id]` for rename/hard-delete; archived rows are purged and the archive column/index are removed in migration `20260507000000_replace_archive_with_delete`.
 - [x] `GET|POST /api/message` updated to `conversationId`-scoped params.
 
 ### Three-rail layout / Conversations UI (Slice 2 + 3) (May 2026)
-- [x] `ConversationContext` provides `activeConversationId`, `setActiveConversation`, `startNewConversation`, `renameActiveConversation`, `archiveActiveConversation`.
+- [x] `ConversationContext` provides `activeConversationId`, `setActiveConversation`, `startNewConversation`, `renameActiveConversation`, `deleteActiveConversation`.
 - [x] `ConversationTitle.tsx` — inline-editable title in chat header; `getTitleFallback` exported.
 - [x] `src/features/Conversations/` — new feature folder: `ConversationItem`, `Conversations`, `ConversationsRail`, `ConversationsMobileSheet`, `constants`, `utils` (formatTime/formatWhen).
 - [x] `ConversationsRail` — 260px left sidebar, `hidden lg:flex`, shows grouped (today/yesterday/earlier) list with search.
@@ -34,6 +34,7 @@ The persistent-kitchen MVP. Highlights:
 - [x] `PantryDrawer` — 36px collapsed tab on right edge; clicks open 320px absolute overlay (no chat reflow); state persisted in `localStorage`.
 - [x] `page.tsx` — three-rail composition: ConversationsRail | ChatWrapper | PantryDrawer; old inventory aside removed.
 - [x] Migration `20260504000000_add_conversations` — must be applied via `npx prisma migrate deploy` (not `db push`) due to backfill step.
+- [x] Chat header archive button replaced with a calm trash affordance; clicking the trash icon opens a shadcn AlertDialog confirmation, confirming fires the DELETE immediately, and saved recipes remain untouched. The earlier deferred-undo toast pattern was dropped because it blocked back-to-back deletes during the undo window.
 - [x] Bug fixed (May 2026): `Conversations.tsx` was reading `data?.grouped` but API returns `{ conversations: GroupedConversations }` — fixed to `data?.conversations`.
 - [x] Bug fixed (May 2026): `src/app/api/message/route.ts` used default import for prisma — fixed to named `{ prisma }`.
 

--- a/prisma/migrations/20260507000000_replace_archive_with_delete/migration.sql
+++ b/prisma/migrations/20260507000000_replace_archive_with_delete/migration.sql
@@ -1,0 +1,10 @@
+DELETE FROM "public"."conversations"
+WHERE "archived" = true;
+
+DROP INDEX IF EXISTS "public"."conversations_userId_archived_updatedAt_idx";
+
+ALTER TABLE "public"."conversations"
+DROP COLUMN "archived";
+
+CREATE INDEX "conversations_userId_updatedAt_idx"
+ON "public"."conversations"("userId", "updatedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,12 +27,11 @@ model Conversation {
   id        String    @id @default(cuid())
   userId    String
   title     String?
-  archived  Boolean   @default(false)
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   messages  Message[]
 
-  @@index([userId, archived, updatedAt])
+  @@index([userId, updatedAt])
   @@map("conversations")
 }
 

--- a/src/app/api/conversation/[id]/route.test.ts
+++ b/src/app/api/conversation/[id]/route.test.ts
@@ -1,0 +1,138 @@
+import { DELETE, PATCH } from "./route";
+import {
+  autoTitleIfNull,
+  deleteConversation,
+  renameConversation,
+} from "@/lib/conversations";
+import { NextRequest } from "next/server";
+
+jest.mock("next/server", () => ({
+  NextRequest: jest.fn(),
+  NextResponse: {
+    json: jest.fn((data, init) => ({
+      json: async () => data,
+      status: init?.status || 200,
+      headers: new Map(Object.entries(init?.headers || {})),
+    })),
+  },
+}));
+
+jest.mock("@/lib/conversations", () => ({
+  renameConversation: jest.fn(),
+  autoTitleIfNull: jest.fn(),
+  deleteConversation: jest.fn(),
+}));
+
+const mockedRenameConversation = jest.mocked(renameConversation);
+const mockedAutoTitleIfNull = jest.mocked(autoTitleIfNull);
+const mockedDeleteConversation = jest.mocked(deleteConversation);
+
+global.Response = class {
+  status: number;
+
+  constructor(_body?: BodyInit | null, init?: ResponseInit) {
+    this.status = init?.status ?? 200;
+  }
+} as typeof Response;
+
+const createMockRequest = (url: string, options: RequestInit = {}) =>
+  ({
+    nextUrl: new URL(url),
+    json: async () => {
+      if (options.body) {
+        return JSON.parse(options.body as string);
+      }
+      return {};
+    },
+  }) as NextRequest;
+
+const params = Promise.resolve({ id: "conv-1" });
+
+describe("Conversation by-id API routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("PATCH /api/conversation/[id]", () => {
+    it("renames a conversation", async () => {
+      const conversation = { id: "conv-1", title: "Weeknight noodles" };
+      mockedRenameConversation.mockResolvedValue(conversation as never);
+
+      const request = createMockRequest("http://localhost:3000/api/conversation/conv-1", {
+        method: "PATCH",
+        body: JSON.stringify({ title: "Weeknight noodles" }),
+      });
+
+      const response = await PATCH(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ conversation });
+      expect(mockedRenameConversation).toHaveBeenCalledWith(
+        "conv-1",
+        "Weeknight noodles"
+      );
+    });
+
+    it("keeps auto-title rename behaviour", async () => {
+      const conversation = { id: "conv-1", title: "Egg ideas" };
+      mockedAutoTitleIfNull.mockResolvedValue(conversation as never);
+
+      const request = createMockRequest("http://localhost:3000/api/conversation/conv-1", {
+        method: "PATCH",
+        body: JSON.stringify({ title: "Egg ideas", autoTitle: true }),
+      });
+
+      const response = await PATCH(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ conversation });
+      expect(mockedAutoTitleIfNull).toHaveBeenCalledWith("conv-1", "Egg ideas");
+    });
+
+    it("returns 400 when title is missing", async () => {
+      const request = createMockRequest("http://localhost:3000/api/conversation/conv-1", {
+        method: "PATCH",
+        body: JSON.stringify({}),
+      });
+
+      const response = await PATCH(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data).toEqual({ error: "title is required" });
+    });
+  });
+
+  describe("DELETE /api/conversation/[id]", () => {
+    it("returns 204 on success", async () => {
+      mockedDeleteConversation.mockResolvedValue(undefined);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/conversation/conv-1?userId=user-1",
+        { method: "DELETE" }
+      );
+
+      const response = await DELETE(request, { params });
+
+      expect(response.status).toBe(204);
+      expect(mockedDeleteConversation).toHaveBeenCalledWith("conv-1", "user-1");
+    });
+
+    it("returns 404 when the conversation does not belong to the user", async () => {
+      mockedDeleteConversation.mockRejectedValue(new Error("Conversation not found"));
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/conversation/conv-1?userId=user-1",
+        { method: "DELETE" }
+      );
+
+      const response = await DELETE(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data).toEqual({ error: "Conversation not found" });
+    });
+  });
+});

--- a/src/app/api/conversation/[id]/route.ts
+++ b/src/app/api/conversation/[id]/route.ts
@@ -1,6 +1,6 @@
 import {
-  archiveConversation,
   autoTitleIfNull,
+  deleteConversation,
   renameConversation,
 } from "@/lib/conversations";
 import { NextRequest, NextResponse } from "next/server";
@@ -10,7 +10,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
-  const { title, archived, autoTitle } = await req.json();
+  const { title, autoTitle } = await req.json();
 
   if (typeof title === "string") {
     if (autoTitle) {
@@ -24,13 +24,34 @@ export async function PATCH(
     return NextResponse.json({ conversation });
   }
 
-  if (archived === true) {
-    const conversation = await archiveConversation(id);
-    return NextResponse.json({ conversation });
-  }
-
   return NextResponse.json(
-    { error: "title or archived is required" },
+    { error: "title is required" },
     { status: 400 }
   );
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const userId = req.nextUrl.searchParams.get("userId");
+
+  if (!userId) {
+    return NextResponse.json({ error: "userId is required" }, { status: 400 });
+  }
+
+  try {
+    await deleteConversation(id, userId);
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Conversation not found") {
+      return NextResponse.json(
+        { error: "Conversation not found" },
+        { status: 404 }
+      );
+    }
+
+    throw error;
+  }
 }

--- a/src/app/api/conversation/route.test.ts
+++ b/src/app/api/conversation/route.test.ts
@@ -1,7 +1,7 @@
 import { GET, POST } from "./route";
 import {
-  createConversation,
   getOrCreateActiveConversation,
+  getOrCreateEmptyConversation,
   listConversations,
 } from "@/lib/conversations";
 import { NextRequest } from "next/server";
@@ -20,13 +20,13 @@ jest.mock("next/server", () => ({
 
 jest.mock("@/lib/conversations", () => ({
   listConversations: jest.fn(),
-  createConversation: jest.fn(),
   getOrCreateActiveConversation: jest.fn(),
+  getOrCreateEmptyConversation: jest.fn(),
 }));
 
 const mockedListConversations = jest.mocked(listConversations);
-const mockedCreateConversation = jest.mocked(createConversation);
 const mockedGetOrCreateActiveConversation = jest.mocked(getOrCreateActiveConversation);
+const mockedGetOrCreateEmptyConversation = jest.mocked(getOrCreateEmptyConversation);
 
 const createMockRequest = (url: string, options: RequestInit = {}) => {
   const parsedUrl = new URL(url);
@@ -49,7 +49,6 @@ function makeConversation(overrides: Partial<{
   id: string;
   userId: string;
   title: string | null;
-  archived: boolean;
   createdAt: Date;
   updatedAt: Date;
   _count: { messages: number };
@@ -58,7 +57,6 @@ function makeConversation(overrides: Partial<{
     id: "conv-1",
     userId: "user-1",
     title: null,
-    archived: false,
     createdAt: new Date("2024-01-01T10:00:00.000Z"),
     updatedAt: new Date("2024-01-01T10:00:00.000Z"),
     _count: { messages: 0 },
@@ -132,9 +130,9 @@ describe("Conversation API Routes", () => {
   });
 
   describe("POST /api/conversation", () => {
-    it("should create a new conversation for valid userId", async () => {
+    it("should return the reusable empty conversation for valid userId", async () => {
       const newConv = makeConversation({ id: "conv-new", userId: "user-1" });
-      mockedCreateConversation.mockResolvedValue(newConv);
+      mockedGetOrCreateEmptyConversation.mockResolvedValue(newConv);
 
       const request = createMockRequest(
         "http://localhost:3000/api/conversation",
@@ -150,7 +148,7 @@ describe("Conversation API Routes", () => {
 
       expect(response.status).toBe(200);
       expect(data).toEqual({ conversation: newConv });
-      expect(mockedCreateConversation).toHaveBeenCalledWith("user-1");
+      expect(mockedGetOrCreateEmptyConversation).toHaveBeenCalledWith("user-1");
     });
 
     it("should return 400 when userId is missing", async () => {
@@ -168,11 +166,11 @@ describe("Conversation API Routes", () => {
 
       expect(response.status).toBe(400);
       expect(data).toEqual({ error: "userId is required" });
-      expect(mockedCreateConversation).not.toHaveBeenCalled();
+      expect(mockedGetOrCreateEmptyConversation).not.toHaveBeenCalled();
     });
 
     it("should handle database errors gracefully", async () => {
-      mockedCreateConversation.mockRejectedValue(new Error("DB error"));
+      mockedGetOrCreateEmptyConversation.mockRejectedValue(new Error("DB error"));
 
       const request = createMockRequest(
         "http://localhost:3000/api/conversation",

--- a/src/app/api/conversation/route.ts
+++ b/src/app/api/conversation/route.ts
@@ -1,6 +1,6 @@
 import {
-  createConversation,
   getOrCreateActiveConversation,
+  getOrCreateEmptyConversation,
   listConversations,
 } from "@/lib/conversations";
 import { NextRequest, NextResponse } from "next/server";
@@ -26,6 +26,6 @@ export async function POST(req: NextRequest) {
   if (!userId) {
     return NextResponse.json({ error: "userId is required" }, { status: 400 });
   }
-  const conversation = await createConversation(userId);
+  const conversation = await getOrCreateEmptyConversation(userId);
   return NextResponse.json({ conversation });
 }

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/src/contexts/ConversationContext.test.tsx
+++ b/src/contexts/ConversationContext.test.tsx
@@ -1,36 +1,35 @@
-/**
- * Tests for ConversationContext
- *
- * Strategy:
- * - Mock SWR so we control what the hook returns without real network calls
- * - Mock fetch for POST/PATCH mutations
- * - Mock SessionContext so we can supply a userId
- * - Use React Testing Library renderHook / render to exercise the context
- */
-
 import React from "react";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import {
   ConversationProvider,
   useConversationContext,
 } from "./ConversationContext";
 
-// ── Mock SWR ──────────────────────────────────────────────────────────────────
-
-type SwrMockReturn = {
-  data: { conversation: { id: string; title: null; createdAt: Date; updatedAt: Date; userId: string; archived: boolean } } | undefined;
-  isLoading: boolean;
+type Conversation = {
+  id: string;
+  userId: string;
+  title: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  _count?: { messages: number };
 };
 
-let swrMockReturn: SwrMockReturn = { data: undefined, isLoading: false };
+type SwrPayload =
+  | { conversation: Conversation }
+  | { conversations: Conversation[] }
+  | undefined;
+
+const swrData = new Map<string, SwrPayload>();
+const mockMutate = jest.fn();
 
 jest.mock("swr", () => ({
   __esModule: true,
-  default: jest.fn(() => swrMockReturn),
-  mutate: jest.fn(),
+  default: jest.fn((key: string | null) => ({
+    data: key ? swrData.get(key) : undefined,
+    isLoading: false,
+  })),
+  mutate: (...args: unknown[]) => mockMutate(...args),
 }));
-
-// ── Mock SessionContext ───────────────────────────────────────────────────────
 
 const mockUserId = "user-test-123";
 
@@ -38,35 +37,45 @@ jest.mock("@/contexts/SessionContext", () => ({
   useSessionContext: jest.fn(() => ({ userId: mockUserId, isLoading: false })),
 }));
 
-// ── Mock localStorage ─────────────────────────────────────────────────────────
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
   return {
     getItem: jest.fn((key: string) => store[key] ?? null),
-    setItem: jest.fn((key: string, value: string) => { store[key] = value; }),
-    removeItem: jest.fn((key: string) => { delete store[key]; }),
-    clear: jest.fn(() => { store = {}; }),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
   };
 })();
 
 Object.defineProperty(window, "localStorage", { value: localStorageMock });
 
-// ── Mock fetch ────────────────────────────────────────────────────────────────
-
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function makeConversation(id = "conv-1") {
+function makeConversation(
+  id = "conv-1",
+  overrides: Partial<Conversation> = {}
+): Conversation {
   return {
     id,
     userId: mockUserId,
     title: null,
-    archived: false,
     createdAt: new Date("2024-01-02T10:00:00.000Z"),
     updatedAt: new Date("2024-01-02T10:00:00.000Z"),
+    _count: { messages: 0 },
+    ...overrides,
   };
 }
 
@@ -74,168 +83,158 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
   <ConversationProvider>{children}</ConversationProvider>
 );
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
 describe("ConversationContext", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    swrData.clear();
     localStorageMock.clear();
-    swrMockReturn = { data: undefined, isLoading: false };
+    mockMutate.mockResolvedValue(undefined);
   });
 
-  describe("useConversationContext outside provider", () => {
-    it("throws when used outside ConversationProvider", () => {
-      // Suppress React error boundary noise in test output
-      const consoleSpy = jest
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
+  it("throws when used outside ConversationProvider", () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-      expect(() => {
-        renderHook(() => useConversationContext());
-      }).toThrow("useConversationContext must be used within a ConversationProvider");
+    expect(() => {
+      renderHook(() => useConversationContext());
+    }).toThrow("useConversationContext must be used within a ConversationProvider");
 
-      consoleSpy.mockRestore();
-    });
+    consoleSpy.mockRestore();
   });
 
-  describe("ConversationProvider mounting", () => {
-    it("sets activeConversationId from the active-conversation endpoint when localStorage is empty", async () => {
-      const conv = makeConversation("conv-from-api");
-      swrMockReturn = {
-        data: { conversation: conv },
-        isLoading: false,
-      };
-
-      const { result } = renderHook(() => useConversationContext(), { wrapper });
-
-      await waitFor(() => {
-        expect(result.current.activeConversationId).toBe("conv-from-api");
-      });
+  it("sets activeConversationId from the active-conversation endpoint when localStorage is empty", async () => {
+    const conversation = makeConversation("conv-from-api");
+    swrData.set(
+      `/api/conversation?active=true&userId=${mockUserId}`,
+      { conversation }
+    );
+    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+      conversations: [conversation],
     });
 
-    it("uses the localStorage value instead of calling API when present", () => {
-      localStorageMock.getItem.mockReturnValueOnce("conv-from-storage");
+    const { result } = renderHook(() => useConversationContext(), { wrapper });
 
-      // SWR should NOT be called with a key when localStorage has a value
-      swrMockReturn = { data: undefined, isLoading: false };
-
-      const { result } = renderHook(() => useConversationContext(), { wrapper });
-
-      expect(result.current.activeConversationId).toBe("conv-from-storage");
-    });
-
-    it("exposes isLoading=true while SWR is loading and no localStorage value", () => {
-      swrMockReturn = { data: undefined, isLoading: true };
-
-      const { result } = renderHook(() => useConversationContext(), { wrapper });
-
-      expect(result.current.isLoading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.activeConversationId).toBe("conv-from-api");
     });
   });
 
-  describe("startNewConversation", () => {
-    it("POSTs to /api/conversation and updates activeConversationId", async () => {
-      const newConv = makeConversation("conv-new");
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ conversation: newConv }),
-      });
+  it("uses the localStorage value instead of fetching an active conversation", () => {
+    localStorageMock.getItem.mockReturnValueOnce("conv-from-storage");
+    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+      conversations: [makeConversation("conv-from-storage")],
+    });
 
-      // Start with a stored conversation so context is not in loading state
-      localStorageMock.getItem.mockReturnValueOnce("conv-old");
+    const { result } = renderHook(() => useConversationContext(), { wrapper });
 
-      const { result } = renderHook(() => useConversationContext(), { wrapper });
+    expect(result.current.activeConversationId).toBe("conv-from-storage");
+  });
 
-      await act(async () => {
-        await result.current.startNewConversation();
-      });
+  it("startNewConversation reuses the server-returned empty conversation", async () => {
+    const current = makeConversation("conv-current", {
+      title: "Dinner",
+      _count: { messages: 2 },
+    });
+    const empty = makeConversation("conv-empty");
+    localStorageMock.getItem.mockReturnValueOnce("conv-current");
+    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+      conversations: [current, empty],
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ conversation: empty }),
+    });
 
-      expect(mockFetch).toHaveBeenCalledWith("/api/conversation", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: mockUserId }),
-      });
+    const { result } = renderHook(() => useConversationContext(), { wrapper });
 
-      expect(result.current.activeConversationId).toBe("conv-new");
-      expect(localStorageMock.setItem).toHaveBeenCalledWith(
-        "ask-ah-mah-active-conversation",
-        "conv-new"
-      );
+    await act(async () => {
+      await result.current.startNewConversation();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/conversation", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId: mockUserId }),
+    });
+    expect(result.current.activeConversationId).toBe("conv-empty");
+  });
+
+  it("renameActiveConversation PATCHes the active id", async () => {
+    const conversation = makeConversation("conv-abc");
+    localStorageMock.getItem.mockReturnValueOnce("conv-abc");
+    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+      conversations: [conversation],
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ conversation: { ...conversation, title: "My Kitchen" } }),
+    });
+
+    const { result } = renderHook(() => useConversationContext(), { wrapper });
+
+    await act(async () => {
+      await result.current.renameActiveConversation("My Kitchen");
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/conversation/conv-abc", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "My Kitchen" }),
     });
   });
 
-  describe("renameActiveConversation", () => {
-    it("PATCHes /api/conversation/:id with the new title", async () => {
-      localStorageMock.getItem.mockReturnValueOnce("conv-abc");
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ conversation: { ...makeConversation("conv-abc"), title: "My Kitchen" } }),
-      });
+  it("deleteActiveConversation fires DELETE immediately and switches active conversation", async () => {
+    const active = makeConversation("conv-delete", {
+      title: "Laksa",
+      _count: { messages: 3 },
+    });
+    const fallback = makeConversation("conv-fallback", {
+      title: "Egg ideas",
+      _count: { messages: 1 },
+    });
+    localStorageMock.getItem.mockReturnValueOnce("conv-delete");
+    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+      conversations: [active, fallback],
+    });
+    mockFetch.mockResolvedValueOnce({ ok: true });
 
-      const { result } = renderHook(() => useConversationContext(), { wrapper });
+    const { result } = renderHook(() => useConversationContext(), { wrapper });
 
-      await act(async () => {
-        await result.current.renameActiveConversation("My Kitchen");
-      });
-
-      expect(mockFetch).toHaveBeenCalledWith("/api/conversation/conv-abc", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: "My Kitchen" }),
-      });
+    await act(async () => {
+      await result.current.deleteActiveConversation();
     });
 
-    it("does nothing when activeConversationId is null", async () => {
-      swrMockReturn = { data: undefined, isLoading: false };
-
-      const { result } = renderHook(() => useConversationContext(), { wrapper });
-
-      await act(async () => {
-        await result.current.renameActiveConversation("Ignored");
-      });
-
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
+    expect(result.current.activeConversationId).toBe("conv-fallback");
+    expect(mockFetch).toHaveBeenCalledWith(
+      `/api/conversation/conv-delete?userId=${encodeURIComponent(mockUserId)}`,
+      { method: "DELETE" }
+    );
   });
 
-  describe("archiveActiveConversation", () => {
-    it("PATCHes with { archived: true } then POSTs to create a new conversation", async () => {
-      localStorageMock.getItem.mockReturnValueOnce("conv-to-archive");
-
-      const newConv = makeConversation("conv-fresh");
-
-      // First call: PATCH archive
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({}),
-      });
-      // Second call: POST startNewConversation
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ conversation: newConv }),
-      });
-
-      const { result } = renderHook(() => useConversationContext(), { wrapper });
-
-      await act(async () => {
-        await result.current.archiveActiveConversation();
-      });
-
-      // First fetch: PATCH with archived: true
-      expect(mockFetch).toHaveBeenNthCalledWith(1, "/api/conversation/conv-to-archive", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ archived: true }),
-      });
-
-      // Second fetch: POST /api/conversation to create a new one
-      expect(mockFetch).toHaveBeenNthCalledWith(2, "/api/conversation", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: mockUserId }),
-      });
-
-      expect(result.current.activeConversationId).toBe("conv-fresh");
+  it("deleteActiveConversation rolls back optimistic update and shows error toast on DELETE failure", async () => {
+    const { toast } = await import("sonner");
+    const active = makeConversation("conv-delete", {
+      title: "Laksa",
+      _count: { messages: 3 },
     });
+    const fallback = makeConversation("conv-fallback", {
+      title: "Egg ideas",
+      _count: { messages: 1 },
+    });
+    localStorageMock.getItem.mockReturnValueOnce("conv-delete");
+    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+      conversations: [active, fallback],
+    });
+    mockFetch.mockResolvedValueOnce({ ok: false });
+
+    const { result } = renderHook(() => useConversationContext(), { wrapper });
+
+    await act(async () => {
+      await result.current.deleteActiveConversation();
+    });
+
+    expect(result.current.activeConversationId).toBe("conv-delete");
+    expect(toast.error).toHaveBeenCalledWith(
+      "Could not delete conversation. Try again."
+    );
   });
 });

--- a/src/contexts/ConversationContext.tsx
+++ b/src/contexts/ConversationContext.tsx
@@ -14,6 +14,10 @@ import useSWR, { mutate as globalMutate } from "swr";
 
 const LOCAL_STORAGE_KEY = "ask-ah-mah-active-conversation";
 
+type ConversationListResponse = {
+  conversations: ConversationEntity[];
+};
+
 interface ConversationContextType {
   activeConversationId: string | null;
   activeConversation: ConversationEntity | null;
@@ -22,7 +26,7 @@ interface ConversationContextType {
   startNewConversation: () => Promise<void>;
   renameActiveConversation: (title: string) => Promise<void>;
   autoTitleActiveConversation: (title: string) => Promise<boolean>;
-  archiveActiveConversation: () => Promise<void>;
+  deleteActiveConversation: () => Promise<void>;
 }
 
 const ConversationContext = createContext<ConversationContextType | undefined>(
@@ -56,8 +60,10 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
   );
 
   // Always fetch the conversations list so activeConversation reflects title updates
-  const { data: listData } = useSWR<{ conversations: ConversationEntity[] }>(
-    userId ? `/api/conversation?userId=${userId}` : null,
+  const listKey = userId ? `/api/conversation?userId=${userId}` : null;
+
+  const { data: listData } = useSWR<ConversationListResponse>(
+    listKey,
     async (url: string) => {
       const res = await fetch(url);
       if (!res.ok) throw new Error("Failed to fetch conversations");
@@ -84,7 +90,24 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(LOCAL_STORAGE_KEY, id);
   };
 
-  const startNewConversation = async () => {
+  const persistActiveConversation = (id: string | null) => {
+    setActiveConversationId(id);
+    if (id) {
+      localStorage.setItem(LOCAL_STORAGE_KEY, id);
+      return;
+    }
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+  };
+
+  const revalidateConversationKeys = () =>
+    globalMutate(
+      (key: unknown) =>
+        typeof key === "string" && key.includes("/api/conversation"),
+      undefined,
+      { revalidate: true }
+    );
+
+  const startNewConversation = async (options?: { revalidate?: boolean }) => {
     if (!userId) return;
     const res = await fetch("/api/conversation", {
       method: "POST",
@@ -94,8 +117,25 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
     if (!res.ok) throw new Error("Failed to create conversation");
     const { conversation } = await res.json();
     setActiveConversation(conversation.id);
-    // Refresh the conversations list rail
-    globalMutate(`/api/conversation?userId=${userId}`);
+    if (listKey) {
+      await globalMutate(
+        listKey,
+        (current?: ConversationListResponse) => {
+          const existing = current?.conversations ?? [];
+          const withoutConversation = existing.filter(
+            (item) => item.id !== conversation.id
+          );
+
+          return {
+            conversations: [conversation, ...withoutConversation],
+          };
+        },
+        false
+      );
+    }
+    if (options?.revalidate !== false) {
+      await revalidateConversationKeys();
+    }
   };
 
   const renameActiveConversation = async (title: string) => {
@@ -106,13 +146,7 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
       body: JSON.stringify({ title }),
     });
     if (!res.ok) return;
-    // Revalidate all conversation-related SWR keys (swrKey may be null when
-    // activeConversationId was loaded from localStorage, so we use a predicate).
-    globalMutate(
-      (key: unknown) => typeof key === "string" && key.includes("/api/conversation"),
-      undefined,
-      { revalidate: true }
-    );
+    await revalidateConversationKeys();
   };
 
   const autoTitleActiveConversation = async (title: string) => {
@@ -124,11 +158,7 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
         body: JSON.stringify({ title, autoTitle: true }),
       });
       if (!res.ok) return false;
-      globalMutate(
-        (key: unknown) => typeof key === "string" && key.includes("/api/conversation"),
-        undefined,
-        { revalidate: true }
-      );
+      await revalidateConversationKeys();
       return true;
     } catch (error) {
       console.error("Failed to auto-title conversation:", error);
@@ -136,19 +166,69 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
     }
   };
 
-  const archiveActiveConversation = async () => {
-    if (!activeConversationId) return;
-    const res = await fetch(`/api/conversation/${activeConversationId}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ archived: true }),
-    });
-    if (!res.ok) return;
-    toast.success("Conversation archived");
-    // Clear stored id so startNewConversation creates fresh
-    setActiveConversationId(null);
-    localStorage.removeItem(LOCAL_STORAGE_KEY);
-    await startNewConversation();
+  const deleteActiveConversation = async (): Promise<void> => {
+    if (
+      !userId ||
+      !activeConversationId ||
+      !activeConversation ||
+      (activeConversation._count?.messages ?? 0) === 0
+    ) {
+      return;
+    }
+
+    const previousConversations = listData?.conversations ?? [];
+    const previousActiveConversationId = activeConversationId;
+    const optimisticConversations = previousConversations.filter(
+      (conversation) => conversation.id !== activeConversationId
+    );
+    const nextConversation =
+      optimisticConversations.find(
+        (conversation) => (conversation._count?.messages ?? 0) > 0
+      ) ??
+      optimisticConversations.find(
+        (conversation) =>
+          conversation.title === null &&
+          (conversation._count?.messages ?? 0) === 0
+      ) ??
+      null;
+
+    if (listKey) {
+      await globalMutate(
+        listKey,
+        { conversations: optimisticConversations },
+        false
+      );
+    }
+
+    if (nextConversation) {
+      persistActiveConversation(nextConversation.id);
+    } else {
+      persistActiveConversation(null);
+      await startNewConversation({ revalidate: false });
+    }
+
+    try {
+      const res = await fetch(
+        `/api/conversation/${previousActiveConversationId}?userId=${encodeURIComponent(userId)}`,
+        { method: "DELETE" }
+      );
+
+      if (!res.ok) {
+        throw new Error("Failed to delete conversation");
+      }
+
+      await revalidateConversationKeys();
+    } catch {
+      if (listKey) {
+        await globalMutate(
+          listKey,
+          { conversations: previousConversations },
+          false
+        );
+      }
+      persistActiveConversation(previousActiveConversationId);
+      toast.error("Could not delete conversation. Try again.");
+    }
   };
 
   const contextIsLoading =
@@ -164,7 +244,7 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
         startNewConversation,
         renameActiveConversation,
         autoTitleActiveConversation,
-        archiveActiveConversation,
+        deleteActiveConversation,
       }}
     >
       {children}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -1,5 +1,16 @@
 "use client";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { useConversationContext } from "@/contexts/ConversationContext";
 import { useSessionContext } from "@/contexts/SessionContext";
@@ -13,6 +24,7 @@ import { upperCaseFirstLetter } from "@/lib/utils";
 import { fetcher } from "@/lib/utils/index";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
+import { Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
@@ -39,9 +51,10 @@ const Chat = () => {
     startNewConversation,
     renameActiveConversation,
     autoTitleActiveConversation,
-    archiveActiveConversation,
+    deleteActiveConversation,
   } = useConversationContext();
   const [convSheetOpen, setConvSheetOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
   const [expectingRecipe, setExpectingRecipe] = useState(false);
   const autoTitledConversations = useRef<Set<string>>(new Set());
@@ -234,6 +247,11 @@ const Chat = () => {
     await saveMessage("user", message);
   };
 
+  const handleDeleteConversation = async () => {
+    await deleteActiveConversation();
+    setDeleteDialogOpen(false);
+  };
+
   return (
     <div
       key={activeConversationId}
@@ -266,16 +284,37 @@ const Chat = () => {
             </svg>
           </button>
         <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={archiveActiveConversation}
-            disabled={messageCount === 0}
-            title={messageCount === 0 ? "Nothing to archive yet" : undefined}
-            className="cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            Archive
-          </Button>
+          <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={messageCount === 0}
+                aria-label="Delete conversation"
+                title={messageCount === 0 ? "Nothing to delete yet" : undefined}
+                className="cursor-pointer text-ink-faint hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete this conversation?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This cannot be undone. Saved recipes are kept.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleDeleteConversation}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                >
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
           <Button
             size="sm"
             onClick={() => startNewConversation()}

--- a/src/features/Conversations/components/ConversationItem.test.tsx
+++ b/src/features/Conversations/components/ConversationItem.test.tsx
@@ -6,7 +6,6 @@ const baseConv: ConversationEntity = {
   id: "conv-1",
   userId: "user-1",
   title: "Sambal night",
-  archived: false,
   createdAt: new Date("2026-05-04T10:00:00Z"),
   updatedAt: new Date("2026-05-04T11:00:00Z"),
   _count: { messages: 5 },

--- a/src/lib/conversations/conversations.test.ts
+++ b/src/lib/conversations/conversations.test.ts
@@ -1,9 +1,10 @@
 import { prisma } from "@/lib/db";
 import {
-  archiveConversation,
   autoTitleConversation,
   createConversation,
+  deleteConversation,
   getOrCreateActiveConversation,
+  getOrCreateEmptyConversation,
   listConversations,
   renameConversation,
 } from "./conversations";
@@ -16,6 +17,7 @@ jest.mock("@/lib/db", () => ({
       findUnique: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      deleteMany: jest.fn(),
     },
     message: {
       findMany: jest.fn(),
@@ -39,7 +41,6 @@ function makeConversation(overrides: Partial<{
   id: string;
   userId: string;
   title: string | null;
-  archived: boolean;
   createdAt: Date;
   updatedAt: Date;
   _count: { messages: number };
@@ -48,7 +49,6 @@ function makeConversation(overrides: Partial<{
     id: "conv-1",
     userId: "user-1",
     title: null,
-    archived: false,
     createdAt: new Date("2024-01-01T10:00:00.000Z"),
     updatedAt: new Date("2024-01-01T10:00:00.000Z"),
     _count: { messages: 0 },
@@ -84,22 +84,10 @@ describe("Conversation Functions", () => {
       expect(result).toHaveLength(0);
     });
 
-    it("excludes archived conversations by default", async () => {
+    it("queries by userId only", async () => {
       mockedPrisma.conversation.findMany.mockResolvedValue([]);
 
       await listConversations("user-1");
-
-      expect(mockedPrisma.conversation.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({ archived: false }),
-        })
-      );
-    });
-
-    it("includes archived conversations when includeArchived is true", async () => {
-      mockedPrisma.conversation.findMany.mockResolvedValue([]);
-
-      await listConversations("user-1", { includeArchived: true });
 
       expect(mockedPrisma.conversation.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -148,6 +136,41 @@ describe("Conversation Functions", () => {
     });
   });
 
+  describe("getOrCreateEmptyConversation", () => {
+    it("returns the existing empty conversation when one exists", async () => {
+      const existing = makeConversation({ id: "conv-empty" });
+      mockedPrisma.conversation.findFirst.mockResolvedValue(existing);
+
+      const result = await getOrCreateEmptyConversation("user-1");
+
+      expect(result.id).toBe("conv-empty");
+      expect(mockedPrisma.conversation.findFirst).toHaveBeenCalledWith({
+        where: {
+          userId: "user-1",
+          title: null,
+          messages: { none: {} },
+        },
+        orderBy: { updatedAt: "desc" },
+        include: { _count: { select: { messages: true } } },
+      });
+      expect(mockedPrisma.conversation.create).not.toHaveBeenCalled();
+    });
+
+    it("creates a new conversation when no empty one exists", async () => {
+      const created = makeConversation({ id: "conv-created" });
+      mockedPrisma.conversation.findFirst.mockResolvedValue(null);
+      mockedPrisma.conversation.create.mockResolvedValue(created);
+
+      const result = await getOrCreateEmptyConversation("user-2");
+
+      expect(result.id).toBe("conv-created");
+      expect(mockedPrisma.conversation.create).toHaveBeenCalledWith({
+        data: { userId: "user-2" },
+        include: { _count: { select: { messages: true } } },
+      });
+    });
+  });
+
   describe("renameConversation", () => {
     it("updates title and returns updated conversation", async () => {
       const updated = makeConversation({ id: "conv-1", title: "My New Title" });
@@ -164,19 +187,23 @@ describe("Conversation Functions", () => {
     });
   });
 
-  describe("archiveConversation", () => {
-    it("sets archived = true and returns updated conversation", async () => {
-      const archived = makeConversation({ id: "conv-1", archived: true });
-      mockedPrisma.conversation.update.mockResolvedValue(archived);
+  describe("deleteConversation", () => {
+    it("deletes the conversation scoped by userId", async () => {
+      mockedPrisma.conversation.deleteMany.mockResolvedValue({ count: 1 });
 
-      const result = await archiveConversation("conv-1");
+      await deleteConversation("conv-1", "user-1");
 
-      expect(result.archived).toBe(true);
-      expect(mockedPrisma.conversation.update).toHaveBeenCalledWith({
-        where: { id: "conv-1" },
-        data: { archived: true },
-        include: { _count: { select: { messages: true } } },
+      expect(mockedPrisma.conversation.deleteMany).toHaveBeenCalledWith({
+        where: { id: "conv-1", userId: "user-1" },
       });
+    });
+
+    it("throws when the conversation does not exist for the user", async () => {
+      mockedPrisma.conversation.deleteMany.mockResolvedValue({ count: 0 });
+
+      await expect(deleteConversation("conv-1", "user-1")).rejects.toThrow(
+        "Conversation not found"
+      );
     });
   });
 

--- a/src/lib/conversations/conversations.ts
+++ b/src/lib/conversations/conversations.ts
@@ -7,23 +7,16 @@ export type ConversationEntity = {
   id: string;
   userId: string;
   title: string | null;
-  archived: boolean;
   createdAt: Date;
   updatedAt: Date;
   _count?: { messages: number };
 };
 
 export async function listConversations(
-  userId: string,
-  options?: { includeArchived?: boolean }
+  userId: string
 ): Promise<ConversationEntity[]> {
-  const includeArchived = options?.includeArchived ?? false;
-
   return prisma.conversation.findMany({
-    where: {
-      userId,
-      ...(includeArchived ? {} : { archived: false }),
-    },
+    where: { userId },
     orderBy: { updatedAt: "desc" },
     include: { _count: { select: { messages: true } } },
   });
@@ -33,7 +26,27 @@ export async function getOrCreateActiveConversation(
   userId: string
 ): Promise<ConversationEntity> {
   const existing = await prisma.conversation.findFirst({
-    where: { userId, archived: false },
+    where: { userId },
+    orderBy: { updatedAt: "desc" },
+    include: { _count: { select: { messages: true } } },
+  });
+
+  if (existing) {
+    return existing;
+  }
+
+  return createConversation(userId);
+}
+
+export async function getOrCreateEmptyConversation(
+  userId: string
+): Promise<ConversationEntity> {
+  const existing = await prisma.conversation.findFirst({
+    where: {
+      userId,
+      title: null,
+      messages: { none: {} },
+    },
     orderBy: { updatedAt: "desc" },
     include: { _count: { select: { messages: true } } },
   });
@@ -82,16 +95,17 @@ export async function autoTitleIfNull(
   });
 }
 
-export async function archiveConversation(
-  id: string
-): Promise<ConversationEntity> {
-  const conversation = await prisma.conversation.update({
-    where: { id },
-    data: { archived: true },
-    include: { _count: { select: { messages: true } } },
+export async function deleteConversation(
+  id: string,
+  userId: string
+): Promise<void> {
+  const result = await prisma.conversation.deleteMany({
+    where: { id, userId },
   });
 
-  return conversation;
+  if (result.count === 0) {
+    throw new Error("Conversation not found");
+  }
 }
 
 export async function autoTitleConversation(id: string): Promise<void> {


### PR DESCRIPTION
…dialog

Removes the Archive pattern entirely and replaces it with a trash icon in the chat header that opens a shadcn AlertDialog. Confirming fires the DELETE immediately — no deferred undo window, no pending-delete state machine, no blocked back-to-back deletes.

- Drop archived column, index, and all archive-related lib/route code; migration purges existing archived rows
- DELETE /api/conversation/[id] scoped by userId, cascades messages
- getOrCreateEmptyConversation powers post-delete fallback and fixes duplicate-empty-conversation bug in startNewConversation
- ConversationContext.deleteActiveConversation simplified to Promise<void> with optimistic update + rollback on failure
- AlertDialog replaces undo toast in Chat.tsx
- Tests updated: timer/commit/cancel assertions removed; immediate-fire and rollback-on-failure cases added

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conversation deletion with confirmation dialog for permanent removal
  * Introduced alert dialog component for user confirmations

* **Changed**
  * Replaced archive functionality with permanent deletion of conversations
  * Updated conversation creation to optimize empty conversation reuse

<!-- end of auto-generated comment: release notes by coderabbit.ai -->