### PR TITLE
fix(suggestions): flip pantry badge to 'All set ✓' when all ingredients present

### DIFF
--- a/src/features/Chat/components/recipe/SuggestionsBlock.tsx
+++ b/src/features/Chat/components/recipe/SuggestionsBlock.tsx
@@ -136,7 +136,7 @@ function SuggestionCard({
           {total === 0
             ? 'Pantry check N/A'
             : haveAll
-              ? `All ${total} in pantry`
+              ? 'All set ✓'
               : `${have}/${total} in pantry · short ${missing.length}`}
         </span>
         <div className="flex-1" />


### PR DESCRIPTION
## Summary

- When all key ingredients for a suggestion are in the pantry, the badge now reads **"All set ✓"** instead of the fraction "All 4 in pantry"
- When ingredients are missing, the existing "X/Y in pantry · short N" label is unchanged
- One-line change in `SuggestionsBlock.tsx`

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)