### PR TITLE
fix(recipe): use recipe title as Unsplash search query instead of tags

### DIFF
--- a/src/app/api/recipe/route.ts
+++ b/src/app/api/recipe/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
   if (body.recipe) {
     const r = body.recipe;
     const tags = r.tags ?? [];
-    const photo = await fetchRecipePhoto(tags);
+    const photo = await fetchRecipePhoto(r.title, tags);
     const recipe = await saveRecipe(
       {
         userId,
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
     metadata = { tags: [], baseServings: 2, ingredients: [], description: "" };
   }
 
-  const legacyPhoto = await fetchRecipePhoto(metadata.tags ?? []);
+  const legacyPhoto = await fetchRecipePhoto(name, metadata.tags ?? []);
   const recipe = await saveRecipe(
     {
       userId,

--- a/src/lib/unsplash/fetchPhoto.test.ts
+++ b/src/lib/unsplash/fetchPhoto.test.ts
@@ -24,10 +24,10 @@ afterEach(() => {
 });
 
 describe("fetchRecipePhoto", () => {
-  it("builds query from first 3 tags and returns photo", async () => {
+  it("uses the recipe title as the primary query", async () => {
     mockUnsplashResponse([MOCK_PHOTO]);
 
-    const result = await fetchRecipePhoto(["stir-fry", "pork", "rice", "spicy"]);
+    const result = await fetchRecipePhoto("Economy Fried Bee Hoon", ["stir-fry", "quick", "budget"]);
 
     expect(result).toEqual({
       url: "https://images.unsplash.com/photo-123",
@@ -36,25 +36,36 @@ describe("fetchRecipePhoto", () => {
     });
 
     const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("query=Economy+Fried+Bee+Hoon");
+    expect(calledUrl).not.toContain("budget");
+    expect(calledUrl).not.toContain("stir-fry");
+  });
+
+  it("falls back to tags when title is empty", async () => {
+    mockUnsplashResponse([MOCK_PHOTO]);
+
+    await fetchRecipePhoto("", ["stir-fry", "pork", "rice", "spicy"]);
+
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
     expect(calledUrl).toContain("query=stir-fry+pork+rice");
     expect(calledUrl).not.toContain("spicy");
   });
 
-  it("falls back to 'food cooking' when tags are empty", async () => {
+  it("falls back to 'food cooking' when both title and tags are empty", async () => {
     mockUnsplashResponse([MOCK_PHOTO]);
 
-    await fetchRecipePhoto([]);
+    await fetchRecipePhoto("", []);
 
     const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
     expect(calledUrl).toContain("query=food+cooking");
   });
 
-  it("retries with 'food cooking' when tag query returns zero results", async () => {
+  it("retries with 'food cooking' when primary query returns zero results", async () => {
     global.fetch = jest.fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) } as unknown as Response)
       .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [MOCK_PHOTO] }) } as unknown as Response);
 
-    const result = await fetchRecipePhoto(["obscuredish123"]);
+    const result = await fetchRecipePhoto("obscuredish123", []);
 
     expect(global.fetch).toHaveBeenCalledTimes(2);
     const secondUrl = (global.fetch as jest.Mock).mock.calls[1][0] as string;
@@ -65,7 +76,7 @@ describe("fetchRecipePhoto", () => {
   it("returns null on network error without throwing", async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error("network failure"));
 
-    const result = await fetchRecipePhoto(["pork"]);
+    const result = await fetchRecipePhoto("pork", []);
 
     expect(result).toBeNull();
   });
@@ -76,7 +87,7 @@ describe("fetchRecipePhoto", () => {
       json: async () => ({}),
     } as unknown as Response);
 
-    const result = await fetchRecipePhoto(["pork"]);
+    const result = await fetchRecipePhoto("pork", []);
 
     expect(result).toBeNull();
   });
@@ -85,7 +96,7 @@ describe("fetchRecipePhoto", () => {
     delete process.env.UNSPLASH_ACCESS_KEY;
     global.fetch = jest.fn();
 
-    const result = await fetchRecipePhoto(["pork"]);
+    const result = await fetchRecipePhoto("pork", []);
 
     expect(result).toBeNull();
     expect(global.fetch).not.toHaveBeenCalled();

--- a/src/lib/unsplash/fetchPhoto.ts
+++ b/src/lib/unsplash/fetchPhoto.ts
@@ -41,15 +41,18 @@ async function search(query: string): Promise<UnsplashPhoto | null> {
 }
 
 export async function fetchRecipePhoto(
-  tags: string[],
+  title: string,
+  tags: string[] = [],
 ): Promise<UnsplashPhoto | null> {
   try {
+    const trimmedTitle = title.trim();
     const query =
-      tags.length > 0 ? tags.slice(0, 3).join(" ") : FALLBACK_QUERY;
+      trimmedTitle ||
+      (tags.length > 0 ? tags.slice(0, 3).join(" ") : FALLBACK_QUERY);
     const result = await search(query);
     if (result) return result;
 
-    // Retry with fallback if tag query returned no results
+    // Retry with fallback if primary query returned no results
     if (query !== FALLBACK_QUERY) {
       return await search(FALLBACK_QUERY);
     }


### PR DESCRIPTION
## Summary

- Tags like `budget`, `quick`, `comfort` are style descriptors that Unsplash treats literally — `"stir-fry quick budget"` returned a calculator photo for Economy Fried Bee Hoon.
- The recipe title is a far stronger food-domain signal and reliably retrieves the right dish image.
- `fetchRecipePhoto` now takes `(title, tags?)` — queries by title first, falls back to tags if title is empty, then to `"food cooking"` if both return no results.
- Updated both call sites in `/api/recipe/route.ts` (structured and legacy paths).
- Updated and expanded the test suite (7 tests, all passing).

## Test plan

- [ ] `pnpm test src/lib/unsplash/fetchPhoto.test.ts` — 7/7 pass
- [ ] `pnpm tsc --noEmit` — no new type errors
- [ ] Save the Economy Fried Bee Hoon recipe in the app — photo should be bee hoon / noodles, not a calculator

🤖 Generated with [Claude Code](https://claude.com/claude-code)