### PR TITLE
feat(conversations): last-message snippet + message count (#125)

### DIFF
--- a/src/features/Conversations/components/ConversationItem.test.tsx
+++ b/src/features/Conversations/components/ConversationItem.test.tsx
@@ -73,4 +73,22 @@ describe("ConversationItem", () => {
     );
     expect(screen.queryByText(/msg/)).not.toBeInTheDocument();
   });
+
+  it("shows snippet when lastMessageSnippet is present", () => {
+    render(
+      <ConversationItem
+        conversation={{ ...baseConv, lastMessageSnippet: "Here is a great recipe for you" }}
+        isActive={false}
+        onClick={() => {}}
+      />
+    );
+    expect(screen.getByText("Here is a great recipe for you")).toBeInTheDocument();
+  });
+
+  it("hides snippet when lastMessageSnippet is absent", () => {
+    render(
+      <ConversationItem conversation={baseConv} isActive={false} onClick={() => {}} />
+    );
+    expect(screen.queryByText(/Here is a great/)).not.toBeInTheDocument();
+  });
 });

--- a/src/features/Conversations/components/ConversationItem.tsx
+++ b/src/features/Conversations/components/ConversationItem.tsx
@@ -28,6 +28,7 @@ interface ConversationItemProps {
 export function ConversationItem({ conversation, isActive, onClick }: ConversationItemProps) {
   const title = conversation.title ?? "New chat";
   const messageCount = conversation._count?.messages ?? 0;
+  const snippet = conversation.lastMessageSnippet;
 
   return (
     <div
@@ -49,9 +50,16 @@ export function ConversationItem({ conversation, isActive, onClick }: Conversati
         </span>
       </div>
 
+      {/* Snippet */}
+      {snippet && (
+        <p className="mt-0.5 font-sans text-[11px] text-ink-faint leading-snug truncate">
+          {snippet}
+        </p>
+      )}
+
       {/* Footer — message count */}
       {messageCount > 0 && (
-        <div className="flex items-center gap-2 mt-1.5">
+        <div className="flex items-center gap-1.5 mt-1.5">
           <span className="font-sans text-[10px] text-ink-faint tabular-nums">
             {messageCount} msg
           </span>

--- a/src/lib/conversations/conversations.ts
+++ b/src/lib/conversations/conversations.ts
@@ -9,17 +9,26 @@ export type ConversationEntity = {
   title: string | null;
   createdAt: Date;
   updatedAt: Date;
+  lastMessageSnippet?: string | null;
   _count?: { messages: number };
 };
 
 export async function listConversations(
   userId: string
 ): Promise<ConversationEntity[]> {
-  return prisma.conversation.findMany({
+  const rows = await prisma.conversation.findMany({
     where: { userId },
     orderBy: { updatedAt: "desc" },
-    include: { _count: { select: { messages: true } } },
+    include: {
+      _count: { select: { messages: true } },
+      messages: { orderBy: { createdAt: "desc" }, take: 1, select: { content: true } },
+    },
   });
+
+  return rows.map(({ messages, ...conv }) => ({
+    ...conv,
+    lastMessageSnippet: messages[0]?.content?.slice(0, 80) ?? null,
+  }));
 }
 
 export async function getOrCreateActiveConversation(


### PR DESCRIPTION
## Summary

- `listConversations` now fetches the most recent message per conversation and maps it to a `lastMessageSnippet` (≤80 chars) on `ConversationEntity`
- `ConversationItem` renders the snippet as a compact `font-sans text-[11px] text-ink-faint` line below the title — single line, ellipsis on overflow
- Items with no messages show no snippet (unchanged)
- Message count badge already existed; no change needed

**Note:** Recipe count per conversation is not implemented — `Recipe` has no `conversationId` FK; would require a schema migration. Tracked separately if needed.

## Test plan

- [ ] Open conversation list with existing conversations — snippets appear below each title
- [ ] New/empty conversation shows no snippet
- [ ] Long messages are truncated with ellipsis on one line
- [ ] Message count still shows correctly
- [ ] `ConversationItem` tests: 9/9 pass

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)