### PR TITLE
chore(styles): fix jarring hover colours and split accent/jade design tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,57 +56,57 @@
   /* Page shell — aged newsprint */
   --background: oklch(0.945 0.024 75);
   /* Soy ink */
-  --foreground: oklch(0.265 0.040 48);
+  --foreground: oklch(0.265 0.04 48);
 
   /* Cards inside tray — cream paper, *lighter* than bg so they pop out */
   --card: oklch(0.975 0.022 80);
-  --card-foreground: oklch(0.265 0.040 48);
+  --card-foreground: oklch(0.265 0.04 48);
   --popover: oklch(0.975 0.022 80);
-  --popover-foreground: oklch(0.265 0.040 48);
+  --popover-foreground: oklch(0.265 0.04 48);
 
   /* Chat scroll area — freshest, lightest surface */
   --chat: oklch(0.985 0.018 82);
 
   /* Inventory / cookbook tray — kraft, distinctly darker than page */
-  --muted: oklch(0.905 0.030 70);
+  --muted: oklch(0.905 0.03 70);
   /* Pencil */
-  --muted-foreground: oklch(0.460 0.038 52);
+  --muted-foreground: oklch(0.46 0.038 52);
   /* Faint ink */
-  --ink-faint: oklch(0.605 0.030 60);
+  --ink-faint: oklch(0.605 0.03 60);
 
   /* Terracotta primary */
   --primary: oklch(0.56 0.135 35);
   --primary-foreground: oklch(0.97 0.02 80);
 
   /* Butter — user message bubbles */
-  --secondary: oklch(0.860 0.100 88);
-  --secondary-foreground: oklch(0.265 0.040 48);
+  --secondary: oklch(0.86 0.1 88);
+  --secondary-foreground: oklch(0.265 0.04 48);
 
-  --accent: oklch(0.50 0.095 168);
+  --accent: oklch(0.5 0.095 168);
   --accent-foreground: oklch(0.97 0.02 80);
   --destructive: oklch(0.56 0.21 25);
 
   /* Stained paper edge — warmer and darker than before */
   --border: oklch(0.815 0.038 70);
-  --border-soft: oklch(0.870 0.030 72);
+  --border-soft: oklch(0.87 0.03 72);
   --input: oklch(0.815 0.038 70);
   --ring: oklch(0.56 0.135 35);
 
   --chart-1: oklch(0.56 0.135 35);
-  --chart-2: oklch(0.50 0.095 168);
-  --chart-3: oklch(0.70 0.13 75);
-  --chart-4: oklch(0.86 0.10 88);
+  --chart-2: oklch(0.5 0.095 168);
+  --chart-3: oklch(0.7 0.13 75);
+  --chart-4: oklch(0.86 0.1 88);
   --chart-5: oklch(0.56 0.21 25);
   --sidebar: oklch(0.975 0.022 80);
-  --sidebar-foreground: oklch(0.265 0.040 48);
+  --sidebar-foreground: oklch(0.265 0.04 48);
   --sidebar-primary: oklch(0.56 0.135 35);
   --sidebar-primary-foreground: oklch(0.97 0.02 80);
-  --sidebar-accent: oklch(0.905 0.030 70);
-  --sidebar-accent-foreground: oklch(0.265 0.040 48);
+  --sidebar-accent: oklch(0.905 0.03 70);
+  --sidebar-accent-foreground: oklch(0.265 0.04 48);
   --sidebar-border: oklch(0.815 0.038 70);
   --sidebar-ring: oklch(0.56 0.135 35);
 
-  --tertiary: oklch(0.70 0.13 75);
+  --tertiary: oklch(0.7 0.13 75);
 }
 
 .dark {
@@ -120,12 +120,12 @@
   --chat: oklch(0.25 0.025 50);
   --primary: oklch(0.66 0.14 35);
   --primary-foreground: oklch(0.22 0.028 50);
-  --secondary: oklch(0.50 0.075 88);
+  --secondary: oklch(0.5 0.075 88);
   --secondary-foreground: oklch(0.95 0.025 78);
-  --muted: oklch(0.30 0.025 50);
-  --muted-foreground: oklch(0.70 0.03 60);
+  --muted: oklch(0.3 0.025 50);
+  --muted-foreground: oklch(0.7 0.03 60);
   --ink-faint: oklch(0.55 0.025 55);
-  --accent: oklch(0.60 0.10 168);
+  --accent: oklch(0.6 0.1 168);
   --accent-foreground: oklch(0.95 0.025 78);
   --destructive: oklch(0.66 0.18 25);
   --border: oklch(1 0 0 / 12%);
@@ -133,15 +133,15 @@
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.66 0.14 35);
   --chart-1: oklch(0.66 0.14 35);
-  --chart-2: oklch(0.60 0.10 168);
+  --chart-2: oklch(0.6 0.1 168);
   --chart-3: oklch(0.75 0.12 78);
-  --chart-4: oklch(0.50 0.075 88);
+  --chart-4: oklch(0.5 0.075 88);
   --chart-5: oklch(0.66 0.18 25);
   --sidebar: oklch(0.28 0.03 50);
   --sidebar-foreground: oklch(0.95 0.025 78);
   --sidebar-primary: oklch(0.66 0.14 35);
   --sidebar-primary-foreground: oklch(0.22 0.028 50);
-  --sidebar-accent: oklch(0.30 0.025 50);
+  --sidebar-accent: oklch(0.3 0.025 50);
   --sidebar-accent-foreground: oklch(0.95 0.025 78);
   --sidebar-border: oklch(1 0 0 / 12%);
   --sidebar-ring: oklch(0.66 0.14 35);
@@ -212,30 +212,59 @@ blockquote {
 
 /* Loader animations */
 @keyframes ahmah-dot {
-  0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
-  40%           { transform: translateY(-3px); opacity: 1; }
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.35;
+  }
+  40% {
+    transform: translateY(-3px);
+    opacity: 1;
+  }
 }
 @keyframes ahmah-shimmer {
-  0%   { background-position: -200% 0; }
-  100% { background-position: 200% 0; }
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
 }
 @keyframes ahmah-pulse-soft {
-  0%, 100% { opacity: 0.55; }
-  50%      { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 @keyframes ahmah-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 @keyframes ahmah-pen {
-  0%   { transform: translateX(0) rotate(-8deg); }
-  50%  { transform: translateX(2px) rotate(-6deg); }
-  100% { transform: translateX(0) rotate(-8deg); }
+  0% {
+    transform: translateX(0) rotate(-8deg);
+  }
+  50% {
+    transform: translateX(2px) rotate(-6deg);
+  }
+  100% {
+    transform: translateX(0) rotate(-8deg);
+  }
 }
 
 /* Recipe letter — scaled amount pulse animation */
 @keyframes scaledPulse {
-  0%   { background-color: oklch(0.86 0.14 60 / 0.7); }
-  100% { background-color: oklch(0.95 0.05 88 / 0.5); }
+  0% {
+    background-color: oklch(0.86 0.14 60 / 0.7);
+  }
+  100% {
+    background-color: oklch(0.95 0.05 88 / 0.5);
+  }
 }
 
 .scaled-num-pulse {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,6 +47,8 @@
   --radius-xl: calc(var(--radius) + 4px);
 
   --color-tertiary: var(--tertiary);
+  --color-jade: var(--jade);
+  --color-jade-foreground: var(--jade-foreground);
 }
 
 :root {
@@ -82,8 +84,13 @@
   --secondary: oklch(0.86 0.1 88);
   --secondary-foreground: oklch(0.265 0.04 48);
 
-  --accent: oklch(0.5 0.095 168);
-  --accent-foreground: oklch(0.97 0.02 80);
+  /* Jade — decorative accent ink (chips, pills, dots) */
+  --jade: oklch(0.5 0.095 168);
+  --jade-foreground: oklch(0.97 0.02 80);
+
+  /* Accent — neutral interactive hover surface (kraft, paper-toned) */
+  --accent: oklch(0.89 0.028 70);
+  --accent-foreground: oklch(0.265 0.04 48);
   --destructive: oklch(0.56 0.21 25);
 
   /* Stained paper edge — warmer and darker than before */
@@ -125,7 +132,9 @@
   --muted: oklch(0.3 0.025 50);
   --muted-foreground: oklch(0.7 0.03 60);
   --ink-faint: oklch(0.55 0.025 55);
-  --accent: oklch(0.6 0.1 168);
+  --jade: oklch(0.6 0.1 168);
+  --jade-foreground: oklch(0.95 0.025 78);
+  --accent: oklch(0.34 0.025 50);
   --accent-foreground: oklch(0.95 0.025 78);
   --destructive: oklch(0.66 0.18 25);
   --border: oklch(1 0 0 / 12%);
@@ -206,7 +215,7 @@ ol li::marker {
 }
 
 blockquote {
-  border-left: 3px solid var(--accent);
+  border-left: 3px solid var(--jade);
   padding-left: 0.5em;
 }
 

--- a/src/components/AboutPopOver/index.tsx
+++ b/src/components/AboutPopOver/index.tsx
@@ -52,7 +52,7 @@ export default function AboutPopOver({
       <PopoverContent
         side="bottom"
         align={popoverAlign}
-        className="w-[600px] max-w-[95vw]"
+        className="w-150 max-w-[95vw]"
       >
         <div className="space-y-2">
           <h4 className="font-medium leading-none">About Ask Ah Mah</h4>

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -281,7 +281,7 @@ const Chat = () => {
               <path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
             </svg>
           </button>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-1.5">
           <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
             <AlertDialogTrigger asChild>
               <Button
@@ -290,7 +290,7 @@ const Chat = () => {
                 disabled={messageCount === 0}
                 aria-label="Delete conversation"
                 title={messageCount === 0 ? "Nothing to delete yet" : undefined}
-                className="cursor-pointer text-ink-faint hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
+                className="cursor-pointer text-ink-faint hover:text-destructive hover:bg-destructive/10 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 <Trash2 className="size-4" />
               </Button>

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -107,7 +107,7 @@ function HaveTag({
       <span
         className={cn(
           BASE,
-          "text-accent bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)]",
+          "text-jade bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)]",
         )}
       >
         HAVE
@@ -235,7 +235,7 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
               <span className="text-border">·</span>
             )}
             {showPantryPill && (
-              <span className="font-sans text-[10px] font-semibold text-accent px-1.5 py-0.5 bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)] rounded-full tracking-normal normal-case">
+              <span className="font-sans text-[10px] font-semibold text-jade px-1.5 py-0.5 bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)] rounded-full tracking-normal normal-case">
                 {haveCount}/{recipe.ingredients.length} in your pantry
               </span>
             )}
@@ -339,7 +339,7 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
           {isSaved ? (
             <button
               disabled
-              className="px-3 py-1.5 font-sans text-xs font-semibold text-accent bg-transparent border border-border rounded-lg cursor-not-allowed inline-flex items-center gap-1 opacity-80"
+              className="px-3 py-1.5 font-sans text-xs font-semibold text-jade bg-transparent border border-border rounded-lg cursor-not-allowed inline-flex items-center gap-1 opacity-80"
             >
               <svg
                 width="11"

--- a/src/features/Chat/components/recipe/SuggestionsBlock.tsx
+++ b/src/features/Chat/components/recipe/SuggestionsBlock.tsx
@@ -124,13 +124,13 @@ function SuggestionCard({
         <span
           className={cn(
             'inline-flex items-center gap-1.5 font-sans text-xs font-semibold',
-            haveAll ? 'text-accent' : 'text-[oklch(0.42_0.18_25)]'
+            haveAll ? 'text-jade' : 'text-[oklch(0.42_0.18_25)]'
           )}
         >
           <span
             className={cn(
               'size-[7px] rounded-full shrink-0',
-              haveAll ? 'bg-accent' : 'bg-[oklch(0.6_0.18_25)]'
+              haveAll ? 'bg-jade' : 'bg-[oklch(0.6_0.18_25)]'
             )}
           />
           {total === 0

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -222,7 +222,7 @@ function LegacyRecipeBody({
               <div className="flex items-center gap-3.5 font-sans text-[12px] text-muted-foreground">
                 {inPantryCount > 0 && (
                   <span className="inline-flex items-center gap-1.5">
-                    <span className="w-2 h-2 rounded-full bg-accent" />
+                    <span className="w-2 h-2 rounded-full bg-jade" />
                     {inPantryCount} in pantry
                   </span>
                 )}
@@ -250,7 +250,7 @@ function LegacyRecipeBody({
                   </span>
                   {inPantry && (
                     <span
-                      className="font-sans text-[10.5px] font-semibold px-[7px] py-[2px] rounded-full tracking-wide shrink-0 text-accent border"
+                      className="font-sans text-[10.5px] font-semibold px-[7px] py-[2px] rounded-full tracking-wide shrink-0 text-jade border"
                       style={{
                         background: "oklch(0.94 0.04 168)",
                         borderColor: "oklch(0.78 0.07 168)",


### PR DESCRIPTION
## Summary

- **Root cause**: `--accent` was doing double duty as the shadcn interactive hover surface *and* the decorative jade ink colour. Every ghost-button hover (trash icon, Cancel, Select focus rings) flashed vivid green on the warm cream paper — jarring and semantically wrong on a delete affordance.
- **Token split**: `--accent` is now a paper-toned kraft surface (`oklch(0.89 0.028 70)`) aligned with shadcn semantics; a new `--jade` token (`oklch(0.5 0.095 168)`) carries the decorative role, exposed as `text-jade` / `bg-jade` in Tailwind via `@theme`.
- **Decorative uses migrated**: `RecipeLetter`, `SuggestionsBlock`, `RecipeDisplay` updated from `text-accent`/`bg-accent` → `text-jade`/`bg-jade`; blockquote border preserved with `var(--jade)`.
- **Trash button**: hover now applies `hover:text-destructive hover:bg-destructive/10` — a soft terracotta wash that signals the action's intent.
- **Header polish**: trash + primary CTA wrapper changed to `items-center gap-1.5` for better baseline alignment.
- Also includes a prior commit normalising OKLCH values and expanding keyframes in `AboutPopOver`.

## Test plan

- [ ] Hover the trash icon — soft terracotta wash, **not** green
- [ ] Hover "+ New conversation" — unchanged (primary terracotta)
- [ ] Hover any ghost/outline surface (AlertDialog Cancel, Select options) — paper-toned, not jade
- [ ] Recipe letter with pantry items — "HAVE" chip, pantry pill still jade
- [ ] `RecipeDisplay` ingredients section dot and "in pantry" label still jade
- [ ] Blockquote left border still jade
- [ ] Dark mode: repeat above
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Introduced new jade color theme, replacing accent colors throughout the interface for improved visual consistency
  * Enhanced chat header layout with refined spacing and added visual feedback for delete actions
  * Optimized component widths for better responsive design
  * Updated pantry and recipe status indicators to align with the new color scheme

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/112)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->