### PR TITLE
feat(cookbook): recipe photos from Unsplash with attribution

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,9 @@ model Recipe {
   description      String?
   totalTimeMinutes Int?
   createdAt        DateTime?
+  imageUrl         String?
+  photographerName String?
+  photographerUrl  String?
 
   @@map("recipes")
   @@index([userId])

--- a/src/app/api/recipe/route.test.ts
+++ b/src/app/api/recipe/route.test.ts
@@ -30,11 +30,13 @@ jest.mock("@/lib/unsplash/fetchPhoto", () => ({
 }));
 
 import { processRecipe } from "@/lib/recipes/recipeProcessor";
+import { fetchRecipePhoto } from "@/lib/unsplash/fetchPhoto";
 
 const mockedDeleteRecipe = jest.mocked(deleteRecipe);
 const mockedGetRecipes = jest.mocked(getRecipes);
 const mockedSaveRecipe = jest.mocked(saveRecipe);
 const mockedProcessRecipe = jest.mocked(processRecipe);
+const mockedFetchRecipePhoto = jest.mocked(fetchRecipePhoto);
 
 const defaultProcessed = {
   tags: [] as string[],
@@ -296,6 +298,7 @@ describe("Recipe API Routes", () => {
         description: "Dry spice mix for chicken.",
         totalTimeMinutes: 5,
       }, null);
+      expect(mockedFetchRecipePhoto).toHaveBeenCalledWith(["quick"]);
       expect(mockedProcessRecipe).not.toHaveBeenCalled();
     });
 
@@ -352,6 +355,7 @@ describe("Recipe API Routes", () => {
         description: "",
         totalTimeMinutes: undefined,
       }, null);
+      expect(mockedFetchRecipePhoto).toHaveBeenCalledWith(["breakfast"]);
       expect(mockedSaveRecipe).toHaveBeenCalledTimes(1);
     });
 

--- a/src/app/api/recipe/route.test.ts
+++ b/src/app/api/recipe/route.test.ts
@@ -25,6 +25,10 @@ jest.mock("@/lib/recipes/recipeProcessor", () => ({
   processRecipe: jest.fn(),
 }));
 
+jest.mock("@/lib/unsplash/fetchPhoto", () => ({
+  fetchRecipePhoto: jest.fn().mockResolvedValue(null),
+}));
+
 import { processRecipe } from "@/lib/recipes/recipeProcessor";
 
 const mockedDeleteRecipe = jest.mocked(deleteRecipe);
@@ -89,6 +93,9 @@ describe("Recipe API Routes", () => {
           description: null,
           totalTimeMinutes: null,
           createdAt: null,
+          imageUrl: null,
+          photographerName: null,
+          photographerUrl: null,
         },
         {
           id: "recipe-2",
@@ -103,6 +110,9 @@ describe("Recipe API Routes", () => {
           description: null,
           totalTimeMinutes: null,
           createdAt: null,
+          imageUrl: null,
+          photographerName: null,
+          photographerUrl: null,
         },
       ];
 
@@ -183,6 +193,9 @@ describe("Recipe API Routes", () => {
           description: null,
           totalTimeMinutes: null,
           createdAt: null,
+          imageUrl: null,
+          photographerName: null,
+          photographerUrl: null,
         },
       ];
 
@@ -223,6 +236,9 @@ describe("Recipe API Routes", () => {
         description: "Dry spice mix for chicken.",
         totalTimeMinutes: 5,
         createdAt: null,
+        imageUrl: null,
+        photographerName: null,
+        photographerUrl: null,
       };
       mockedSaveRecipe.mockResolvedValue(savedRecipe);
 
@@ -279,7 +295,7 @@ describe("Recipe API Routes", () => {
         steps: [{ title: "Mix", body: "Combine all ingredients." }],
         description: "Dry spice mix for chicken.",
         totalTimeMinutes: 5,
-      });
+      }, null);
       expect(mockedProcessRecipe).not.toHaveBeenCalled();
     });
 
@@ -297,6 +313,9 @@ describe("Recipe API Routes", () => {
         description: null,
         totalTimeMinutes: null,
         createdAt: null,
+        imageUrl: null,
+        photographerName: null,
+        photographerUrl: null,
       };
 
       mockedProcessRecipe.mockResolvedValue({
@@ -332,7 +351,7 @@ describe("Recipe API Routes", () => {
         ingredients: [],
         description: "",
         totalTimeMinutes: undefined,
-      });
+      }, null);
       expect(mockedSaveRecipe).toHaveBeenCalledTimes(1);
     });
 
@@ -350,6 +369,9 @@ describe("Recipe API Routes", () => {
         description: null,
         totalTimeMinutes: null,
         createdAt: null,
+        imageUrl: null,
+        photographerName: null,
+        photographerUrl: null,
       };
 
       mockedProcessRecipe.mockResolvedValue(defaultProcessed);
@@ -380,7 +402,7 @@ describe("Recipe API Routes", () => {
         ingredients: [],
         description: "",
         totalTimeMinutes: undefined,
-      });
+      }, null);
     });
 
     it("should return 400 when userId is missing", async () => {
@@ -439,6 +461,9 @@ describe("Recipe API Routes", () => {
         description: null,
         totalTimeMinutes: null,
         createdAt: null,
+        imageUrl: null,
+        photographerName: null,
+        photographerUrl: null,
       };
 
       mockedProcessRecipe.mockResolvedValue(defaultProcessed);
@@ -471,7 +496,7 @@ describe("Recipe API Routes", () => {
         ingredients: [],
         description: "",
         totalTimeMinutes: undefined,
-      });
+      }, null);
     });
 
     it("should handle special characters in recipe", async () => {
@@ -492,6 +517,9 @@ describe("Recipe API Routes", () => {
         description: null,
         totalTimeMinutes: null,
         createdAt: null,
+        imageUrl: null,
+        photographerName: null,
+        photographerUrl: null,
       };
 
       mockedProcessRecipe.mockResolvedValue(defaultProcessed);
@@ -516,7 +544,7 @@ describe("Recipe API Routes", () => {
         ingredients: [],
         description: "",
         totalTimeMinutes: undefined,
-      });
+      }, null);
     });
 
     it("should handle database errors during save", async () => {
@@ -547,7 +575,7 @@ describe("Recipe API Routes", () => {
         ingredients: [],
         description: "",
         totalTimeMinutes: undefined,
-      });
+      }, null);
     });
 
     it("should handle malformed JSON", async () => {

--- a/src/app/api/recipe/route.ts
+++ b/src/app/api/recipe/route.ts
@@ -1,6 +1,7 @@
 import { deleteRecipe, getRecipes, saveRecipe } from "@/lib/recipes";
 import { processRecipe } from "@/lib/recipes/recipeProcessor";
 import { RecipeIngredientModel } from "@/lib/recipes/schemas";
+import { fetchRecipePhoto } from "@/lib/unsplash/fetchPhoto";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
@@ -23,27 +24,32 @@ export async function POST(req: NextRequest) {
   // New structured path: body.recipe contains the fully-structured object
   if (body.recipe) {
     const r = body.recipe;
-    const recipe = await saveRecipe({
-      userId,
-      name: r.title,
-      instructions: r.description ?? "",  // store description as instructions fallback for legacy reads
-      tags: r.tags ?? [],
-      recipeId,
-      baseServings: r.baseServings,
-      ingredients: r.ingredients.map(
-        (ing: RecipeIngredientModel) => ({
-          name: ing.name,
-          category: ing.category,
-          // Convert string amount to number for storage (legacy RecipeIngredient type uses number)
-          amount: ing.amount ? parseFloat(ing.amount) || undefined : undefined,
-          unit: ing.unit,
-          note: ing.note,
-        })
-      ),
-      steps: r.steps,
-      description: r.description,
-      totalTimeMinutes: r.totalTimeMinutes,
-    });
+    const tags = r.tags ?? [];
+    const photo = await fetchRecipePhoto(tags);
+    const recipe = await saveRecipe(
+      {
+        userId,
+        name: r.title,
+        instructions: r.description ?? "",  // store description as instructions fallback for legacy reads
+        tags,
+        recipeId,
+        baseServings: r.baseServings,
+        ingredients: r.ingredients.map(
+          (ing: RecipeIngredientModel) => ({
+            name: ing.name,
+            category: ing.category,
+            // Convert string amount to number for storage (legacy RecipeIngredient type uses number)
+            amount: ing.amount ? parseFloat(ing.amount) || undefined : undefined,
+            unit: ing.unit,
+            note: ing.note,
+          })
+        ),
+        steps: r.steps,
+        description: r.description,
+        totalTimeMinutes: r.totalTimeMinutes,
+      },
+      photo,
+    );
     return NextResponse.json(recipe);
   }
 
@@ -57,17 +63,21 @@ export async function POST(req: NextRequest) {
     metadata = { tags: [], baseServings: 2, ingredients: [], description: "" };
   }
 
-  const recipe = await saveRecipe({
-    userId,
-    name,
-    instructions,
-    tags: metadata.tags,
-    recipeId,
-    baseServings: metadata.baseServings,
-    ingredients: metadata.ingredients,
-    description: metadata.description,
-    totalTimeMinutes: metadata.totalTimeMinutes,
-  });
+  const legacyPhoto = await fetchRecipePhoto(metadata.tags ?? []);
+  const recipe = await saveRecipe(
+    {
+      userId,
+      name,
+      instructions,
+      tags: metadata.tags,
+      recipeId,
+      baseServings: metadata.baseServings,
+      ingredients: metadata.ingredients,
+      description: metadata.description,
+      totalTimeMinutes: metadata.totalTimeMinutes,
+    },
+    legacyPhoto,
+  );
 
   return NextResponse.json(recipe);
 }

--- a/src/features/RecipeList/components/RecipeCard.tsx
+++ b/src/features/RecipeList/components/RecipeCard.tsx
@@ -1,5 +1,6 @@
 import { RecipeWithId } from "@/lib/recipes/schemas";
 import { getRandomRecipeProcessingMessage, isTempId } from "@/features/Chat/constants";
+import Image from "next/image";
 
 interface RecipeCardProps {
   recipe: RecipeWithId;
@@ -41,19 +42,43 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
       </button>
 
       {/* Image strip */}
-      <div
-        className="h-28 border-b border-border flex items-center justify-center shrink-0"
-        style={{
-          background:
-            "repeating-linear-gradient(135deg, oklch(0.84 0.05 60) 0 8px, oklch(0.80 0.05 60) 8px 16px)",
-        }}
-      >
-        {isOptimistic && (
-          <span className="font-mono text-[10px] tracking-widest text-foreground/40 uppercase">
-            Saving…
-          </span>
-        )}
-      </div>
+      {recipe.imageUrl ? (
+        <div className="h-28 border-b border-border shrink-0 relative overflow-hidden">
+          <Image
+            src={recipe.imageUrl}
+            alt={recipe.name}
+            fill
+            className="object-cover"
+            sizes="(max-width: 640px) 100vw, 320px"
+          />
+          {recipe.photographerName && recipe.photographerUrl && (
+            <a
+              href={recipe.photographerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="absolute bottom-1 right-2 font-sans text-[9px] text-white/70 hover:text-white transition-colors leading-none"
+              style={{ textShadow: "0 1px 2px rgba(0,0,0,0.6)" }}
+            >
+              Photo by {recipe.photographerName}
+            </a>
+          )}
+        </div>
+      ) : (
+        <div
+          className="h-28 border-b border-border flex items-center justify-center shrink-0"
+          style={{
+            background:
+              "repeating-linear-gradient(135deg, oklch(0.84 0.05 60) 0 8px, oklch(0.80 0.05 60) 8px 16px)",
+          }}
+        >
+          {isOptimistic && (
+            <span className="font-mono text-[10px] tracking-widest text-foreground/40 uppercase">
+              Saving…
+            </span>
+          )}
+        </div>
+      )}
 
       {/* Content */}
       <div className="flex flex-col flex-1 p-5 gap-2.5">

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -1,3 +1,4 @@
+import { UnsplashPhoto } from "../unsplash/fetchPhoto";
 import { prisma } from "../db";
 import { Recipe } from "./schemas";
 
@@ -9,9 +10,19 @@ export async function getRecipes(userId: string) {
   return recipes;
 }
 
-export async function saveRecipe(recipe: Recipe) {
+export async function saveRecipe(
+  recipe: Recipe,
+  photo?: UnsplashPhoto | null,
+) {
   return await prisma.recipe.create({
-    data: recipe,
+    data: {
+      ...recipe,
+      ...(photo && {
+        imageUrl: photo.url,
+        photographerName: photo.photographerName,
+        photographerUrl: photo.photographerUrl,
+      }),
+    },
   });
 }
 

--- a/src/lib/recipes/schemas.test.ts
+++ b/src/lib/recipes/schemas.test.ts
@@ -1,14 +1,14 @@
 import { RecipeIngredientModelSchema, RecipeIngredientSchema } from "./schemas";
 
 describe("recipe ingredient schemas", () => {
-  it("requires category on recipe model ingredients", () => {
+  it("allows missing category on recipe model ingredients", () => {
     expect(() =>
       RecipeIngredientModelSchema.parse({
         name: "chicken thigh",
         amount: "500",
         unit: "g",
       }),
-    ).toThrow();
+    ).not.toThrow();
   });
 
   it("requires category on persisted recipe ingredients", () => {

--- a/src/lib/recipes/schemas.ts
+++ b/src/lib/recipes/schemas.ts
@@ -82,4 +82,9 @@ export type Recipe = {
   createdAt?: Date;
 };
 
-export type RecipeWithId = Recipe & { id: string };
+export type RecipeWithId = Recipe & {
+  id: string;
+  imageUrl?: string | null;
+  photographerName?: string | null;
+  photographerUrl?: string | null;
+};

--- a/src/lib/unsplash/fetchPhoto.test.ts
+++ b/src/lib/unsplash/fetchPhoto.test.ts
@@ -1,0 +1,93 @@
+import { fetchRecipePhoto } from "./fetchPhoto";
+
+const MOCK_PHOTO = {
+  urls: { regular: "https://images.unsplash.com/photo-123" },
+  user: {
+    name: "Jane Cook",
+    links: { html: "https://unsplash.com/@janecook" },
+  },
+};
+
+function mockUnsplashResponse(results: unknown[]) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ results }),
+  } as unknown as Response);
+}
+
+beforeEach(() => {
+  process.env.UNSPLASH_ACCESS_KEY = "test-key";
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe("fetchRecipePhoto", () => {
+  it("builds query from first 3 tags and returns photo", async () => {
+    mockUnsplashResponse([MOCK_PHOTO]);
+
+    const result = await fetchRecipePhoto(["stir-fry", "pork", "rice", "spicy"]);
+
+    expect(result).toEqual({
+      url: "https://images.unsplash.com/photo-123",
+      photographerName: "Jane Cook",
+      photographerUrl: expect.stringContaining("https://unsplash.com/@janecook"),
+    });
+
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("query=stir-fry+pork+rice");
+    expect(calledUrl).not.toContain("spicy");
+  });
+
+  it("falls back to 'food cooking' when tags are empty", async () => {
+    mockUnsplashResponse([MOCK_PHOTO]);
+
+    await fetchRecipePhoto([]);
+
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("query=food+cooking");
+  });
+
+  it("retries with 'food cooking' when tag query returns zero results", async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [MOCK_PHOTO] }) } as unknown as Response);
+
+    const result = await fetchRecipePhoto(["obscuredish123"]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    const secondUrl = (global.fetch as jest.Mock).mock.calls[1][0] as string;
+    expect(secondUrl).toContain("query=food+cooking");
+    expect(result?.url).toBe("https://images.unsplash.com/photo-123");
+  });
+
+  it("returns null on network error without throwing", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("network failure"));
+
+    const result = await fetchRecipePhoto(["pork"]);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when API returns non-ok response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const result = await fetchRecipePhoto(["pork"]);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when UNSPLASH_ACCESS_KEY is not set", async () => {
+    delete process.env.UNSPLASH_ACCESS_KEY;
+    global.fetch = jest.fn();
+
+    const result = await fetchRecipePhoto(["pork"]);
+
+    expect(result).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/unsplash/fetchPhoto.ts
+++ b/src/lib/unsplash/fetchPhoto.ts
@@ -1,0 +1,55 @@
+const UNSPLASH_API = "https://api.unsplash.com";
+const FALLBACK_QUERY = "food cooking";
+
+export interface UnsplashPhoto {
+  url: string;
+  photographerName: string;
+  photographerUrl: string;
+}
+
+async function search(query: string): Promise<UnsplashPhoto | null> {
+  const accessKey = process.env.UNSPLASH_ACCESS_KEY;
+  if (!accessKey) return null;
+
+  const params = new URLSearchParams({
+    query,
+    orientation: "landscape",
+    per_page: "1",
+  });
+
+  const res = await fetch(`${UNSPLASH_API}/search/photos?${params}`, {
+    headers: { Authorization: `Client-ID ${accessKey}` },
+    next: { revalidate: 0 },
+  });
+
+  if (!res.ok) return null;
+
+  const data = await res.json();
+  const photo = data?.results?.[0];
+  if (!photo) return null;
+
+  return {
+    url: photo.urls.regular,
+    photographerName: photo.user.name,
+    photographerUrl: `${photo.user.links.html}?utm_source=ask_ah_mah&utm_medium=referral`,
+  };
+}
+
+export async function fetchRecipePhoto(
+  tags: string[],
+): Promise<UnsplashPhoto | null> {
+  try {
+    const query =
+      tags.length > 0 ? tags.slice(0, 3).join(" ") : FALLBACK_QUERY;
+    const result = await search(query);
+    if (result) return result;
+
+    // Retry with fallback if tag query returned no results
+    if (query !== FALLBACK_QUERY) {
+      return await search(FALLBACK_QUERY);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/unsplash/fetchPhoto.ts
+++ b/src/lib/unsplash/fetchPhoto.ts
@@ -17,10 +17,15 @@ async function search(query: string): Promise<UnsplashPhoto | null> {
     per_page: "1",
   });
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
   const res = await fetch(`${UNSPLASH_API}/search/photos?${params}`, {
     headers: { Authorization: `Client-ID ${accessKey}` },
     next: { revalidate: 0 },
+    signal: controller.signal,
   });
+  clearTimeout(timeout);
 
   if (!res.ok) return null;
 


### PR DESCRIPTION
## Summary

- Adds `imageUrl`, `photographerName`, `photographerUrl` nullable fields to the `Recipe` model (schema push — migration history drifted, used `db push`)
- New server-side `fetchRecipePhoto` utility queries Unsplash by top 3 recipe tags, falls back to `"food cooking"`, returns null gracefully on errors
- `/api/recipe` POST fetches a photo at save time for both structured and legacy paths
- `RecipeCard` renders the photo via Next.js `<Image>` when present, with a small "Photo by [name]" attribution overlay; falls back to striped placeholder
- `RecipeIngredientModelSchema.category` made optional so legacy saved recipes without category now parse and render (closes the recipe-disappearing bug fix from #101)

Closes #103, #104, #105

## Test plan
- [ ] Add `UNSPLASH_ACCESS_KEY` to `.env.local` and save a new recipe — photo should appear on the cookbook card
- [ ] Verify attribution credit shows and links to photographer profile
- [ ] Existing saved recipes (no imageUrl) show striped placeholder with no regression
- [ ] Remove `UNSPLASH_ACCESS_KEY` and save a recipe — save should succeed with null imageUrl
- [ ] All tests pass: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipes now display images fetched from Unsplash, enhancing visual presentation of saved recipes
  * Photographer attribution links included with images when available

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/106)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->