### PR TITLE
fix(recipe): accept null from model for optional ingredient fields

### DIFF
--- a/src/lib/recipes/schemas.ts
+++ b/src/lib/recipes/schemas.ts
@@ -22,10 +22,10 @@ export type RecipeStep = z.infer<typeof RecipeStepSchema>;
 // Ingredient as emitted by the model (amounts as strings for scaling)
 export const RecipeIngredientModelSchema = z.object({
   name: z.string(),
-  category: CategorySchema.optional(),
-  amount: z.string().optional(),   // string so "1 1/2" works
-  unit: z.string().optional(),
-  note: z.string().optional(),
+  category: CategorySchema.nullish().transform((v) => v ?? undefined),
+  amount: z.string().nullish().transform((v) => v ?? undefined),   // string so "1 1/2" works
+  unit: z.string().nullish().transform((v) => v ?? undefined),
+  note: z.string().nullish().transform((v) => v ?? undefined),
 });
 export type RecipeIngredientModel = z.infer<typeof RecipeIngredientModelSchema>;
 


### PR DESCRIPTION
The model emits `"unit": null` for ingredients with no meaningful unit (e.g. "a pinch of dried chili"). Zod's `.optional()` only accepts `string | undefined`, so `safeParse` was failing silently and dropping the entire recipe block — card never rendered, prose still showed.

Switch RecipeIngredientModelSchema optional fields to `.nullish()` with a transform to normalise `null → undefined`, keeping the output type unchanged so no downstream components need updating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated recipe ingredient data validation to improve consistency when handling empty or null fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/110)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->