### PR TITLE
feat(recipe): cooking mode — step-by-step fullscreen view (#122)

### DIFF
--- a/src/features/Chat/components/recipe/CookingMode.tsx
+++ b/src/features/Chat/components/recipe/CookingMode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface Step {
   title: string;
@@ -19,33 +19,39 @@ export function CookingMode({ title, steps, onExit }: CookingModeProps) {
   const [current, setCurrent] = useState(0);
   const wakeLockRef = useRef<WakeLockSentinel | null>(null);
   const total = steps.length;
-  const step = steps[current];
+
+  const requestWakeLock = useCallback(async () => {
+    if (!("wakeLock" in navigator)) return;
+    try {
+      const lock = await navigator.wakeLock.request("screen");
+      lock.addEventListener("release", () => {
+        if (wakeLockRef.current === lock) wakeLockRef.current = null;
+      });
+      wakeLockRef.current = lock;
+    } catch {}
+  }, []);
 
   useEffect(() => {
-    if (!("wakeLock" in navigator)) return;
-    navigator.wakeLock.request("screen").then((lock) => {
-      wakeLockRef.current = lock;
-    }).catch(() => {});
-
+    requestWakeLock();
     return () => {
       wakeLockRef.current?.release().catch(() => {});
       wakeLockRef.current = null;
     };
-  }, []);
+  }, [requestWakeLock]);
 
-  // Re-acquire wake lock if page becomes visible again
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible" && !wakeLockRef.current && "wakeLock" in navigator) {
-        navigator.wakeLock.request("screen").then((lock) => {
-          wakeLockRef.current = lock;
-        }).catch(() => {});
+      if (document.visibilityState === "visible" && (!wakeLockRef.current || wakeLockRef.current.released)) {
+        requestWakeLock();
       }
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
-  }, []);
+  }, [requestWakeLock]);
 
+  if (total === 0) return null;
+
+  const step = steps[Math.min(current, total - 1)];
   const prev = () => setCurrent((c) => Math.max(0, c - 1));
   const next = () => setCurrent((c) => Math.min(total - 1, c + 1));
 

--- a/src/features/Chat/components/recipe/CookingMode.tsx
+++ b/src/features/Chat/components/recipe/CookingMode.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useEffect, useRef, useState } from "react";
+
+interface Step {
+  title: string;
+  body: string;
+  tip?: string;
+}
+
+interface CookingModeProps {
+  title: string;
+  steps: Step[];
+  onExit: () => void;
+}
+
+export function CookingMode({ title, steps, onExit }: CookingModeProps) {
+  const [current, setCurrent] = useState(0);
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+  const total = steps.length;
+  const step = steps[current];
+
+  useEffect(() => {
+    if (!("wakeLock" in navigator)) return;
+    navigator.wakeLock.request("screen").then((lock) => {
+      wakeLockRef.current = lock;
+    }).catch(() => {});
+
+    return () => {
+      wakeLockRef.current?.release().catch(() => {});
+      wakeLockRef.current = null;
+    };
+  }, []);
+
+  // Re-acquire wake lock if page becomes visible again
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible" && !wakeLockRef.current && "wakeLock" in navigator) {
+        navigator.wakeLock.request("screen").then((lock) => {
+          wakeLockRef.current = lock;
+        }).catch(() => {});
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, []);
+
+  const prev = () => setCurrent((c) => Math.max(0, c - 1));
+  const next = () => setCurrent((c) => Math.min(total - 1, c + 1));
+
+  return (
+    <div className="fixed inset-0 z-50 bg-background flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-3.5 border-b border-border shrink-0">
+        <div>
+          <div className="font-display font-semibold text-base text-foreground leading-tight tracking-tight truncate max-w-[240px] sm:max-w-none">
+            {title}
+          </div>
+          <div className="font-sans text-[11px] text-ink-faint mt-0.5 tabular-nums">
+            Step {current + 1} of {total}
+          </div>
+        </div>
+        <button
+          onClick={onExit}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 font-sans text-xs font-semibold text-foreground bg-card border border-border rounded-lg shadow-[0_1px_0_var(--border-soft)] hover:bg-muted/50 transition-colors cursor-pointer shrink-0"
+        >
+          Exit cooking mode
+        </button>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-1 bg-border shrink-0">
+        <div
+          className="h-full bg-primary transition-all duration-300"
+          style={{ width: `${((current + 1) / total) * 100}%` }}
+        />
+      </div>
+
+      {/* Step content */}
+      <div className="flex-1 overflow-y-auto flex flex-col justify-center px-6 py-8 sm:px-12 max-w-2xl mx-auto w-full">
+        {/* Step number stamp */}
+        <div className="mb-6 flex items-center gap-3">
+          <div className="shrink-0 size-12 bg-primary text-white flex items-center justify-center font-display font-bold text-2xl rounded-[50%_50%_50%_10px] -rotate-3 shadow-[inset_0_-2px_0_oklch(0.405_0.130_32),0_1px_0_oklch(0.405_0.130_32)]">
+            {current + 1}
+          </div>
+          <div className="font-display font-semibold text-2xl text-foreground leading-tight tracking-tight">
+            {step.title}
+          </div>
+        </div>
+
+        <div className="font-display text-[1.25rem] leading-relaxed text-foreground">
+          {step.body}
+        </div>
+
+        {step.tip && (
+          <div className="mt-5 pl-4 border-l-[3px] border-[oklch(0.65_0.10_60)] font-display italic text-base text-muted-foreground leading-relaxed">
+            — {step.tip}
+          </div>
+        )}
+      </div>
+
+      {/* Navigation footer */}
+      <div className="px-5 py-4 border-t border-border flex items-center gap-3 shrink-0 max-w-2xl mx-auto w-full">
+        <button
+          onClick={prev}
+          disabled={current === 0}
+          className={cn(
+            "flex-1 py-3 font-sans text-sm font-semibold rounded-xl border transition-colors cursor-pointer",
+            current === 0
+              ? "text-muted-foreground border-border bg-card opacity-40 cursor-not-allowed"
+              : "text-foreground border-border bg-card shadow-[0_1px_0_var(--border-soft)] hover:bg-muted/50"
+          )}
+        >
+          ← Prev
+        </button>
+
+        {current < total - 1 ? (
+          <button
+            onClick={next}
+            className="flex-[2] py-3 font-sans text-sm font-semibold text-white bg-primary border border-[oklch(0.405_0.130_32)] rounded-xl shadow-[0_2px_0_oklch(0.405_0.130_32)] hover:bg-[oklch(0.50_0.130_32)] transition-colors cursor-pointer"
+          >
+            Next step →
+          </button>
+        ) : (
+          <button
+            onClick={onExit}
+            className="flex-[2] py-3 font-sans text-sm font-semibold text-white bg-jade border border-[oklch(0.35_0.10_168)] rounded-xl shadow-[0_2px_0_oklch(0.35_0.10_168)] hover:opacity-90 transition-opacity cursor-pointer"
+          >
+            Done — all finished!
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils/index";
 import { TimerIcon } from "lucide-react";
 import { useState } from "react";
+import { CookingMode } from "./CookingMode";
 import { toast } from "sonner";
 import useSWR, { useSWRConfig } from "swr";
 import { ScaledNum } from "./ScaledNum";
@@ -141,6 +142,7 @@ function ingredientHave(name: string, inventoryNames: string[]): boolean {
 export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterProps) {
   const [servings, setServings] = useState(recipe.baseServings);
   const [inFlight, setInFlight] = useState<Set<string>>(new Set());
+  const [cooking, setCooking] = useState(false);
   const ratio = servings / recipe.baseServings;
   const { userId } = useSessionContext();
   const { mutate } = useSWRConfig();
@@ -220,8 +222,9 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
         return parts.join(" ");
       })
       .join("\n");
-    navigator.clipboard.writeText(lines).then(() =>
-      toast.success("Shopping list copied to clipboard"),
+    navigator.clipboard.writeText(lines).then(
+      () => toast.success("Shopping list copied to clipboard"),
+      () => toast.error("Couldn't copy — try selecting and copying manually"),
     );
   };
 
@@ -238,6 +241,17 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
     "font-sans text-[10px] font-bold tracking-widest uppercase";
 
   const showPantryPill = !!userId;
+  const canCook = recipe.steps.length > 0;
+
+  if (cooking) {
+    return (
+      <CookingMode
+        title={recipe.title}
+        steps={recipe.steps}
+        onExit={() => setCooking(false)}
+      />
+    );
+  }
 
   return (
     <div className=" border-y border-border-soft p-[20px_26px_22px] relative">
@@ -398,42 +412,41 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
         </div>
       )}
 
-      {/* Action bar — only when onSave is provided */}
-      {onSave && (
+      {/* Action bar */}
+      {(onSave || canCook) && (
         <div className="flex gap-2 items-center pt-3 mt-4.5 border-t border-dashed border-border">
-          {isSaved ? (
-            <button
-              disabled
-              className="px-3 py-1.5 font-sans text-xs font-semibold text-jade bg-transparent border border-border rounded-lg cursor-not-allowed inline-flex items-center gap-1 opacity-80"
-            >
-              <svg
-                width="11"
-                height="11"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                stroke="currentColor"
-                strokeWidth="2"
+          {onSave && (
+            isSaved ? (
+              <button
+                disabled
+                className="px-3 py-1.5 font-sans text-xs font-semibold text-jade bg-transparent border border-border rounded-lg cursor-not-allowed inline-flex items-center gap-1 opacity-80"
               >
-                <path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16l-7-3-7 3z" />
-              </svg>
-              Saved
-            </button>
-          ) : (
-            <button
-              onClick={() => onSave(recipe)}
-              className="px-3 py-1.5 font-sans text-xs font-semibold text-foreground bg-card border border-border rounded-lg cursor-pointer shadow-[0_1px_0_var(--border-soft)] hover:bg-muted/50 transition-colors inline-flex items-center gap-1"
-            >
-              <svg
-                width="11"
-                height="11"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2">
+                  <path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16l-7-3-7 3z" />
+                </svg>
+                Saved
+              </button>
+            ) : (
+              <button
+                onClick={() => onSave(recipe)}
+                className="px-3 py-1.5 font-sans text-xs font-semibold text-foreground bg-card border border-border rounded-lg cursor-pointer shadow-[0_1px_0_var(--border-soft)] hover:bg-muted/50 transition-colors inline-flex items-center gap-1"
               >
-                <path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16l-7-3-7 3z" />
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16l-7-3-7 3z" />
+                </svg>
+                Save to cookbook
+              </button>
+            )
+          )}
+          {canCook && (
+            <button
+              onClick={() => setCooking(true)}
+              className="ml-auto px-3 py-1.5 font-sans text-xs font-semibold text-white bg-primary border border-[oklch(0.405_0.130_32)] rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.405_0.130_32)] hover:bg-[oklch(0.50_0.130_32)] transition-colors inline-flex items-center gap-1.5"
+            >
+              <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+                <path d="M5 3l8 5-8 5V3z" fill="currentColor"/>
               </svg>
-              Save to cookbook
+              Start cooking
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary

- New `CookingMode` component renders as a fixed fullscreen overlay (z-50) over the chat
- "Start cooking" button appears in the recipe action bar when the recipe has structured steps; hidden for legacy recipes
- One step at a time: large upright type (20px+), step title, body, and optional Ah Mah tip
- Progress bar (`Step X of N`) across the top
- Prev / Next navigation; last step shows "Done — all finished!" which exits back to the recipe view
- **Screen Wake Lock API** requested on entry, released on exit; re-acquired when tab regains focus — gracefully degrades on unsupported browsers (no crash, no warning)
- Also restores the clipboard error toast from #130 that was lost in squash

## Test plan

- [ ] Recipe with structured steps → "Start cooking" button appears in action bar
- [ ] Recipe with no steps (legacy) → no "Start cooking" button
- [ ] Click "Start cooking" → fullscreen cooking mode appears
- [ ] Step counter and progress bar advance correctly
- [ ] Prev disabled on step 1; Next replaced with "Done" on last step
- [ ] "Done" and "Exit cooking mode" both return to recipe view
- [ ] Screen doesn't sleep while cooking mode is open (mobile/laptop)
- [ ] No regression on save, shortfall card, or ingredient grid

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Cooking Mode that guides users through recipes with step progress, tips, and navigation controls.
  * Added a "Start cooking" action to launch guided recipe preparation and an exit flow to return to the recipe view.
  * Improved "Copy shopping list" feedback with success and error notifications.
  * Keeps the device screen awake during cooking sessions using a wake-lock while active.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/131)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->