### PR TITLE
fix(pantry): tighten information density (#120)

### DIFF
--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -50,7 +50,7 @@ function groupByCategory(items: InventoryItem[]): { label: Category; items: Inve
 }
 
 const SectionLabel = ({ children, count }: { children: ReactNode; count?: number }) => (
-  <div className="flex items-center justify-between border-b border-dashed border-border pb-2.5 mb-3">
+  <div className="flex items-center justify-between border-b border-dashed border-border pb-2 mb-2.5">
     <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">{children}</span>
     {count !== undefined && (
       <span className="font-mono text-[11px] text-ink-faint tabular-nums">{count}</span>
@@ -138,7 +138,7 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
     (kitchenwareInventory ?? []).some((i) => i.shelfLife === "short");
 
   return (
-    <div className="flex flex-col gap-4 animate-in fade-in duration-300 p-5 h-full">
+    <div className="flex flex-col gap-3 animate-in fade-in duration-300 p-4 h-full">
       {/* Pantry header */}
       <div className="flex items-start justify-between gap-2">
         <div>
@@ -216,7 +216,7 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
       )}
 
       {/* Ingredients card — grouped by category */}
-      <section className="bg-card border border-border rounded-xl p-3.5 shadow-[0_1px_0_oklch(0.87_0.03_72),0_8px_18px_-16px_oklch(0.3_0.05_50/0.4)]">
+      <section className="bg-card border border-border rounded-xl p-3 shadow-[0_1px_0_oklch(0.87_0.03_72),0_8px_18px_-16px_oklch(0.3_0.05_50/0.4)]">
         <SectionLabel count={ingredientsSorted?.length ?? 0}>Ingredients</SectionLabel>
         {isLoading && <p className="text-xs text-muted-foreground font-display italic">Looking in the pantry…</p>}
         {!isLoading && ingredientsSorted?.length === 0 ? (
@@ -224,10 +224,10 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
             Add what&rsquo;s in your fridge — Ah Mah understands &ldquo;a bit of ginger&rdquo;.
           </p>
         ) : (
-          <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-2">
             {groupByCategory(ingredientsSorted ?? []).map((group) => (
               <div key={group.label}>
-                <div className="flex items-center gap-2 mb-1.5">
+                <div className="flex items-center gap-2 mb-1">
                   <span className="font-sans text-[9.5px] font-bold tracking-[0.18em] uppercase text-ink-faint shrink-0">
                     {group.label}
                   </span>
@@ -236,7 +236,7 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
                     {group.items.length}
                   </span>
                 </div>
-                <div className="flex flex-wrap gap-1.5">
+                <div className="flex flex-wrap gap-1">
                   {group.items.map((item) => (
                     <InventoryItemBadge key={item.id} item={item} onRemove={removeItem} />
                   ))}
@@ -248,7 +248,7 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
       </section>
 
       {/* Equipment card */}
-      <section className="bg-card border border-border rounded-xl p-3.5 shadow-[0_1px_0_oklch(0.87_0.03_72),0_8px_18px_-16px_oklch(0.3_0.05_50/0.4)]">
+      <section className="bg-card border border-border rounded-xl p-3 shadow-[0_1px_0_oklch(0.87_0.03_72),0_8px_18px_-16px_oklch(0.3_0.05_50/0.4)]">
         <SectionLabel count={kitchenwareSorted?.length ?? 0}>Equipment</SectionLabel>
         {isLoading && <p className="text-xs text-muted-foreground font-display italic">Rummaging through the cupboards…</p>}
         {!isLoading && kitchenwareSorted?.length === 0 ? (
@@ -256,7 +256,7 @@ const Inventory = ({ onClose }: { onClose?: () => void }) => {
             Got a wok? A pressure cooker? Tell Ah Mah what you cook with.
           </p>
         ) : (
-          <div className="flex flex-wrap gap-1.5">
+          <div className="flex flex-wrap gap-1">
             {kitchenwareSorted?.map((item: InventoryItem) => (
               <InventoryItemBadge key={item.id} item={item} onRemove={removeItem} />
             ))}

--- a/src/features/Inventory/components/InventoryItemBadge.tsx
+++ b/src/features/Inventory/components/InventoryItemBadge.tsx
@@ -11,7 +11,7 @@ export const InventoryItemBadge = ({
   onRemove,
 }: InventoryItemBadgeProps) => {
   return (
-    <Badge key={item.id} variant="outline" className="relative pr-8 pl-3 py-1.5 bg-background border-border rounded-md shadow-[0_1px_0_oklch(0.82_0.04_70)] text-foreground">
+    <Badge key={item.id} variant="outline" className="relative pr-6 pl-2.5 py-0.5 bg-background border-border rounded-md shadow-[0_1px_0_oklch(0.82_0.04_70)] text-foreground text-[12px]">
       {item.shelfLife === "short" && (
         <span
           aria-label="Short shelf life"
@@ -27,12 +27,12 @@ export const InventoryItemBadge = ({
 
       <button
         onClick={() => onRemove(item.name)}
-        className="absolute right-1 cursor-pointer p-1 hover:bg-secondary rounded group"
+        className="absolute right-0.5 cursor-pointer p-0.5 hover:bg-secondary rounded group"
       >
         <svg
           className="text-gray-400 group-hover:text-gray-500"
-          width="16"
-          height="16"
+          width="12"
+          height="12"
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary

- Badge padding reduced (`py-1.5 pl-3 pr-8` → `py-0.5 pl-2.5 pr-6`) and font size set to 12px to match small-text scale
- X button shrunk from 16×16 to 12×12 SVG with tighter padding (`p-1` → `p-0.5`)
- Section card padding reduced (`p-3.5` → `p-3`)
- Category group gap tightened (`gap-3` → `gap-2`), badge row gap (`gap-1.5` → `gap-1`)
- SectionLabel bottom spacing reduced (`pb-2.5 mb-3` → `pb-2 mb-2.5`)
- Top-level container gap reduced (`gap-4` → `gap-3`) and padding (`p-5` → `p-4`)

## Test plan

- [ ] Open pantry rail with 10+ ingredient items — all visible without scrolling on a ~900px viewport
- [ ] Short-shelf-life dot and label remain legible
- [ ] Badge text is not truncated or clipped
- [ ] X (remove) button still clickable and hover state visible

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)