### PR TITLE
fix(recipe): accept null from model for optional ingredient fields

### DIFF
--- a/src/lib/recipes/schemas.ts
+++ b/src/lib/recipes/schemas.ts
@@ -22,10 +22,10 @@ export type RecipeStep = z.infer<typeof RecipeStepSchema>;
 // Ingredient as emitted by the model (amounts as strings for scaling)
 export const RecipeIngredientModelSchema = z.object({
   name: z.string(),
-  category: CategorySchema.optional(),
-  amount: z.string().optional(),   // string so "1 1/2" works
-  unit: z.string().optional(),
-  note: z.string().optional(),
+  category: CategorySchema.nullish().transform((v) => v ?? undefined),
+  amount: z.string().nullish().transform((v) => v ?? undefined),   // string so "1 1/2" works
+  unit: z.string().nullish().transform((v) => v ?? undefined),
+  note: z.string().nullish().transform((v) => v ?? undefined),
 });
 export type RecipeIngredientModel = z.infer<typeof RecipeIngredientModelSchema>;
 


### PR DESCRIPTION
## Summary

- The model emits `"unit": null` for ingredients with no unit (e.g. "a pinch of dried chili"). Zod's `.optional()` rejects `null`, so `RecipeBlockSchema.safeParse()` was failing silently — recipe card never rendered, prose text still showed.
- Changed `RecipeIngredientModelSchema` optional fields (`category`, `amount`, `unit`, `note`) to `.nullish().transform(v => v ?? undefined)`, normalising `null → undefined` at parse time.
- Output type stays `string | undefined` so no downstream components (`RecipeLetter`, etc.) needed updating.

## Test plan

- [ ] Run `pnpm tsc --noEmit` — no new type errors
- [ ] Run `pnpm test` — no regressions vs. baseline
- [ ] In the app, trigger a recipe where an ingredient has no unit (e.g. "a pinch of dried chili") — recipe card should render
- [ ] Confirm Save button appears and saving works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced recipe ingredient field handling to better process cases where category, amount, unit, or note values are missing or null.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->