### PR TITLE
fix(ui): recipe header, servings label, and delete button hover

### DIFF
--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -154,7 +154,7 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
         </div>
 
         <div className={cn(EYEBROW_BASE, "text-muted-foreground")}>
-          From Ah Mah's Kitchen
+          From Ah Mah&apos;s Kitchen
         </div>
 
         <div className="flex-1" />

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -154,7 +154,7 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
         </div>
 
         <div className={cn(EYEBROW_BASE, "text-muted-foreground")}>
-          The way I make it
+          From Ah Mah's Kitchen
         </div>
 
         <div className="flex-1" />
@@ -165,12 +165,17 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
           </div>
         )}
 
-        <ServingsStepper
-          servings={servings}
-          baseServings={recipe.baseServings}
-          onDecrement={() => setServings((s) => Math.max(1, s - 1))}
-          onIncrement={() => setServings((s) => Math.min(12, s + 1))}
-        />
+        <div className="flex flex-col items-end gap-0.5">
+          <span className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
+            Servings
+          </span>
+          <ServingsStepper
+            servings={servings}
+            baseServings={recipe.baseServings}
+            onDecrement={() => setServings((s) => Math.max(1, s - 1))}
+            onIncrement={() => setServings((s) => Math.min(12, s + 1))}
+          />
+        </div>
       </div>
 
       {/* Title */}

--- a/src/features/RecipeList/components/RecipeCard.tsx
+++ b/src/features/RecipeList/components/RecipeCard.tsx
@@ -31,7 +31,7 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
     >
       {/* Delete button — revealed on hover */}
       <button
-        className="absolute top-2 right-2 z-20 p-1.5 rounded-md bg-card border border-border opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer text-muted-foreground hover:text-foreground"
+        className="absolute top-2 right-2 z-20 p-1.5 rounded-md bg-card border border-border opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer text-muted-foreground hover:bg-muted/60"
         onClick={(e) => { e.stopPropagation(); onDelete(recipe.id); }}
         aria-label={`Delete ${recipe.name}`}
       >


### PR DESCRIPTION
Closes #78
Closes #79

## Summary
- Renamed ribbon header in `RecipeLetter` from "The way I make it" → "From Ah Mah's Kitchen"
- Added a "SERVINGS" eyebrow label above the servings stepper in `RecipeLetter`, matching the `RecipeDisplay` pattern
- Replaced the dark green `hover:text-foreground` on the `RecipeCard` delete button with `hover:bg-muted/60` (ghost/muted style)

## Test plan
- [ ] Open the chat view and verify the recipe ribbon header reads "From Ah Mah's Kitchen"
- [ ] Confirm the servings stepper shows a "SERVINGS" label above it
- [ ] Hover the delete button on a recipe card — confirm no dark green, just a subtle background tint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated recipe header presentation with refreshed branding text messaging for a modernized look and feel.
  * Improved servings selector layout with better-positioned labels and optimized structure for enhanced visual clarity and overall usability.
  * Refined delete button interactions with enhanced hover state styling that provides clearer and more intuitive visual feedback to users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->