### PR TITLE
fix(recipe): make ingredient category optional so old recipes render

### DIFF
--- a/src/lib/recipes/schemas.ts
+++ b/src/lib/recipes/schemas.ts
@@ -22,7 +22,7 @@ export type RecipeStep = z.infer<typeof RecipeStepSchema>;
 // Ingredient as emitted by the model (amounts as strings for scaling)
 export const RecipeIngredientModelSchema = z.object({
   name: z.string(),
-  category: CategorySchema,
+  category: CategorySchema.optional(),
   amount: z.string().optional(),   // string so "1 1/2" works
   unit: z.string().optional(),
   note: z.string().optional(),


### PR DESCRIPTION
## Summary

- `RecipeIngredientModelSchema` had `category` as a required field, but the model was not reliably emitting it (especially before the Spice category PR)
- Recipes saved without `category` failed `RecipeBlockSchema.safeParse()` silently — `extractRecipeBlocks` skipped the block, `stripFences` removed the fence text, leaving only the intro/outro with no card on reload
- Fix: `category: CategorySchema.optional()` — matches the `Ingredient` interface in `RecipeLetter.tsx` which already declared it optional

## Test plan
- [ ] Open a previously broken chat session — recipe card should now render
- [ ] New recipes with category still display correctly (category displayed/used for pantry matching via `ingredientHave`)
- [ ] All 28 jest tests pass (`parseBlocks`, `RecipeLetter`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipe ingredients can now be created without specifying a category field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/101)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->