### PR TITLE
feat(recipe): fix HAVE/NEED matching with token-overlap algorithm

### DIFF
--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -2,6 +2,7 @@
 
 import { useSessionContext } from "@/contexts/SessionContext";
 import { GetInventoryResponse, InventoryItem } from "@/lib/inventory/schemas";
+import { ingredientMatches } from "@/lib/recipes/matchIngredient";
 import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils/index";
 import { useState } from "react";
@@ -109,8 +110,7 @@ function HaveTag({ have }: { have: boolean }) {
 }
 
 function ingredientHave(name: string, inventoryNames: string[]): boolean {
-  const n = name.trim().toLowerCase();
-  return inventoryNames.some((inv) => inv.includes(n) || n.includes(inv));
+  return ingredientMatches(name, inventoryNames);
 }
 
 export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {

--- a/src/lib/recipes/matchIngredient.test.ts
+++ b/src/lib/recipes/matchIngredient.test.ts
@@ -1,0 +1,56 @@
+import { ingredientMatches } from "./matchIngredient";
+
+describe("ingredientMatches", () => {
+  it("matches the real doubanjiang bug from the screenshot", () => {
+    expect(
+      ingredientMatches("doubanjiang (fermented bean paste)", [
+        "Doubanjiang (fermented chili bean paste)",
+      ]),
+    ).toBe(true);
+  });
+
+  it("matches green bell pepper against bell pepper", () => {
+    expect(ingredientMatches("green bell pepper", ["bell pepper"])).toBe(true);
+  });
+
+  it("matches pork belly slices against parenthetical variant", () => {
+    expect(
+      ingredientMatches("pork belly slices", [
+        "Pork belly slices (sukiyaki thin)",
+      ]),
+    ).toBe(true);
+  });
+
+  it("matches olive oil against generic oil", () => {
+    expect(ingredientMatches("olive oil", ["oil"])).toBe(true);
+  });
+
+  it("does not match scallion against green onion (known synonym limitation)", () => {
+    expect(ingredientMatches("scallion", ["green onion"])).toBe(false);
+  });
+
+  it("returns false for empty ingredient name", () => {
+    expect(ingredientMatches("", ["garlic"])).toBe(false);
+  });
+
+  it("returns false when ingredient is stopwords only", () => {
+    expect(ingredientMatches("fresh whole", ["garlic", "ginger"])).toBe(false);
+  });
+
+  it("returns false when no inventory match exists", () => {
+    expect(ingredientMatches("star anise", ["garlic", "ginger", "soy sauce"])).toBe(false);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(ingredientMatches("GARLIC", ["garlic"])).toBe(true);
+  });
+
+  it("matches in reverse direction (inventory name contained in ingredient)", () => {
+    expect(ingredientMatches("sea salt", ["salt"])).toBe(true);
+  });
+
+  it("strips stopword modifiers before matching", () => {
+    expect(ingredientMatches("fresh ginger", ["ginger"])).toBe(true);
+    expect(ingredientMatches("ground pepper", ["pepper"])).toBe(true);
+  });
+});

--- a/src/lib/recipes/matchIngredient.ts
+++ b/src/lib/recipes/matchIngredient.ts
@@ -1,0 +1,31 @@
+const STOPWORDS = new Set([
+  "fresh", "ground", "chopped", "minced", "sliced", "diced",
+  "whole", "thin", "thinly", "raw", "cooked", "dried",
+  "powder", "extract", "pure", "fine", "coarse",
+  "large", "small", "medium",
+  "of", "the", "and", "a", "to",
+]);
+
+function tokenize(s: string): Set<string> {
+  return new Set(
+    s
+      .toLowerCase()
+      .replace(/\([^)]*\)/g, " ")
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((t) => t.length > 1 && !STOPWORDS.has(t)),
+  );
+}
+
+export function ingredientMatches(
+  ingredientName: string,
+  inventoryNames: string[],
+): boolean {
+  const a = tokenize(ingredientName);
+  if (a.size === 0) return false;
+  return inventoryNames.some((inv) => {
+    const b = tokenize(inv);
+    for (const t of a) if (b.has(t)) return true;
+    return false;
+  });
+}


### PR DESCRIPTION
## Summary

- Replaces the broken bidirectional `includes` matcher with a token-overlap algorithm
- Strips parenthetical qualifiers and stopword modifiers before comparing
- Matches if ≥1 significant token is shared between the recipe ingredient name and any pantry item name

Fixes the real case from the screenshot: "doubanjiang (fermented bean paste)" was showing NEED even though "Doubanjiang (fermented chili bean paste)" was in the pantry — the extra "chili" qualifier defeated substring containment in either direction.

## Test plan

- [x] 11 unit tests in `matchIngredient.test.ts` covering the doubanjiang bug, bell pepper, pork belly, olive oil, scallion (known limitation), empty/stopword-only inputs, and case-insensitivity
- [x] Manual: open a recipe with fuzzy ingredient variants — HAVE/NEED pills and the "X/Y in your pantry" counter should both reflect correct matches
- [ ] Verify Vercel preview shows correct HAVE status for pantry items with parenthetical names

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ingredient detection now better recognizes synonyms, case variations, and generic-to-specific matches (e.g., "oil" matching "olive oil") for improved accuracy

* **Tests**
  * Added comprehensive test coverage for ingredient matching edge cases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/95)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->