### PR TITLE
feat(recipe): click NEED pill to add ingredient to pantry

### DIFF
--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import { useSessionContext } from "@/contexts/SessionContext";
-import { GetInventoryResponse, InventoryItem } from "@/lib/inventory/schemas";
+import { Category, GetInventoryResponse, InventoryItem } from "@/lib/inventory/schemas";
 import { ingredientMatches } from "@/lib/recipes/matchIngredient";
 import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils/index";
 import { useState } from "react";
-import useSWR from "swr";
+import { toast } from "sonner";
+import useSWR, { useSWRConfig } from "swr";
 import { ScaledNum } from "./ScaledNum";
 import { scaleAmount } from "./scaleAmount";
 
 interface Ingredient {
   name: string;
+  category?: Category;
   amount?: string;
   unit?: string;
   note?: string;
@@ -82,7 +84,15 @@ function ServingsStepper({
   );
 }
 
-function HaveTag({ have }: { have: boolean }) {
+function HaveTag({
+  have,
+  ingredientName,
+  onAdd,
+}: {
+  have: boolean;
+  ingredientName: string;
+  onAdd?: () => void;
+}) {
   const BASE =
     "font-sans text-[9.5px] font-bold px-1.5 py-0.5 rounded-full tracking-wider shrink-0";
   if (have) {
@@ -98,14 +108,16 @@ function HaveTag({ have }: { have: boolean }) {
     );
   }
   return (
-    <span
+    <button
+      onClick={onAdd}
+      aria-label={`Add ${ingredientName} to pantry`}
       className={cn(
         BASE,
-        "text-muted-foreground bg-transparent border border-border",
+        "text-muted-foreground bg-transparent border border-border cursor-pointer hover:bg-muted hover:text-foreground transition-colors",
       )}
     >
       NEED
-    </span>
+    </button>
   );
 }
 
@@ -117,10 +129,28 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
   const [servings, setServings] = useState(recipe.baseServings);
   const ratio = servings / recipe.baseServings;
   const { userId } = useSessionContext();
-  const { data: inventoryData } = useSWR<GetInventoryResponse>(
-    userId ? `/api/inventory?userId=${userId}` : null,
-    fetcher,
-  );
+  const { mutate } = useSWRConfig();
+  const inventoryKey = userId ? `/api/inventory?userId=${userId}` : null;
+  const { data: inventoryData } = useSWR<GetInventoryResponse>(inventoryKey, fetcher);
+
+  const addToPantry = async (ing: Ingredient) => {
+    if (!userId) return;
+    try {
+      const res = await fetch("/api/inventory", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          items: [{ name: ing.name, type: "ingredient", ...(ing.category && { category: ing.category }) }],
+          userId,
+        }),
+      });
+      if (!res.ok) throw new Error();
+      toast.success(`Added ${ing.name} to your pantry`);
+      mutate(inventoryKey);
+    } catch {
+      toast.error(`Couldn't add ${ing.name} — please try again`);
+    }
+  };
 
   const inventoryItems: InventoryItem[] = [
     ...(inventoryData?.ingredientInventory ?? []),
@@ -236,7 +266,11 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
                     )}
                   </span>
                   {userId && inventoryItems.length > 0 && (
-                    <HaveTag have={have} />
+                    <HaveTag
+                      have={have}
+                      ingredientName={ing.name}
+                      onAdd={have ? undefined : () => addToPantry(ing)}
+                    />
                   )}
                 </div>
               );

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -88,10 +88,12 @@ function HaveTag({
   have,
   ingredientName,
   onAdd,
+  pending,
 }: {
   have: boolean;
   ingredientName: string;
   onAdd?: () => void;
+  pending?: boolean;
 }) {
   const BASE =
     "font-sans text-[9.5px] font-bold px-1.5 py-0.5 rounded-full tracking-wider shrink-0";
@@ -109,11 +111,16 @@ function HaveTag({
   }
   return (
     <button
+      type="button"
       onClick={onAdd}
+      disabled={pending}
       aria-label={`Add ${ingredientName} to pantry`}
       className={cn(
         BASE,
-        "text-muted-foreground bg-transparent border border-border cursor-pointer hover:bg-muted hover:text-foreground transition-colors",
+        "text-muted-foreground bg-transparent border border-border transition-colors",
+        pending
+          ? "opacity-50 cursor-not-allowed"
+          : "cursor-pointer hover:bg-muted hover:text-foreground",
       )}
     >
       NEED
@@ -127,6 +134,7 @@ function ingredientHave(name: string, inventoryNames: string[]): boolean {
 
 export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
   const [servings, setServings] = useState(recipe.baseServings);
+  const [inFlight, setInFlight] = useState<Set<string>>(new Set());
   const ratio = servings / recipe.baseServings;
   const { userId } = useSessionContext();
   const { mutate } = useSWRConfig();
@@ -134,7 +142,8 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
   const { data: inventoryData } = useSWR<GetInventoryResponse>(inventoryKey, fetcher);
 
   const addToPantry = async (ing: Ingredient) => {
-    if (!userId) return;
+    if (!userId || inFlight.has(ing.name)) return;
+    setInFlight((prev) => new Set(prev).add(ing.name));
     try {
       const res = await fetch("/api/inventory", {
         method: "POST",
@@ -144,11 +153,17 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
           userId,
         }),
       });
-      if (!res.ok) throw new Error();
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        const msg = payload?.error ?? `Failed to add ${ing.name} (${res.status})`;
+        throw new Error(msg);
+      }
       toast.success(`Added ${ing.name} to your pantry`);
       mutate(inventoryKey);
-    } catch {
-      toast.error(`Couldn't add ${ing.name} — please try again`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : `Couldn't add ${ing.name} — please try again`);
+    } finally {
+      setInFlight((prev) => { const s = new Set(prev); s.delete(ing.name); return s; });
     }
   };
 
@@ -270,6 +285,7 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
                       have={have}
                       ingredientName={ing.name}
                       onAdd={have ? undefined : () => addToPantry(ing)}
+                      pending={inFlight.has(ing.name)}
                     />
                   )}
                 </div>


### PR DESCRIPTION
## Summary

- NEED pills on recipe ingredients are now clickable `<button>` elements
- Clicking adds the ingredient to the pantry (`name` + `category` if present, `type: "ingredient"`, no quantity)
- Success toast confirms; error toast on failure
- SWR revalidates `/api/inventory` so the pill flips to HAVE on next render (via the token-overlap matcher from #95)
- HAVE pills remain passive `<span>` — removing from pantry stays in the sidebar
- Hover affordance only: `cursor-pointer` + `hover:bg-muted` + `hover:text-foreground` — no persistent "+" icon

## Test plan

- [ ] Open a recipe with NEED ingredients — hover shows cursor change + bg shift
- [ ] Click a NEED pill → toast "Added X to your pantry" → pill flips to HAVE → pantry sidebar updates
- [ ] Click with no network → toast error, pill stays NEED
- [ ] HAVE pills are not interactive (no click handler, no cursor change)
- [ ] Signed-out / empty-pantry users: no pills rendered (existing gate unchanged)

Closes #93
Part of #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add missing ingredients to pantry directly from the recipe view via interactive "NEED" buttons. Buttons show a loading/disabled state while adding. Category info is included when available. Success and error notifications confirm the action, streamlining ingredient management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/96)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->