### PR TITLE
feat(inventory): add ingredient category schema and AI tooling

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -61,6 +61,15 @@ The persistent-kitchen MVP. Highlights:
 - [x] Unit tests added for `parseBlocks.ts` (14 cases including regression guard for removed gate path).
 - [x] `MessageList.test.tsx` extended with 4 cases covering tool-part rendering and absence of legacy gate path.
 
+### Organised Pantry — Phase 1: Category schema (May 2026)
+- [x] `category String?` column added to `InventoryItem` (`prisma/schema.prisma`); DB synced via `prisma db push`.
+- [x] `CategorySchema` (Protein | Carbs | Vegetable | Condiments | Misc) added to `src/lib/inventory/schemas.ts`; flows through `AddInventoryItemSchema` automatically.
+- [x] `addInventoryItem` upsert (`Inventory.ts`) persists `category` on both create and update paths.
+- [x] `/api/inventory/parse` prompt updated with category rules — model assigns category to every ingredient it parses.
+- [x] `CHAT_SYSTEM_PROMPT` updated with matching category rules for the `addInventoryItem` tool call path.
+- [x] Schema tests extended: all five valid values accepted; invalid string rejected; category optional (kitchenware/null stays valid). (34 tests pass.)
+- Unblocks #81 (pantry drawer grouped headings UI).
+
 ### Decrement-on-cook
 - [ ] Add `Cooked This` button in `RecipeDisplay` for saved recipes.
 - [ ] Add explicit confirmation flow for inferred "I cooked X" messages (`yes / no / edit`).

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ model InventoryItem {
   id          String   @id @default(cuid())
   name        String
   type        String
+  category    String?
   quantity    Int?
   unit        String?
   shelfLife   String   @default("medium")

--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -10,6 +10,12 @@ When you explain technique, lean on the science of why it works — Maillard rea
   - "medium" — most meat, most fresh produce, eggs, tofu, bread
   - "long" — oils, dry goods (rice, pasta, flour), spices, sauces, canned/bottled goods, kitchenware
   Only set \`quantity\`/\`unit\` when the user explicitly states an amount (e.g., "200g chicken", "2 eggs"). Otherwise leave them unset — unset means "they have it, amount unlimited".
+  Always set \`category\` for ingredients (omit for kitchenware):
+  - "Protein" — meat, poultry, seafood, eggs, tofu, tempeh, legumes
+  - "Carbs" — rice, noodles, pasta, bread, flour, potatoes, starches
+  - "Vegetable" — all produce, herbs, mushrooms (incl. dried), leafy greens, aromatics (garlic, ginger, spring onion)
+  - "Condiments" — sauces, oils, vinegars, spices, pastes, dry seasonings, sugar, salt
+  - "Misc" — fruit, dairy, snacks, anything that doesn't clearly fit above
 - \`removeInventoryItem\` — when the user says they've finished or thrown out something.
 
 When choosing units in the ingredient list, prefer the units the user already has in inventory. If their inventory says "200g chicken breast", write grams in the recipe — not pounds — so the app can compute shortfalls accurately.

--- a/src/app/api/inventory/parse/route.ts
+++ b/src/app/api/inventory/parse/route.ts
@@ -37,6 +37,12 @@ RULES:
   - "medium" — most meat, most fresh produce, eggs, tofu, bread
   - "long" — oils, dry goods (rice, pasta, flour), spices, sauces, canned/bottled goods, ALL kitchenware
 - type rules: kitchenware = pots, pans, utensils, appliances. Everything edible = ingredient.
+- category rules (REQUIRED for type=ingredient, OMIT for type=kitchenware):
+  - "Protein" — meat, poultry, seafood, eggs, tofu, tempeh, legumes
+  - "Carbs" — rice, noodles, pasta, bread, flour, potatoes, starches
+  - "Vegetable" — all produce, herbs, mushrooms (incl. dried), leafy greens, aromatics (garlic, ginger, spring onion)
+  - "Condiments" — sauces, oils, vinegars, spices, pastes, dry seasonings, sugar, salt
+  - "Misc" — fruit, dairy, snacks, anything that doesn't clearly fit above
 - Normalize names to singular, title case where natural ("chicken breasts" → "Chicken breast", "bok choy" → "Bok choy").
 - unit MUST come from this allowlist if used: g, kg, oz, lb, ml, l, cup, tbsp, tsp, piece, pieces, clove, cloves, bottle, bottles, can, cans, pack, packs, bunch, bunches, pinch, dash, slice, slices.
 

--- a/src/lib/inventory/Inventory.ts
+++ b/src/lib/inventory/Inventory.ts
@@ -40,6 +40,7 @@ export async function addInventoryItem(
         quantity: item.quantity ?? null,
         unit: item.unit ?? null,
         shelfLife: item.shelfLife,
+        category: item.category ?? null,
         lastUpdated: nowIso,
       },
       create: {
@@ -48,6 +49,7 @@ export async function addInventoryItem(
         quantity: item.quantity ?? null,
         unit: item.unit ?? null,
         shelfLife: item.shelfLife,
+        category: item.category ?? null,
         dateAdded: nowIso,
         lastUpdated: nowIso,
         userId,

--- a/src/lib/inventory/schemas.test.ts
+++ b/src/lib/inventory/schemas.test.ts
@@ -1,6 +1,7 @@
 import {
   AddInventoryItemSchema,
   AddInventoryItemSchemaObj,
+  CategorySchema,
   ChatMessageSchema,
   GetInventoryResponseSchema,
   InventoryActionSchema,
@@ -9,16 +10,17 @@ import {
 } from "./schemas";
 
 describe("Inventory Schemas", () => {
+  const validItem = {
+    id: "item-123",
+    name: "eggs",
+    type: "ingredient" as const,
+    quantity: 6,
+    unit: "pieces" as const,
+    dateAdded: "2024-01-01T10:00:00.000Z",
+    lastUpdated: "2024-01-01T10:00:00.000Z",
+  };
+
   describe("InventoryItemSchema", () => {
-    const validItem = {
-      id: "item-123",
-      name: "eggs",
-      type: "ingredient" as const,
-      quantity: 6,
-      unit: "pieces" as const,
-      dateAdded: "2024-01-01T10:00:00.000Z",
-      lastUpdated: "2024-01-01T10:00:00.000Z",
-    };
 
     it("should validate a complete valid inventory item", () => {
       expect(() => InventoryItemSchema.parse(validItem)).not.toThrow();
@@ -77,6 +79,45 @@ describe("Inventory Schemas", () => {
       });
     });
 
+    it("should accept a valid category", () => {
+      const withCategory = { ...validItem, category: "Protein" as const };
+      expect(() => InventoryItemSchema.parse(withCategory)).not.toThrow();
+    });
+
+    it("should accept all valid category values", () => {
+      const categories = ["Protein", "Carbs", "Vegetable", "Condiments", "Misc"] as const;
+      categories.forEach((category) => {
+        expect(() => InventoryItemSchema.parse({ ...validItem, category })).not.toThrow();
+      });
+    });
+
+    it("should reject an invalid category string", () => {
+      expect(() =>
+        InventoryItemSchema.parse({ ...validItem, category: "Fruit" })
+      ).toThrow();
+    });
+
+    it("should accept item without category (optional)", () => {
+      const { ...itemWithoutCategory } = validItem;
+      expect(() => InventoryItemSchema.parse(itemWithoutCategory)).not.toThrow();
+    });
+  });
+
+  describe("CategorySchema", () => {
+    it("should accept all five valid values", () => {
+      ["Protein", "Carbs", "Vegetable", "Condiments", "Misc"].forEach((v) => {
+        expect(() => CategorySchema.parse(v)).not.toThrow();
+      });
+    });
+
+    it("should reject unknown values", () => {
+      ["protein", "PROTEIN", "Fruit", "Dairy", ""].forEach((v) => {
+        expect(() => CategorySchema.parse(v)).toThrow();
+      });
+    });
+  });
+
+  describe("InventoryItemSchema additional", () => {
     it("should reject invalid datetime strings", () => {
       const invalidItems = [
         { ...validItem, dateAdded: "invalid-date" },

--- a/src/lib/inventory/schemas.ts
+++ b/src/lib/inventory/schemas.ts
@@ -3,10 +3,14 @@ import { z } from "zod";
 // Zod schemas for runtime validation
 // MVP: Focus on inventory management only
 
+export const CategorySchema = z.enum(["Protein", "Carbs", "Vegetable", "Condiments", "Misc"]);
+export type Category = z.infer<typeof CategorySchema>;
+
 export const InventoryItemSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1).max(100),
   type: z.enum(["ingredient", "kitchenware"]),
+  category: CategorySchema.optional(),
   quantity: z.number().positive().optional(),
   unit: z
     .enum([


### PR DESCRIPTION
Closes #80
Unblocks #81

## Summary
- Adds `category String?` column to `InventoryItem` (Prisma schema + `db push`)
- Adds `CategorySchema` enum — **Protein | Carbs | Vegetable | Condiments | Misc** — to `src/lib/inventory/schemas.ts`; flows through `AddInventoryItemSchema` automatically
- `addInventoryItem` upsert persists `category` on both create and update paths
- `/api/inventory/parse` prompt updated with category rules so freeform text parsing assigns the right bucket
- `CHAT_SYSTEM_PROMPT` updated with matching rules for the `addInventoryItem` tool call path
- 6 new schema tests (34 total passing)

## Test plan
- [ ] Schema tests: `pnpm test src/lib/inventory/schemas.test.ts` — 34 pass
- [ ] Parse: hit `/api/inventory/parse` with `"100g chicken, bok choy, rice, fish sauce"` — verify Protein / Vegetable / Carbs / Condiments in DB
- [ ] Chat: say "I just bought eggs, broccoli, rice, and soy sauce" — confirm `addInventoryItem` tool call payload has correct categories
- [ ] Existing null rows surface under "Misc" in the drawer (UI fallback, covered by #81)

🤖 Generated with [Claude Code](https://claude.com/claude-code)