### PR TITLE
fix(ux): design-critique quick wins — trash placement, pantry copy, shelf-life legend

### DIFF
--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -1,16 +1,5 @@
 "use client";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { useConversationContext } from "@/contexts/ConversationContext";
 import { useSessionContext } from "@/contexts/SessionContext";
@@ -24,7 +13,6 @@ import { upperCaseFirstLetter } from "@/lib/utils";
 import { fetcher } from "@/lib/utils/index";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
-import { Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
@@ -54,7 +42,6 @@ const Chat = () => {
     deleteActiveConversation,
   } = useConversationContext();
   const [convSheetOpen, setConvSheetOpen] = useState(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
   const autoTitledConversations = useRef<Set<string>>(new Set());
   const autoTitlingConversations = useRef<Set<string>>(new Set());
@@ -247,7 +234,6 @@ const Chat = () => {
 
   const handleDeleteConversation = async () => {
     await deleteActiveConversation();
-    setDeleteDialogOpen(false);
   };
 
   return (
@@ -263,6 +249,8 @@ const Chat = () => {
             <ConversationTitle
               title={activeConversation?.title}
               onRename={renameActiveConversation}
+              onDelete={handleDeleteConversation}
+              canDelete={messageCount > 0}
             />
             <div className="text-[11.5px] text-ink-faint mt-0.5 tracking-wide">
               {messageCount > 0
@@ -281,38 +269,6 @@ const Chat = () => {
               <path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
             </svg>
           </button>
-        <div className="flex items-center gap-1.5">
-          <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-            <AlertDialogTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={messageCount === 0}
-                aria-label="Delete conversation"
-                title={messageCount === 0 ? "Nothing to delete yet" : undefined}
-                className="cursor-pointer text-ink-faint hover:text-destructive hover:bg-destructive/10 disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                <Trash2 className="size-4" />
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete this conversation?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This cannot be undone. Saved recipes are kept.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={handleDeleteConversation}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                >
-                  Delete
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
           <Button
             size="sm"
             onClick={() => startNewConversation()}
@@ -322,7 +278,6 @@ const Chat = () => {
           >
             + New conversation
           </Button>
-        </div>
       </div>
       <MessageList
         messages={allMessages}

--- a/src/features/Chat/components/ConversationTitle.tsx
+++ b/src/features/Chat/components/ConversationTitle.tsx
@@ -1,5 +1,17 @@
 "use client";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Trash2 } from "lucide-react";
 import { useRef, useState } from "react";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -13,11 +25,15 @@ export function getTitleFallback(): string {
 interface ConversationTitleProps {
   title: string | null | undefined;
   onRename: (title: string) => Promise<void>;
+  onDelete: () => Promise<void>;
+  canDelete: boolean;
 }
 
 export default function ConversationTitle({
   title,
   onRename,
+  onDelete,
+  canDelete,
 }: ConversationTitleProps) {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState("");
@@ -100,6 +116,35 @@ export default function ConversationTitle({
           />
         </svg>
       </button>
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <button
+            disabled={!canDelete}
+            aria-label="Delete conversation"
+            title={!canDelete ? "Nothing to delete yet" : undefined}
+            className="text-ink-faint hover:text-destructive hover:bg-destructive/10 rounded-sm p-0.5 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Trash2 size={12} />
+          </button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this conversation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This cannot be undone. Saved recipes are kept.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={onDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -111,6 +111,9 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
   const kitchenwareSorted = kitchenwareInventory?.sort((a, b) =>
     a.name.localeCompare(b.name)
   );
+  const hasShortShelfItem =
+    (ingredientInventory ?? []).some((i) => i.shelfLife === "short") ||
+    (kitchenwareInventory ?? []).some((i) => i.shelfLife === "short");
 
   return (
     <div className="flex flex-col gap-4 animate-in fade-in duration-300 p-5 h-full">
@@ -120,7 +123,13 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
           <div className="font-display italic font-medium text-[22px] text-foreground leading-tight tracking-tight">
             Pantry
           </div>
-          <div className="text-xs text-ink-faint mt-0.5">What&rsquo;s on Ah Mah&rsquo;s shelves</div>
+          <div className="text-xs text-ink-faint mt-0.5">What&rsquo;s in your kitchen</div>
+          {hasShortShelfItem && (
+            <div className="flex items-center gap-1.5 mt-1 text-[11px] text-ink-faint">
+              <span className="inline-block h-2 w-2 rounded-full bg-tertiary shrink-0" />
+              Short shelf life — use soon
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           {onClose && (


### PR DESCRIPTION
## Summary

Three focused fixes from a design critique, chosen for high impact / low risk:

- **Trash → title row**: the delete icon was sitting directly adjacent to `+ New conversation` (destructive next to constructive, easy misclick). Moved it next to the rename pencil in `ConversationTitle` where all conversation-mutation actions now live. The primary CTA stands alone. AlertDialog confirm moves with it; `Chat.tsx` sheds the now-unused state, imports, and JSX block.

- **Pantry subtitle copy**: "What's on Ah Mah's shelves" → "What's in your kitchen". The Ah Mah persona belongs to the chatbot, not the user's pantry data.

- **Short-shelf-life legend**: the butter-coloured dot on pantry items (meaning "use soon") was only discoverable via desktop hover. A one-line legend now appears below the pantry subtitle whenever ≥1 item has `shelfLife === "short"`, using the same `bg-tertiary` token as the badge dot for consistent encoding.

## Test plan

- [ ] Chat header right side shows **only** `+ New conversation` — no trash icon
- [ ] Conversation title row shows `<title> ✏️ 🗑`. Click trash → AlertDialog ("Delete this conversation? This cannot be undone.") → Cancel dismisses, Delete removes
- [ ] With zero messages, trash icon in title row is disabled (opacity-40, "Nothing to delete yet" tooltip)
- [ ] Pantry rail subtitle reads **"What's in your kitchen"**
- [ ] With a short-shelf-life item present: `● Short shelf life — use soon` legend appears under the subtitle
- [ ] Remove all short-shelf items: legend disappears
- [ ] `pnpm test` — same pass/fail count as `main` (6 pre-existing failures, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)