### PR TITLE
feat(chat-header): unified mobile header with overflow menu (#132)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -85,14 +85,12 @@ The persistent-kitchen MVP. Highlights:
 - [x] Items with null category (pre-existing rows) fall under Misc.
 
 ### Mobile fixes — Round 1: chat header (May 2026)
-- [x] Chat header now renders at all widths below `lg` (was `hidden sm:flex` — true mobile had no header).
-- [x] Two-row mobile header (`lg:hidden`): row 1 = action bar (hamburger left, `+` and `⋯` right); row 2 = full-width title hero at `text-[20px]` — gives the title a full viewport-width row so long names aren't cramped.
-- [x] Desktop header (`hidden lg:flex`) preserved as single row with dot + title + meta line below + `+` + `⋯`.
-- [x] Meta line (message count + started time) dropped from mobile — redundant with per-item metadata visible in `ConversationsMobileSheet`.
-- [x] Tapping the title row (with ▾ chevron) opens `ConversationsMobileSheet` — same destination as the hamburger.
-- [x] Rename and Delete moved from inline `ConversationTitle` controls into a `⋯` `DropdownMenu` overflow.
-- [x] `ConversationTitle` refactored: pure visual display with optional tappable/chevron/titleClassName props; `ConversationActionsMenu` is a new export holding the dropdown + AlertDialog delete confirm.
+- [x] Chat header now renders at all widths (was `hidden sm:flex` — true mobile had no header at all).
+- [x] Single row at all widths: `[≡] • Title… [⋯]`. Hamburger (`lg:hidden`) opens `ConversationsMobileSheet`; title is plain text that truncates with ellipsis.
+- [x] All conversation actions consolidated into `⋯` overflow menu: New conversation (disabled when no messages), Rename, Delete.
+- [x] `ConversationTitle` refactored: pure visual display with optional `titleClassName` override; `ConversationActionsMenu` is a separate named export holding the dropdown + AlertDialog delete confirm.
 - [x] `dropdown-menu` shadcn primitive added.
+- [x] `ConversationsMobileSheet` suppresses the shadcn auto-close X (`showCloseButton={false}`) to prevent overlap with the Conversations component's `+` button.
 
 ### Better Auth — Setup & Login UI (May 2026)
 - [x] `better-auth` installed with Prisma adapter (`postgresql` provider).

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -86,10 +86,12 @@ The persistent-kitchen MVP. Highlights:
 
 ### Mobile fixes — Round 1: chat header (May 2026)
 - [x] Chat header now renders at all widths below `lg` (was `hidden sm:flex` — true mobile had no header).
-- [x] Hamburger (`lg:hidden`) pinned leftmost; tapping title (with ▾ chevron) opens the same `ConversationsMobileSheet` — one destination, two entry points.
-- [x] `+ New conversation` full-text button replaced with a `+` icon button (primary fill) at all widths.
+- [x] Two-row mobile header (`lg:hidden`): row 1 = action bar (hamburger left, `+` and `⋯` right); row 2 = full-width title hero at `text-[20px]` — gives the title a full viewport-width row so long names aren't cramped.
+- [x] Desktop header (`hidden lg:flex`) preserved as single row with dot + title + meta line below + `+` + `⋯`.
+- [x] Meta line (message count + started time) dropped from mobile — redundant with per-item metadata visible in `ConversationsMobileSheet`.
+- [x] Tapping the title row (with ▾ chevron) opens `ConversationsMobileSheet` — same destination as the hamburger.
 - [x] Rename and Delete moved from inline `ConversationTitle` controls into a `⋯` `DropdownMenu` overflow.
-- [x] `ConversationTitle` refactored: pure visual display with optional tappable/chevron props; `ConversationActionsMenu` is a new export holding the dropdown + AlertDialog delete confirm.
+- [x] `ConversationTitle` refactored: pure visual display with optional tappable/chevron/titleClassName props; `ConversationActionsMenu` is a new export holding the dropdown + AlertDialog delete confirm.
 - [x] `dropdown-menu` shadcn primitive added.
 
 ### Better Auth — Setup & Login UI (May 2026)

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -84,6 +84,14 @@ The persistent-kitchen MVP. Highlights:
 - [x] Each sub-group: label + dotted-line spacer + count, then the badges. Empty categories hidden.
 - [x] Items with null category (pre-existing rows) fall under Misc.
 
+### Mobile fixes — Round 1: chat header (May 2026)
+- [x] Chat header now renders at all widths below `lg` (was `hidden sm:flex` — true mobile had no header).
+- [x] Hamburger (`lg:hidden`) pinned leftmost; tapping title (with ▾ chevron) opens the same `ConversationsMobileSheet` — one destination, two entry points.
+- [x] `+ New conversation` full-text button replaced with a `+` icon button (primary fill) at all widths.
+- [x] Rename and Delete moved from inline `ConversationTitle` controls into a `⋯` `DropdownMenu` overflow.
+- [x] `ConversationTitle` refactored: pure visual display with optional tappable/chevron props; `ConversationActionsMenu` is a new export holding the dropdown + AlertDialog delete confirm.
+- [x] `dropdown-menu` shadcn primitive added.
+
 ### Better Auth — Setup & Login UI (May 2026)
 - [x] `better-auth` installed with Prisma adapter (`postgresql` provider).
 - [x] Google OAuth and Email (Magic Link via Resend) providers configured in `src/lib/auth.ts`.

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -241,39 +241,24 @@ const Chat = () => {
       key={activeConversationId}
       className="flex flex-col animate-in fade-in duration-300 h-full"
     >
-      {/* Mobile header (<lg) — two rows: action bar + title hero */}
-      <div className="lg:hidden flex flex-col border-b border-dashed border-border shrink-0">
-        {/* Row 1: action bar */}
-        <div className="flex items-center gap-2 px-3 py-2.5">
-          <button
-            onClick={() => setConvSheetOpen(true)}
-            className="flex items-center justify-center w-9 h-9 rounded-lg text-ink-faint hover:text-foreground hover:bg-muted transition-colors cursor-pointer shrink-0"
-            aria-label="Open conversations"
-          >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-            </svg>
-          </button>
-          <div className="flex-1" />
-          <button
-            onClick={() => startNewConversation()}
-            disabled={messageCount === 0}
-            title={messageCount === 0 ? "Start a conversation first" : "New conversation"}
-            aria-label="New conversation"
-            className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed shrink-0 shadow-[0_1px_0_oklch(0.35_0.12_35)]"
-          >
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-              <path d="M8 2v12M2 8h12" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round"/>
-            </svg>
-          </button>
-          <ConversationActionsMenu
-            onStartRename={() => setTitleEditing(true)}
-            onDelete={handleDeleteConversation}
-            canDelete={messageCount > 0}
-          />
-        </div>
-        {/* Row 2: title hero */}
-        <div className="px-4 pb-3">
+      {/* Chat header — single row at all widths */}
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-dashed border-border shrink-0">
+        {/* Hamburger — hidden when persistent sidebar is present */}
+        <button
+          onClick={() => setConvSheetOpen(true)}
+          className="lg:hidden flex items-center justify-center w-9 h-9 rounded-lg text-ink-faint hover:text-foreground hover:bg-muted transition-colors cursor-pointer shrink-0"
+          aria-label="Open conversations"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+          </svg>
+        </button>
+
+        {/* Active indicator dot */}
+        <div className="w-2 h-2 rounded-full bg-primary shrink-0 shadow-[0_0_0_4px_oklch(0.56_0.135_35/0.18)]" />
+
+        {/* Title + meta — flex-1 min-w-0 ensures truncation before buttons */}
+        <div className="flex flex-col min-w-0 flex-1 overflow-hidden">
           <ConversationTitle
             title={activeConversation?.title}
             onTap={() => setConvSheetOpen(true)}
@@ -281,27 +266,15 @@ const Chat = () => {
             editing={titleEditing}
             onEditingChange={setTitleEditing}
             onRename={renameActiveConversation}
-            titleClassName="font-display italic font-medium text-[20px] text-foreground leading-tight tracking-tight truncate"
           />
-        </div>
-      </div>
-
-      {/* Desktop header (lg+) — single row: dot + title/meta + buttons */}
-      <div className="hidden lg:flex items-center gap-2 px-3 py-2.5 border-b border-dashed border-border shrink-0">
-        <div className="w-2 h-2 rounded-full bg-primary shrink-0 shadow-[0_0_0_4px_oklch(0.56_0.135_35/0.18)]" />
-        <div className="flex flex-col min-w-0 flex-1">
-          <ConversationTitle
-            title={activeConversation?.title}
-            editing={titleEditing}
-            onEditingChange={setTitleEditing}
-            onRename={renameActiveConversation}
-          />
-          <div className="text-[11px] text-ink-faint tracking-wide">
+          <div className="text-[11px] text-ink-faint tracking-wide truncate">
             {messageCount > 0
               ? `${messageCount} message${messageCount !== 1 ? "s" : ""}${startedAt ? ` · started ${startedAt}` : ""}`
               : "Start a conversation"}
           </div>
         </div>
+
+        {/* New conversation */}
         <button
           onClick={() => startNewConversation()}
           disabled={messageCount === 0}
@@ -313,6 +286,8 @@ const Chat = () => {
             <path d="M8 2v12M2 8h12" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round"/>
           </svg>
         </button>
+
+        {/* Overflow menu — rename + delete */}
         <ConversationActionsMenu
           onStartRename={() => setTitleEditing(true)}
           onDelete={handleDeleteConversation}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -274,21 +274,10 @@ const Chat = () => {
           </div>
         </div>
 
-        {/* New conversation */}
-        <button
-          onClick={() => startNewConversation()}
-          disabled={messageCount === 0}
-          title={messageCount === 0 ? "Start a conversation first" : "New conversation"}
-          aria-label="New conversation"
-          className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed shrink-0 shadow-[0_1px_0_oklch(0.35_0.12_35)]"
-        >
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-            <path d="M8 2v12M2 8h12" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round"/>
-          </svg>
-        </button>
-
-        {/* Overflow menu — rename + delete */}
+        {/* Overflow menu — new / rename / delete */}
         <ConversationActionsMenu
+          onNewConversation={() => startNewConversation()}
+          canStartNew={messageCount > 0}
           onStartRename={() => setTitleEditing(true)}
           onDelete={handleDeleteConversation}
           canDelete={messageCount > 0}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { useConversationContext } from "@/contexts/ConversationContext";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { ConversationsMobileSheet } from "@/features/Conversations";
@@ -17,7 +16,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
 import { z } from "zod";
-import ConversationTitle from "./components/ConversationTitle";
+import ConversationTitle, { ConversationActionsMenu } from "./components/ConversationTitle";
 import { MessageInput } from "./components/MessageInput";
 import { MessageList } from "./components/MessageList";
 import { INITIAL_MESSAGE, LOADING_MESSAGES } from "./constants";
@@ -42,6 +41,7 @@ const Chat = () => {
     deleteActiveConversation,
   } = useConversationContext();
   const [convSheetOpen, setConvSheetOpen] = useState(false);
+  const [titleEditing, setTitleEditing] = useState(false);
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
   const autoTitledConversations = useRef<Set<string>>(new Set());
   const autoTitlingConversations = useRef<Set<string>>(new Set());
@@ -241,43 +241,58 @@ const Chat = () => {
       key={activeConversationId}
       className="flex flex-col animate-in fade-in duration-300 h-full"
     >
-      <div className="hidden sm:flex items-center justify-between px-7 py-3.5 border-b border-dashed border-border shrink-0">
-        <div className="flex items-center gap-3">
-          {/* Active indicator dot */}
-          <div className="w-2 h-2 rounded-full bg-primary shrink-0 shadow-[0_0_0_4px_oklch(0.56_0.135_35/0.18)]" />
-          <div>
-            <ConversationTitle
-              title={activeConversation?.title}
-              onRename={renameActiveConversation}
-              onDelete={handleDeleteConversation}
-              canDelete={messageCount > 0}
-            />
-            <div className="text-[11.5px] text-ink-faint mt-0.5 tracking-wide">
-              {messageCount > 0
-                ? `${messageCount} message${messageCount !== 1 ? "s" : ""}${startedAt ? ` · started ${startedAt}` : ""}`
-                : "Start a conversation"}
-            </div>
+      {/* Chat header — visible at all widths; lg+ shows hamburger only when the sidebar is absent */}
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-dashed border-border shrink-0">
+        {/* Hamburger — drawer toggle; hidden when persistent sidebar is showing */}
+        <button
+          onClick={() => setConvSheetOpen(true)}
+          className="lg:hidden flex items-center justify-center w-9 h-9 rounded-lg text-ink-faint hover:text-foreground hover:bg-muted transition-colors cursor-pointer shrink-0"
+          aria-label="Open conversations"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+          </svg>
+        </button>
+
+        {/* Active indicator dot */}
+        <div className="w-2 h-2 rounded-full bg-primary shrink-0 shadow-[0_0_0_4px_oklch(0.56_0.135_35/0.18)]" />
+
+        {/* Title block — tapping opens the conversations sheet on mobile */}
+        <div className="flex flex-col min-w-0 flex-1">
+          <ConversationTitle
+            title={activeConversation?.title}
+            onTap={() => setConvSheetOpen(true)}
+            withChevron
+            editing={titleEditing}
+            onEditingChange={setTitleEditing}
+            onRename={renameActiveConversation}
+          />
+          <div className="text-[11px] text-ink-faint tracking-wide">
+            {messageCount > 0
+              ? `${messageCount} message${messageCount !== 1 ? "s" : ""}${startedAt ? ` · started ${startedAt}` : ""}`
+              : "Start a conversation"}
           </div>
         </div>
-        {/* Mobile: conversations button */}
-          <button
-            onClick={() => setConvSheetOpen(true)}
-            className="lg:hidden p-1.5 text-ink-faint hover:text-foreground transition-colors cursor-pointer"
-            aria-label="Open conversations"
-          >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-            </svg>
-          </button>
-          <Button
-            size="sm"
-            onClick={() => startNewConversation()}
-            disabled={messageCount === 0}
-            title={messageCount === 0 ? "Start a conversation first" : undefined}
-            className="bg-primary text-primary-foreground hover:bg-primary/90 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            + New conversation
-          </Button>
+
+        {/* New conversation icon button */}
+        <button
+          onClick={() => startNewConversation()}
+          disabled={messageCount === 0}
+          title={messageCount === 0 ? "Start a conversation first" : "New conversation"}
+          aria-label="New conversation"
+          className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed shrink-0 shadow-[0_1px_0_oklch(0.35_0.12_35)]"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <path d="M8 2v12M2 8h12" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round"/>
+          </svg>
+        </button>
+
+        {/* Overflow menu — rename + delete */}
+        <ConversationActionsMenu
+          onStartRename={() => setTitleEditing(true)}
+          onDelete={handleDeleteConversation}
+          canDelete={messageCount > 0}
+        />
       </div>
       <MessageList
         messages={allMessages}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -241,28 +241,57 @@ const Chat = () => {
       key={activeConversationId}
       className="flex flex-col animate-in fade-in duration-300 h-full"
     >
-      {/* Chat header — visible at all widths; lg+ shows hamburger only when the sidebar is absent */}
-      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-dashed border-border shrink-0">
-        {/* Hamburger — drawer toggle; hidden when persistent sidebar is showing */}
-        <button
-          onClick={() => setConvSheetOpen(true)}
-          className="lg:hidden flex items-center justify-center w-9 h-9 rounded-lg text-ink-faint hover:text-foreground hover:bg-muted transition-colors cursor-pointer shrink-0"
-          aria-label="Open conversations"
-        >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-          </svg>
-        </button>
-
-        {/* Active indicator dot */}
-        <div className="w-2 h-2 rounded-full bg-primary shrink-0 shadow-[0_0_0_4px_oklch(0.56_0.135_35/0.18)]" />
-
-        {/* Title block — tapping opens the conversations sheet on mobile */}
-        <div className="flex flex-col min-w-0 flex-1">
+      {/* Mobile header (<lg) — two rows: action bar + title hero */}
+      <div className="lg:hidden flex flex-col border-b border-dashed border-border shrink-0">
+        {/* Row 1: action bar */}
+        <div className="flex items-center gap-2 px-3 py-2.5">
+          <button
+            onClick={() => setConvSheetOpen(true)}
+            className="flex items-center justify-center w-9 h-9 rounded-lg text-ink-faint hover:text-foreground hover:bg-muted transition-colors cursor-pointer shrink-0"
+            aria-label="Open conversations"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+            </svg>
+          </button>
+          <div className="flex-1" />
+          <button
+            onClick={() => startNewConversation()}
+            disabled={messageCount === 0}
+            title={messageCount === 0 ? "Start a conversation first" : "New conversation"}
+            aria-label="New conversation"
+            className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed shrink-0 shadow-[0_1px_0_oklch(0.35_0.12_35)]"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <path d="M8 2v12M2 8h12" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round"/>
+            </svg>
+          </button>
+          <ConversationActionsMenu
+            onStartRename={() => setTitleEditing(true)}
+            onDelete={handleDeleteConversation}
+            canDelete={messageCount > 0}
+          />
+        </div>
+        {/* Row 2: title hero */}
+        <div className="px-4 pb-3">
           <ConversationTitle
             title={activeConversation?.title}
             onTap={() => setConvSheetOpen(true)}
             withChevron
+            editing={titleEditing}
+            onEditingChange={setTitleEditing}
+            onRename={renameActiveConversation}
+            titleClassName="font-display italic font-medium text-[20px] text-foreground leading-tight tracking-tight truncate"
+          />
+        </div>
+      </div>
+
+      {/* Desktop header (lg+) — single row: dot + title/meta + buttons */}
+      <div className="hidden lg:flex items-center gap-2 px-3 py-2.5 border-b border-dashed border-border shrink-0">
+        <div className="w-2 h-2 rounded-full bg-primary shrink-0 shadow-[0_0_0_4px_oklch(0.56_0.135_35/0.18)]" />
+        <div className="flex flex-col min-w-0 flex-1">
+          <ConversationTitle
+            title={activeConversation?.title}
             editing={titleEditing}
             onEditingChange={setTitleEditing}
             onRename={renameActiveConversation}
@@ -273,8 +302,6 @@ const Chat = () => {
               : "Start a conversation"}
           </div>
         </div>
-
-        {/* New conversation icon button */}
         <button
           onClick={() => startNewConversation()}
           disabled={messageCount === 0}
@@ -286,8 +313,6 @@ const Chat = () => {
             <path d="M8 2v12M2 8h12" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round"/>
           </svg>
         </button>
-
-        {/* Overflow menu — rename + delete */}
         <ConversationActionsMenu
           onStartRename={() => setTitleEditing(true)}
           onDelete={handleDeleteConversation}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -261,8 +261,6 @@ const Chat = () => {
         <div className="flex flex-col min-w-0 flex-1 overflow-hidden">
           <ConversationTitle
             title={activeConversation?.title}
-            onTap={() => setConvSheetOpen(true)}
-            withChevron
             editing={titleEditing}
             onEditingChange={setTitleEditing}
             onRename={renameActiveConversation}

--- a/src/features/Chat/components/ConversationTitle.tsx
+++ b/src/features/Chat/components/ConversationTitle.tsx
@@ -33,7 +33,12 @@ interface ConversationTitleProps {
   editing: boolean;
   onEditingChange: (editing: boolean) => void;
   onRename: (title: string) => Promise<void>;
+  /** Override default title typography (e.g. larger on mobile hero row) */
+  titleClassName?: string;
 }
+
+const DEFAULT_TITLE_CLASS =
+  "font-display italic font-medium text-[16.5px] text-foreground leading-tight tracking-tight truncate";
 
 export default function ConversationTitle({
   title,
@@ -42,6 +47,7 @@ export default function ConversationTitle({
   editing,
   onEditingChange,
   onRename,
+  titleClassName,
 }: ConversationTitleProps) {
   const [value, setValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -91,7 +97,7 @@ export default function ConversationTitle({
 
   const titleEl = (
     <div className="flex items-center gap-1.5 min-w-0">
-      <span className="font-display italic font-medium text-[16.5px] text-foreground leading-tight tracking-tight truncate">
+      <span className={titleClassName ?? DEFAULT_TITLE_CLASS}>
         {displayTitle}
       </span>
       {withChevron && (

--- a/src/features/Chat/components/ConversationTitle.tsx
+++ b/src/features/Chat/components/ConversationTitle.tsx
@@ -96,7 +96,7 @@ export default function ConversationTitle({
   }
 
   const titleEl = (
-    <div className="flex items-center gap-1.5 min-w-0">
+    <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
       <span className={titleClassName ?? DEFAULT_TITLE_CLASS}>
         {displayTitle}
       </span>
@@ -124,7 +124,7 @@ export default function ConversationTitle({
     return (
       <button
         onClick={onTap}
-        className="flex flex-col items-start min-w-0 text-left bg-transparent border-none p-0 cursor-pointer"
+        className="flex flex-col items-start w-full min-w-0 overflow-hidden text-left bg-transparent border-none p-0 cursor-pointer"
       >
         {titleEl}
       </button>

--- a/src/features/Chat/components/ConversationTitle.tsx
+++ b/src/features/Chat/components/ConversationTitle.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useRef, useState } from "react";
@@ -137,12 +138,16 @@ export default function ConversationTitle({
 // ── ConversationActionsMenu ───────────────────────────────────────────────────
 
 interface ConversationActionsMenuProps {
+  onNewConversation: () => void;
+  canStartNew: boolean;
   onStartRename: () => void;
   onDelete: () => Promise<void>;
   canDelete: boolean;
 }
 
 export function ConversationActionsMenu({
+  onNewConversation,
+  canStartNew,
   onStartRename,
   onDelete,
   canDelete,
@@ -165,6 +170,10 @@ export function ConversationActionsMenu({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem disabled={!canStartNew} onClick={onNewConversation}>
+            New conversation
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem onClick={onStartRename}>Rename</DropdownMenuItem>
           <DropdownMenuItem
             disabled={!canDelete}

--- a/src/features/Chat/components/ConversationTitle.tsx
+++ b/src/features/Chat/components/ConversationTitle.tsx
@@ -9,12 +9,14 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { Trash2 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useRef, useState } from "react";
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
 
 export function getTitleFallback(): string {
   return "New chat";
@@ -24,18 +26,23 @@ export function getTitleFallback(): string {
 
 interface ConversationTitleProps {
   title: string | null | undefined;
+  /** When provided, title becomes a tappable button */
+  onTap?: () => void;
+  /** Show a ▾ chevron to signal tappability */
+  withChevron?: boolean;
+  editing: boolean;
+  onEditingChange: (editing: boolean) => void;
   onRename: (title: string) => Promise<void>;
-  onDelete: () => Promise<void>;
-  canDelete: boolean;
 }
 
 export default function ConversationTitle({
   title,
+  onTap,
+  withChevron,
+  editing,
+  onEditingChange,
   onRename,
-  onDelete,
-  canDelete,
 }: ConversationTitleProps) {
-  const [editing, setEditing] = useState(false);
   const [value, setValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const committingRef = useRef(false);
@@ -44,7 +51,7 @@ export default function ConversationTitle({
 
   const startEditing = () => {
     setValue(displayTitle);
-    setEditing(true);
+    onEditingChange(true);
     setTimeout(() => inputRef.current?.select(), 0);
   };
 
@@ -55,7 +62,7 @@ export default function ConversationTitle({
     if (trimmed && trimmed !== displayTitle) {
       await onRename(trimmed);
     }
-    setEditing(false);
+    onEditingChange(false);
     committingRef.current = false;
   };
 
@@ -64,7 +71,7 @@ export default function ConversationTitle({
       e.preventDefault();
       commitRename();
     } else if (e.key === "Escape") {
-      setEditing(false);
+      onEditingChange(false);
     }
   };
 
@@ -72,7 +79,7 @@ export default function ConversationTitle({
     return (
       <input
         ref={inputRef}
-        className="font-display italic font-medium text-[19px] text-foreground leading-tight tracking-tight bg-transparent border-b border-border outline-none w-full max-w-[280px]"
+        className="font-display italic font-medium text-[16.5px] text-foreground leading-tight tracking-tight bg-transparent border-b border-border outline-none w-full min-w-0"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onBlur={commitRename}
@@ -82,51 +89,88 @@ export default function ConversationTitle({
     );
   }
 
-  return (
-    <div className="flex items-center gap-1.5">
-      <span className="font-display italic font-medium text-[19px] text-foreground leading-tight tracking-tight">
+  const titleEl = (
+    <div className="flex items-center gap-1.5 min-w-0">
+      <span className="font-display italic font-medium text-[16.5px] text-foreground leading-tight tracking-tight truncate">
         {displayTitle}
       </span>
-      <button
-        onClick={startEditing}
-        className="text-ink-faint hover:text-muted-foreground transition-colors cursor-pointer"
-        aria-label="Rename conversation"
-      >
-        {/* Pencil icon 12×12 */}
+      {withChevron && (
         <svg
-          width="12"
-          height="12"
-          viewBox="0 0 24 24"
+          width="11"
+          height="11"
+          viewBox="0 0 16 16"
           fill="none"
-          xmlns="http://www.w3.org/2000/svg"
+          className="text-ink-faint shrink-0"
         >
           <path
-            d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"
+            d="M4 6l4 4 4-4"
             stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-          <path
-            d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"
-            stroke="currentColor"
-            strokeWidth="2"
+            strokeWidth="1.7"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
         </svg>
+      )}
+    </div>
+  );
+
+  if (onTap) {
+    return (
+      <button
+        onClick={onTap}
+        className="flex flex-col items-start min-w-0 text-left bg-transparent border-none p-0 cursor-pointer"
+      >
+        {titleEl}
       </button>
-      <AlertDialog>
-        <AlertDialogTrigger asChild>
+    );
+  }
+
+  return titleEl;
+}
+
+// ── ConversationActionsMenu ───────────────────────────────────────────────────
+
+interface ConversationActionsMenuProps {
+  onStartRename: () => void;
+  onDelete: () => Promise<void>;
+  canDelete: boolean;
+}
+
+export function ConversationActionsMenu({
+  onStartRename,
+  onDelete,
+  canDelete,
+}: ConversationActionsMenuProps) {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
           <button
-            disabled={!canDelete}
-            aria-label="Delete conversation"
-            title={!canDelete ? "Nothing to delete yet" : undefined}
-            className="text-ink-faint hover:text-destructive hover:bg-destructive/10 rounded-sm p-0.5 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            className="flex items-center justify-center w-9 h-9 rounded-lg text-ink-faint hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+            aria-label="More options"
           >
-            <Trash2 size={12} />
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <circle cx="3" cy="8" r="1.4" />
+              <circle cx="8" cy="8" r="1.4" />
+              <circle cx="13" cy="8" r="1.4" />
+            </svg>
           </button>
-        </AlertDialogTrigger>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={onStartRename}>Rename</DropdownMenuItem>
+          <DropdownMenuItem
+            disabled={!canDelete}
+            className="text-destructive focus:text-destructive"
+            onClick={() => setDeleteDialogOpen(true)}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this conversation?</AlertDialogTitle>
@@ -145,6 +189,6 @@ export default function ConversationTitle({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
+    </>
   );
 }

--- a/src/features/Chat/components/ConversationTitle.tsx
+++ b/src/features/Chat/components/ConversationTitle.tsx
@@ -86,7 +86,7 @@ export default function ConversationTitle({
     return (
       <input
         ref={inputRef}
-        className="font-display italic font-medium text-[16.5px] text-foreground leading-tight tracking-tight bg-transparent border-b border-border outline-none w-full min-w-0"
+        className={`${DEFAULT_TITLE_CLASS} bg-transparent border-b border-border outline-none w-full`}
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onBlur={commitRename}
@@ -177,7 +177,7 @@ export function ConversationActionsMenu({
           <DropdownMenuItem onClick={onStartRename}>Rename</DropdownMenuItem>
           <DropdownMenuItem
             disabled={!canDelete}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
             onClick={() => setDeleteDialogOpen(true)}
           >
             Delete

--- a/src/features/Conversations/components/ConversationsMobileSheet.tsx
+++ b/src/features/Conversations/components/ConversationsMobileSheet.tsx
@@ -11,7 +11,7 @@ interface ConversationsMobileSheetProps {
 export function ConversationsMobileSheet({ open, onOpenChange }: ConversationsMobileSheetProps) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="left" className="w-[280px] p-0 bg-muted paper">
+      <SheetContent side="left" className="w-[280px] p-0 bg-muted paper" showCloseButton={false}>
         <SheetTitle className="sr-only">Conversations</SheetTitle>
         <div className="flex flex-col p-4 h-full overflow-hidden">
           <Conversations onItemClick={() => onOpenChange(false)} />


### PR DESCRIPTION
## Summary

- Chat header now renders at all widths (was `hidden sm:flex` — true mobile had no header at all)
- Single row: `[≡] • Title… [⋯]` — hamburger opens conversations sheet; title truncates with ellipsis before the menu button
- All conversation actions consolidated into `⋯` overflow menu: New conversation / Rename / Delete
- `ConversationTitle` refactored into pure display component; `ConversationActionsMenu` is a separate named export
- `dropdown-menu` shadcn primitive added
- `ConversationsMobileSheet` suppresses the shadcn auto-close X (was overlapping the Conversations `+` button)

## Test plan

- [ ] At 390px: header visible, `[≡]` opens conversations sheet, long title ellipsizes cleanly before `[⋯]`
- [ ] `⋯` dropdown shows: New conversation (disabled when no messages) → Rename → Delete
- [ ] New conversation, Rename, Delete all still work correctly
- [ ] Mobile sheet opens cleanly — no close button overlap in the top-right corner
- [ ] Desktop (≥1024px): header renders correctly with the persistent sidebar

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented mobile-responsive chat header with improved interaction design.
  * Conversation actions (rename, delete, new chat) now accessible through a dropdown menu.

* **Improvements**
  * Enhanced mobile experience with optimized header layout for small screens.
  * Refined mobile sheet interaction by simplifying controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/141)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->