### PR TITLE
feat(pantry): squeeze layout at xl+, overlay at lg–xl

### DIFF
--- a/src/features/Inventory/components/PantryDrawer.tsx
+++ b/src/features/Inventory/components/PantryDrawer.tsx
@@ -48,9 +48,16 @@ export function PantryDrawer() {
         </span>
       </button>
 
-      {/* Open overlay — absolute over chat */}
+      {/* xl+ (≥1280px): squeeze — pantry is a static flex sibling, chat narrows */}
       {open && (
-        <div className="hidden lg:flex absolute right-9 top-0 bottom-0 w-80 flex-col bg-muted paper border-l border-border z-20 overflow-y-auto">
+        <div className="hidden xl:flex w-80 flex-col bg-muted paper border-l border-border overflow-y-auto">
+          <InventoryWrapper onClose={() => setOpen(false)} />
+        </div>
+      )}
+
+      {/* lg–xl (1024–1279px): overlay — pantry floats over chat */}
+      {open && (
+        <div className="hidden lg:flex xl:hidden absolute right-9 top-0 bottom-0 w-80 flex-col bg-muted paper border-l border-border z-20 overflow-y-auto">
           <InventoryWrapper onClose={() => setOpen(false)} />
         </div>
       )}


### PR DESCRIPTION
## Summary

- At ≥1280px (`xl`), pantry renders as a permanent flex-column sibling — chat narrows instead of being obscured by the floating panel
- At 1024–1279px (`lg`–`xl`), existing absolute overlay behaviour is preserved
- Mobile (< 1024px) and state persistence via `localStorage` are unchanged
- `page.tsx` required no changes — `PantryDrawer` was already a flex sibling

## Why squeeze at xl+

The overlay was clipping recipe cards on the right side of the chat. Squeeze fixes this by giving both chat and pantry dedicated columns. At 1440px chat gets ~844px; at 1280px ~684px — enough for recipe cards without wrapping.

## Test plan

- [ ] At ≥1280px: open pantry → chat narrows, pantry visible as a static column, no content obscured
- [ ] At 1024–1279px: open pantry → pantry floats as an overlay over chat (original behaviour)
- [ ] Collapsed 36px tab visible at both breakpoints
- [ ] Open/closed state persists across page reloads
- [ ] Mobile pantry sheet unaffected

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive behavior of the Pantry Drawer, which now intelligently adapts its layout across different screen sizes for improved usability on various devices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->