### PR TITLE
feat(pantry): group ingredients by category (#81)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -70,6 +70,11 @@ The persistent-kitchen MVP. Highlights:
 - [x] Schema tests extended: all five valid values accepted; invalid string rejected; category optional (kitchenware/null stays valid). (34 tests pass.)
 - Unblocks #81 (pantry drawer grouped headings UI).
 
+### Organised Pantry — Phase 2: Category headings UI (May 2026)
+- [x] Ingredients section in `Inventory.tsx` now renders category sub-groups (Protein / Carbs / Vegetable / Condiments / Misc) instead of a flat badge list.
+- [x] Each sub-group: label + dotted-line spacer + count, then the badges. Empty categories hidden.
+- [x] Items with null category (pre-existing rows) fall under Misc.
+
 ### Decrement-on-cook
 - [ ] Add `Cooked This` button in `RecipeDisplay` for saved recipes.
 - [ ] Add explicit confirmation flow for inferred "I cooked X" messages (`yes / no / edit`).

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useSessionContext } from "@/contexts/SessionContext";
 import {
+  Category,
   GetInventoryResponse,
   InventoryItem,
 } from "@/lib/inventory/schemas";
@@ -12,6 +13,19 @@ import { ReactNode, useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
 import { InventoryItemBadge } from "./components/InventoryItemBadge";
+
+const CATEGORY_ORDER: Category[] = ["Protein", "Carbs", "Vegetable", "Condiments", "Misc"];
+
+function groupByCategory(items: InventoryItem[]): { label: Category; items: InventoryItem[] }[] {
+  const map = new Map<Category, InventoryItem[]>(CATEGORY_ORDER.map((c) => [c, []]));
+  for (const item of items) {
+    const key: Category = (item.category as Category) ?? "Misc";
+    map.get(key)?.push(item);
+  }
+  return CATEGORY_ORDER.map((label) => ({ label, items: map.get(label)! })).filter(
+    (g) => g.items.length > 0,
+  );
+}
 
 const SectionLabel = ({ children, count }: { children: ReactNode; count?: number }) => (
   <div className="flex items-center justify-between border-b border-dashed border-border pb-2.5 mb-3">
@@ -170,7 +184,7 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
         </Card>
       )}
 
-      {/* Ingredients card */}
+      {/* Ingredients card — grouped by category */}
       <section className="bg-card border border-border rounded-xl p-3.5 shadow-[0_1px_0_oklch(0.87_0.03_72),0_8px_18px_-16px_oklch(0.3_0.05_50/0.4)]">
         <SectionLabel count={ingredientsSorted?.length ?? 0}>Ingredients</SectionLabel>
         {isLoading && <p className="text-xs text-muted-foreground font-display italic">Looking in the pantry…</p>}
@@ -179,9 +193,24 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
             Add what&rsquo;s in your fridge — Ah Mah understands &ldquo;a bit of ginger&rdquo;.
           </p>
         ) : (
-          <div className="flex flex-wrap gap-1.5">
-            {ingredientsSorted?.map((item: InventoryItem) => (
-              <InventoryItemBadge key={item.id} item={item} onRemove={removeItem} />
+          <div className="flex flex-col gap-3">
+            {groupByCategory(ingredientsSorted ?? []).map((group) => (
+              <div key={group.label}>
+                <div className="flex items-center gap-2 mb-1.5">
+                  <span className="font-sans text-[9.5px] font-bold tracking-[0.18em] uppercase text-ink-faint shrink-0">
+                    {group.label}
+                  </span>
+                  <span className="flex-1 border-t border-dotted border-border" />
+                  <span className="font-mono text-[10px] text-ink-faint tabular-nums shrink-0">
+                    {group.items.length}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {group.items.map((item) => (
+                    <InventoryItemBadge key={item.id} item={item} onRemove={removeItem} />
+                  ))}
+                </div>
+              </div>
             ))}
           </div>
         )}


### PR DESCRIPTION
Closes #81

## Summary
- Ingredients section in `Inventory.tsx` now renders five category sub-groups (Protein / Carbs / Vegetable / Condiments / Misc) instead of a flat badge list
- Each sub-group shows a label + dotted-line spacer + count, followed by the ingredient badges
- Empty categories are hidden
- Items with `null` category (pre-existing rows, kitchenware seeds) fall under Misc
- Matches the reference design in `temp/Ask Ah Mah/inventory.jsx`

## Test plan
- [ ] Open the pantry drawer — ingredients should appear grouped under category headings
- [ ] Add a new ingredient via the text field (e.g. "chicken breast, rice, bok choy, soy sauce") — confirm it lands in the correct group
- [ ] Verify pre-existing uncategorised items appear under Misc
- [ ] Verify empty categories are not rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingredients are now organized by category (Protein, Carbs, Vegetable, Condiments, Misc) with item counts displayed per group and empty categories hidden.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/88)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->