### PR TITLE
fix(ux): servings stepper adjacent to ingredient list; merge tiny pantry categories

### DIFF
--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -222,46 +222,42 @@ export function RecipeLetter({ recipe, onSave, isSaved }: RecipeLetterProps) {
         </div>
       )}
 
-      {/* Meta row — time · pantry pill on left, servings stepper on right */}
-      <div className="flex items-center gap-3 mb-4 pb-3 border-b border-dashed border-border">
-          <div className="flex items-center gap-2.5 text-muted-foreground">
-            {timeLabel && (
-              <span className="font-mono text-xs flex items-center gap-1">
-                <TimerIcon className="w-3.5 h-3.5" />
-                {timeLabel}
-              </span>
-            )}
-            {timeLabel && showPantryPill && (
-              <span className="text-border">·</span>
-            )}
-            {showPantryPill && (
-              <span className="font-sans text-[10px] font-semibold text-jade px-1.5 py-0.5 bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)] rounded-full tracking-normal normal-case">
-                {haveCount}/{recipe.ingredients.length} in your pantry
-              </span>
-            )}
-          </div>
-          <div className="flex-1" />
-          <span className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
-            Servings
-          </span>
-          <ServingsStepper
-            servings={servings}
-            baseServings={recipe.baseServings}
-            onDecrement={() => setServings((s) => Math.max(1, s - 1))}
-            onIncrement={() => setServings((s) => Math.min(12, s + 1))}
-          />
+      {/* Meta row — time · pantry pill */}
+      {(timeLabel || showPantryPill) && (
+        <div className="flex items-center gap-2.5 text-muted-foreground mb-4 pb-3 border-b border-dashed border-border">
+          {timeLabel && (
+            <span className="font-mono text-xs flex items-center gap-1">
+              <TimerIcon className="w-3.5 h-3.5" />
+              {timeLabel}
+            </span>
+          )}
+          {timeLabel && showPantryPill && (
+            <span className="text-border">·</span>
+          )}
+          {showPantryPill && (
+            <span className="font-sans text-[10px] font-semibold text-jade px-1.5 py-0.5 bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)] rounded-full tracking-normal normal-case">
+              {haveCount}/{recipe.ingredients.length} in your pantry
+            </span>
+          )}
         </div>
+      )}
 
       {/* Ingredients — neat 2-column grid card */}
       {recipe.ingredients.length > 0 && (
         <div className="mb-5.5">
-          <div
-            className={cn(
-              EYEBROW_BASE,
-              "text-muted-foreground mb-2 flex items-baseline gap-2.5",
-            )}
-          >
-            <span>What to gather</span>
+          <div className="flex items-center justify-between mb-2">
+            <span className={cn(EYEBROW_BASE, "text-muted-foreground")}>What to gather</span>
+            <div className="flex items-center gap-1.5">
+              <span className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
+                Servings
+              </span>
+              <ServingsStepper
+                servings={servings}
+                baseServings={recipe.baseServings}
+                onDecrement={() => setServings((s) => Math.max(1, s - 1))}
+                onIncrement={() => setServings((s) => Math.min(12, s + 1))}
+              />
+            </div>
           </div>
           <div className="bg-card border border-border rounded-xl p-3.5 grid grid-cols-1 sm:grid-cols-2 gap-x-4.5 gap-y-1 shadow-[0_1px_0_var(--border-soft)]">
             {recipe.ingredients.map((ing, i) => {

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -15,6 +15,7 @@ import useSWR, { mutate } from "swr";
 import { InventoryItemBadge } from "./components/InventoryItemBadge";
 
 const CATEGORY_ORDER: Category[] = ["Protein", "Carbs", "Vegetable", "Condiments", "Spice", "Misc"];
+const CATEGORY_MIN_ITEMS = 3;
 
 function groupByCategory(items: InventoryItem[]): { label: Category; items: InventoryItem[] }[] {
   const map = new Map<Category, InventoryItem[]>(CATEGORY_ORDER.map((c) => [c, []]));
@@ -22,9 +23,30 @@ function groupByCategory(items: InventoryItem[]): { label: Category; items: Inve
     const key: Category = (item.category as Category) ?? "Misc";
     map.get(key)?.push(item);
   }
-  return CATEGORY_ORDER.map((label) => ({ label, items: map.get(label)! })).filter(
-    (g) => g.items.length > 0,
-  );
+
+  const overflow: InventoryItem[] = [];
+  const result: { label: Category; items: InventoryItem[] }[] = [];
+
+  for (const label of CATEGORY_ORDER) {
+    const group = map.get(label)!;
+    if (group.length === 0) continue;
+    if (label !== "Misc" && group.length < CATEGORY_MIN_ITEMS) {
+      overflow.push(...group);
+    } else {
+      result.push({ label, items: group });
+    }
+  }
+
+  if (overflow.length > 0) {
+    const misc = result.find((g) => g.label === "Misc");
+    if (misc) {
+      misc.items = [...misc.items, ...overflow].sort((a, b) => a.name.localeCompare(b.name));
+    } else {
+      result.push({ label: "Misc", items: overflow.sort((a, b) => a.name.localeCompare(b.name)) });
+    }
+  }
+
+  return result;
 }
 
 const SectionLabel = ({ children, count }: { children: ReactNode; count?: number }) => (


### PR DESCRIPTION
## Summary

**#118 — Servings stepper placement**
- Stepper moves from the top meta row to inline with the "What to gather" heading — the control and the thing it controls are now adjacent
- Meta row is simplified to just time + pantry pill (hides entirely if neither applies)

**#116 — Pantry category threshold**
- Categories with fewer than 3 items are merged into Misc instead of showing an isolated header for 1–2 items
- Items folded into Misc are re-sorted alphabetically
- Threshold is `CATEGORY_MIN_ITEMS = 3` (named constant, not magic number)

## Test plan

- [ ] Recipe with ingredients: servings stepper appears to the right of "What to gather", not in the top strip
- [ ] Scaling still works — decrement/increment updates all ingredient amounts
- [ ] Pantry: a category with 1 or 2 items has its items folded into Misc, no lone header
- [ ] Pantry: a category with 3+ items still shows its own labelled group
- [ ] Pantry: items merged into Misc are sorted alphabetically alongside existing Misc items

Closes #116, #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized recipe metadata layout: servings control now appears in the ingredients section for improved visual hierarchy
  * Enhanced inventory display by consolidating items from smaller categories into a unified group for a cleaner organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/127)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->