### PR TITLE
feat(recipe-display): strip pantry awareness; mobile padding (#135)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -38,6 +38,13 @@ The persistent-kitchen MVP. Highlights:
 - [x] Bug fixed (May 2026): `Conversations.tsx` was reading `data?.grouped` but API returns `{ conversations: GroupedConversations }` — fixed to `data?.conversations`.
 - [x] Bug fixed (May 2026): `src/app/api/message/route.ts` used default import for prisma — fixed to named `{ prisma }`.
 
+### RecipeDisplay (cookbook): strip pantry awareness + mobile padding (May 2026)
+- [x] `RecipeDisplay` no longer fetches inventory or shows HAVE/NEED badges — cookbook is recipe storage, not meal planning.
+- [x] `LegacyRecipeBody` and the `RecipeLetter`-based structured path collapsed into a single `RecipeBody`: legacy recipes use `Streamdown` markdown fallback; structured recipes (with `steps`) render numbered step cards.
+- [x] Mobile padding: `px-4 sm:px-9` throughout (was `px-6 sm:px-9`).
+- [x] Servings stepper moved inline with "What to gather" ingredients heading — saves vertical space on mobile.
+- [x] All 16 `RecipeDisplay` tests pass; SWR/session mocks removed; structured-steps and no-pantry assertions added.
+
 ### Recipe card enrichment — description + total time (May 2026)
 - [x] `description` and `totalTimeMinutes` exist in schema/types.
 - [x] `processRecipe` extracts description + total time on save.

--- a/src/features/RecipeDisplay/RecipeDisplay.test.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.test.tsx
@@ -47,11 +47,6 @@ jest.mock("@/components/ui/badge", () => ({
   ),
 }));
 
-jest.mock("swr", () => ({
-  __esModule: true,
-  default: jest.fn(() => ({ data: undefined, error: undefined })),
-}));
-
 const mockSelectedRecipe = jest.fn();
 
 jest.mock("@/contexts/RecipeContext", () => ({
@@ -60,10 +55,6 @@ jest.mock("@/contexts/RecipeContext", () => ({
     setSelectedRecipe: jest.fn(),
     exitRecipe: jest.fn(),
   }),
-}));
-
-jest.mock("@/contexts/SessionContext", () => ({
-  useSessionContext: () => ({ userId: "user-123" }),
 }));
 
 const baseRecipe = {
@@ -98,7 +89,7 @@ describe("RecipeDisplay", () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it("renders recipe instructions via Streamdown", () => {
+    it("renders recipe instructions via Streamdown for legacy recipes", () => {
       render(<RecipeDisplay />);
       const method = screen.getByTestId("streamdown");
       expect(method).toHaveTextContent("Heat butter");
@@ -115,7 +106,6 @@ describe("RecipeDisplay", () => {
 
     it("renders structured ingredients", () => {
       render(<RecipeDisplay />);
-      // Structured list shows scaled amount + unit
       expect(screen.getAllByText(/3 piece/).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/2 tbsp/).length).toBeGreaterThan(0);
     });
@@ -123,6 +113,43 @@ describe("RecipeDisplay", () => {
     it("renders the copy button", () => {
       render(<RecipeDisplay />);
       expect(screen.getByText("Copy")).toBeInTheDocument();
+    });
+
+    it("renders no pantry badges or inventory-based UI", () => {
+      render(<RecipeDisplay />);
+      expect(screen.queryByText(/in pantry/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/\bNEED\b/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/\bHAVE\b/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/short/i)).not.toBeInTheDocument();
+    });
+
+    it("renders the ingredients section as 'What to gather'", () => {
+      render(<RecipeDisplay />);
+      expect(screen.getByText("What to gather")).toBeInTheDocument();
+    });
+  });
+
+  describe("Structured steps", () => {
+    it("renders step title and body when steps are present", () => {
+      mockSelectedRecipe.mockReturnValue({
+        ...baseRecipe,
+        steps: [
+          { title: "Heat the pan", body: "Put butter in a pan on medium heat.", tip: "Don't let it brown." },
+          { title: "Add eggs", body: "Beat and pour in eggs." },
+        ],
+      });
+      render(<RecipeDisplay />);
+      expect(screen.getByText("Heat the pan")).toBeInTheDocument();
+      expect(screen.getByText("Put butter in a pan on medium heat.")).toBeInTheDocument();
+      expect(screen.getByText("Don't let it brown.")).toBeInTheDocument();
+      expect(screen.getByText("Add eggs")).toBeInTheDocument();
+      expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
+    });
+
+    it("falls back to Streamdown when steps array is empty", () => {
+      mockSelectedRecipe.mockReturnValue({ ...baseRecipe, steps: [] });
+      render(<RecipeDisplay />);
+      expect(screen.getByTestId("streamdown")).toBeInTheDocument();
     });
   });
 
@@ -135,22 +162,20 @@ describe("RecipeDisplay", () => {
     it("scales ingredient amounts when servings increase", () => {
       render(<RecipeDisplay />);
       fireEvent.click(screen.getByLabelText("Increase servings"));
-      // Doubling baseServings 2 → 3 → eggs scales 3 × 1.5 = 4.5
       expect(screen.getByText(/4\.5 piece/)).toBeInTheDocument();
     });
 
     it("scales ingredient amounts when servings decrease", () => {
       render(<RecipeDisplay />);
       fireEvent.click(screen.getByLabelText("Decrease servings"));
-      // 3 eggs * (1/2) = 1.5
       expect(screen.getByText(/1\.5 piece/)).toBeInTheDocument();
     });
 
     it("does not go below 1 serving", () => {
       render(<RecipeDisplay />);
       const dec = screen.getByLabelText("Decrease servings");
-      fireEvent.click(dec); // 1
-      fireEvent.click(dec); // should clamp at 1
+      fireEvent.click(dec);
+      fireEvent.click(dec);
       expect(dec).toBeDisabled();
     });
   });
@@ -160,9 +185,7 @@ describe("RecipeDisplay", () => {
       render(<RecipeDisplay />);
       fireEvent.click(screen.getByText("Copy"));
       await waitFor(() => {
-        expect(mockClipboard.writeText).toHaveBeenCalledWith(
-          baseRecipe.instructions,
-        );
+        expect(mockClipboard.writeText).toHaveBeenCalledWith(baseRecipe.instructions);
       });
     });
 
@@ -170,9 +193,7 @@ describe("RecipeDisplay", () => {
       render(<RecipeDisplay />);
       fireEvent.click(screen.getByText("Copy"));
       await waitFor(() => {
-        expect(toast.success).toHaveBeenCalledWith(
-          "Recipe copied to clipboard!",
-        );
+        expect(toast.success).toHaveBeenCalledWith("Recipe copied to clipboard!");
       });
     });
 
@@ -185,5 +206,4 @@ describe("RecipeDisplay", () => {
       });
     });
   });
-
 });

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -1,15 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { useRecipeContext } from "@/contexts/RecipeContext";
-import { useSessionContext } from "@/contexts/SessionContext";
-import { RecipeLetter } from "@/features/Chat/components/recipe/RecipeLetter";
-import { GetInventoryResponse, InventoryItem } from "@/lib/inventory/schemas";
 import { RecipeIngredient, RecipeStep, RecipeWithId } from "@/lib/recipes/schemas";
-import { fetcher } from "@/lib/utils/index";
 import Image from "next/image";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Streamdown } from "streamdown";
-import useSWR from "swr";
 
 const formatAmount = (n: number) => {
   if (Number.isInteger(n)) return String(n);
@@ -17,13 +12,10 @@ const formatAmount = (n: number) => {
 };
 
 const extractInstructions = (markdown: string): string => {
-  // Find the **Instructions:** heading and return everything after it.
-  // Also strips the trailing -----  delimiter if present.
   const match = markdown.match(/\*\*Instructions:\*\*\s*\n([\s\S]*)/i);
   if (match) {
     return match[1].replace(/\n?\s*-----\s*$/, "").trim();
   }
-  // Fallback: return the full text (e.g. freeform recipes without the delimiter format)
   return markdown;
 };
 
@@ -34,89 +26,27 @@ const formatTime = (minutes: number): string => {
   return m > 0 ? `${h} h ${m} m` : `${h} h`;
 };
 
-const findInventoryMatch = (
-  ingredient: RecipeIngredient,
-  inventory: InventoryItem[],
-): InventoryItem | undefined => {
-  const target = ingredient.name.trim().toLowerCase();
-  return inventory.find((item) => item.name.trim().toLowerCase() === target);
-};
-
-const computeShortfall = (
-  scaledAmount: number,
-  recipeUnit: string | undefined,
-  inv: InventoryItem | undefined,
-): number | null => {
-  if (!inv) return null;
-  if (inv.quantity == null) return null;
-  if (!recipeUnit || !inv.unit) return null;
-  if (recipeUnit.toLowerCase() !== inv.unit.toLowerCase()) return null;
-  const diff = scaledAmount - inv.quantity;
-  return diff > 0 ? diff : null;
-};
-
-function LegacyRecipeBody({
-  selectedRecipe,
-}: {
-  selectedRecipe: RecipeWithId;
-}) {
-  const { userId } = useSessionContext();
-  const [servings, setServings] = useState<number>(
-    selectedRecipe?.baseServings ?? 2,
-  );
-
-  const { data: inventoryData } = useSWR<GetInventoryResponse>(
-    userId ? `/api/inventory?userId=${userId}` : null,
-    fetcher,
-  );
-
+function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
+  const [servings, setServings] = useState<number>(selectedRecipe.baseServings ?? 2);
   const baseServings = selectedRecipe.baseServings || 2;
   const ingredients = (selectedRecipe.ingredients || []) as RecipeIngredient[];
-  const allInventory = [
-    ...(inventoryData?.ingredientInventory ?? []),
-    ...(inventoryData?.kitchenwareInventory ?? []),
-  ];
+  const steps = (selectedRecipe.steps || []) as RecipeStep[];
   const scale = servings / baseServings;
-
-  const ingredientStatus = ingredients.map((ing) => {
-    const scaled = ing.amount != null ? ing.amount * scale : undefined;
-    const inv = findInventoryMatch(ing, allInventory);
-    const comparable =
-      scaled != null &&
-      inv?.quantity != null &&
-      !!ing.unit &&
-      !!inv.unit &&
-      ing.unit.toLowerCase() === inv.unit.toLowerCase();
-    const short = comparable ? computeShortfall(scaled, ing.unit, inv) : null;
-    const inPantry = comparable && short == null;
-    return { ing, scaled, inv, short, inPantry };
-  });
-  const inPantryCount = ingredientStatus.filter((s) => s.inPantry).length;
-  const shortCount = ingredientStatus.filter((s) => s.short != null).length;
 
   return (
     <>
       {/* Hero strip */}
       <div
         className="relative h-[180px] sm:h-[220px] border-b border-border flex items-end"
-        style={{
-          background:
-            "linear-gradient(135deg, oklch(0.55 0.13 35) 0%, oklch(0.42 0.10 30) 100%)",
-        }}
+        style={{ background: "linear-gradient(135deg, oklch(0.55 0.13 35) 0%, oklch(0.42 0.10 30) 100%)" }}
       >
         <div
           className="absolute inset-0"
-          style={{
-            backgroundImage:
-              "repeating-linear-gradient(135deg, oklch(1 0 0 / 0.04) 0 12px, transparent 12px 24px)",
-          }}
+          style={{ backgroundImage: "repeating-linear-gradient(135deg, oklch(1 0 0 / 0.04) 0 12px, transparent 12px 24px)" }}
         />
         <div
-          className="relative w-full px-9 pt-6 pb-5 text-white"
-          style={{
-            background:
-              "linear-gradient(to top, oklch(0 0 0 / 0.3), transparent)",
-          }}
+          className="relative w-full px-4 sm:px-9 pt-6 pb-5 text-white"
+          style={{ background: "linear-gradient(to top, oklch(0 0 0 / 0.3), transparent)" }}
         >
           {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-2.5">
@@ -140,17 +70,12 @@ function LegacyRecipeBody({
       </div>
 
       {/* Body */}
-      <div className="px-6 sm:px-9 py-7 pb-12">
+      <div className="px-4 sm:px-9 py-7 pb-12">
         {/* From Ah Mah */}
         {selectedRecipe.description && (
           <div className="flex gap-3.5 items-start mb-6 pb-5 border-b border-dashed border-border">
             <div className="relative w-10 h-10 shrink-0">
-              <Image
-                src="/granny-icon.png"
-                alt=""
-                fill
-                className="object-contain"
-              />
+              <Image src="/granny-icon.png" alt="" fill className="object-contain" />
             </div>
             <div>
               <div className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint mb-1">
@@ -163,9 +88,9 @@ function LegacyRecipeBody({
           </div>
         )}
 
-        {/* Stat row — total time + servings stepper */}
-        <div className="flex flex-wrap items-end gap-3 mb-7">
-          {selectedRecipe.totalTimeMinutes && (
+        {/* Stat row — total time */}
+        {selectedRecipe.totalTimeMinutes && (
+          <div className="flex flex-wrap items-end gap-3 mb-7">
             <div className="flex flex-col px-3.5 py-2 bg-card border border-border rounded-lg shadow-[0_1px_0_var(--color-border-soft)] min-w-[78px]">
               <span className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
                 Total time
@@ -174,102 +99,57 @@ function LegacyRecipeBody({
                 {formatTime(selectedRecipe.totalTimeMinutes)}
               </span>
             </div>
-          )}
-          <div className="flex flex-col px-3.5 py-2 bg-card border border-border rounded-lg shadow-[0_1px_0_var(--color-border-soft)] min-w-[78px]">
-            <span className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
-              Yields
-            </span>
-            <span className="font-display font-semibold text-[18px] text-foreground tabular-nums mt-0.5">
-              {servings} {servings === 1 ? "serving" : "servings"}
-            </span>
           </div>
-          <div className="flex-1" />
-          <div className="flex flex-col items-end gap-1.5">
-            <span className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint">
-              Servings
-            </span>
-            <div className="inline-flex items-center bg-card border border-border rounded-lg overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
-              <button
-                onClick={() => setServings((s) => Math.max(1, s - 1))}
-                disabled={servings <= 1}
-                aria-label="Decrease servings"
-                className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-r border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
-              >
-                −
-              </button>
-              <span className="min-w-11 text-center font-display font-semibold text-[15px] text-foreground tabular-nums">
-                {servings}
-              </span>
-              <button
-                onClick={() => setServings((s) => Math.min(20, s + 1))}
-                disabled={servings >= 20}
-                aria-label="Increase servings"
-                className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-l border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
-              >
-                +
-              </button>
-            </div>
-          </div>
-        </div>
+        )}
 
-        {/* Ingredients */}
+        {/* Ingredients — header inline with servings stepper */}
         {ingredients.length > 0 && (
           <section className="mb-9">
-            <div className="flex items-baseline justify-between mb-1 flex-wrap gap-3">
+            <div className="flex items-center justify-between mb-1 gap-3">
               <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight m-0">
-                Ingredients
+                What to gather
               </h2>
-              <div className="flex items-center gap-3.5 font-sans text-[12px] text-muted-foreground">
-                {inPantryCount > 0 && (
-                  <span className="inline-flex items-center gap-1.5">
-                    <span className="w-2 h-2 rounded-full bg-jade" />
-                    {inPantryCount} in pantry
-                  </span>
-                )}
-                {shortCount > 0 && (
-                  <span className="inline-flex items-center gap-1.5">
-                    <span className="w-2 h-2 rounded-full bg-destructive" />
-                    {shortCount} short
-                  </span>
-                )}
+              <div className="inline-flex items-center bg-card border border-border rounded-lg overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
+                <button
+                  onClick={() => setServings((s) => Math.max(1, s - 1))}
+                  disabled={servings <= 1}
+                  aria-label="Decrease servings"
+                  className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-r border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                >
+                  −
+                </button>
+                <span className="min-w-11 text-center font-display font-semibold text-[15px] text-foreground tabular-nums">
+                  {servings}
+                </span>
+                <button
+                  onClick={() => setServings((s) => Math.min(20, s + 1))}
+                  disabled={servings >= 20}
+                  aria-label="Increase servings"
+                  className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-l border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                >
+                  +
+                </button>
               </div>
             </div>
             <ul className="list-none p-0 mt-2 border-t border-border">
-              {ingredientStatus.map(({ ing, scaled, inv, short, inPantry }, i) => (
-                <li
-                  key={i}
-                  className="flex items-baseline gap-3 py-2.5 border-b border-dashed border-border"
-                >
-                  <span className="basis-20 sm:basis-24 shrink-0 font-mono text-[13px] font-semibold text-foreground tabular-nums text-right">
-                    {scaled != null
-                      ? `${formatAmount(scaled)}${ing.unit ? ` ${ing.unit}` : ""}`
-                      : "—"}
-                  </span>
-                  <span className="flex-1 font-display text-[15px] text-foreground leading-[1.4]">
-                    {ing.name}
-                  </span>
-                  {inPantry && (
-                    <span
-                      className="font-sans text-[10.5px] font-semibold px-[7px] py-[2px] rounded-full tracking-wide shrink-0 text-jade border"
-                      style={{
-                        background: "oklch(0.94 0.04 168)",
-                        borderColor: "oklch(0.78 0.07 168)",
-                      }}
-                    >
-                      in pantry
+              {ingredients.map((ing, i) => {
+                const scaled = ing.amount != null ? ing.amount * scale : undefined;
+                return (
+                  <li
+                    key={i}
+                    className="flex items-baseline gap-3 py-2.5 border-b border-dashed border-border"
+                  >
+                    <span className="basis-20 sm:basis-24 shrink-0 font-mono text-[13px] font-semibold text-foreground tabular-nums text-right">
+                      {scaled != null
+                        ? `${formatAmount(scaled)}${ing.unit ? ` ${ing.unit}` : ""}`
+                        : "—"}
                     </span>
-                  )}
-                  {short != null && (
-                    <span
-                      className="font-sans text-[10.5px] font-semibold px-[7px] py-[2px] rounded-full tracking-wide shrink-0 text-destructive border border-destructive/30 bg-destructive/10"
-                      title={`You have ${inv?.quantity}${inv?.unit ? ` ${inv.unit}` : ""}`}
-                    >
-                      short {formatAmount(short)}
-                      {ing.unit ? ` ${ing.unit}` : ""}
+                    <span className="flex-1 font-display text-[15px] text-foreground leading-[1.4]">
+                      {ing.name}
                     </span>
-                  )}
-                </li>
-              ))}
+                  </li>
+                );
+              })}
             </ul>
           </section>
         )}
@@ -279,11 +159,36 @@ function LegacyRecipeBody({
           <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight mb-4">
             Method
           </h2>
-          <div className="recipe-prose">
-            <Streamdown>
-              {extractInstructions(selectedRecipe.instructions || "")}
-            </Streamdown>
-          </div>
+          {steps.length > 0 ? (
+            <ol className="list-none p-0 flex flex-col gap-5">
+              {steps.map((step, i) => (
+                <li key={i} className="flex gap-4">
+                  <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums pt-0.5 shrink-0 w-5 text-right">
+                    {i + 1}.
+                  </span>
+                  <div className="flex-1">
+                    {step.title && (
+                      <div className="font-display font-semibold text-[15px] text-foreground mb-0.5">
+                        {step.title}
+                      </div>
+                    )}
+                    <div className="font-sans text-[14px] text-foreground leading-[1.6]">
+                      {step.body}
+                    </div>
+                    {step.tip && (
+                      <div className="mt-1.5 text-[12.5px] text-ink-faint italic">
+                        {step.tip}
+                      </div>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <div className="recipe-prose">
+              <Streamdown>{extractInstructions(selectedRecipe.instructions || "")}</Streamdown>
+            </div>
+          )}
         </section>
       </div>
     </>
@@ -307,7 +212,7 @@ export default function RecipeDisplay() {
   return (
     <div className="flex flex-col h-full">
       {/* Top strip — Back / Copy */}
-      <div className="flex items-center justify-between px-6 py-3 border-b border-dashed border-border shrink-0">
+      <div className="flex items-center justify-between px-4 sm:px-6 py-3 border-b border-dashed border-border shrink-0">
         <button
           onClick={exitRecipe}
           className="font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
@@ -342,32 +247,9 @@ export default function RecipeDisplay() {
         </div>
       </div>
 
-      {selectedRecipe.steps && (selectedRecipe.steps as RecipeStep[]).length > 0 ? (
-        // New structured recipe — render RecipeLetter (no onSave — it's already saved)
-        <div className="flex-1 overflow-y-auto px-6 sm:px-9 py-7 pb-12">
-          <RecipeLetter
-            recipe={{
-              title: selectedRecipe.name,
-              description: selectedRecipe.description ?? undefined,
-              totalTimeMinutes: selectedRecipe.totalTimeMinutes ?? undefined,
-              baseServings: selectedRecipe.baseServings,
-              ingredients: (selectedRecipe.ingredients as RecipeIngredient[]).map(ing => ({
-                name: ing.name,
-                amount: ing.amount != null ? String(ing.amount) : undefined,
-                unit: ing.unit ?? undefined,
-              })),
-              steps: selectedRecipe.steps as RecipeStep[],
-              tags: selectedRecipe.tags ?? undefined,
-            }}
-            // No onSave — recipe is already saved (it came from the cookbook)
-          />
-        </div>
-      ) : (
-        // Legacy recipe — fall back to existing layout (hero strip + body)
-        <div className="flex-1 overflow-y-auto">
-          <LegacyRecipeBody selectedRecipe={selectedRecipe} />
-        </div>
-      )}
+      <div className="flex-1 overflow-y-auto">
+        <RecipeBody selectedRecipe={selectedRecipe} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- `RecipeDisplay` (cookbook) no longer fetches inventory or shows pantry-aware badges — cookbook is recipe storage, chat is pantry-aware
- Collapsed `LegacyRecipeBody` + `RecipeLetter` structured path into a single `RecipeBody`: legacy recipes use Streamdown markdown fallback; structured recipes (with `steps`) render numbered step cards inline
- Mobile outer padding `px-4 sm:px-9` (was `px-6 sm:px-9`)
- Servings stepper moved inline with "What to gather" heading — saves vertical space on mobile
- Removed ~91 lines net; SWR, session, and inventory imports gone

## Test plan

- [ ] Open a saved recipe from the cookbook → Network tab shows no `/api/inventory` request
- [ ] No "in pantry", HAVE, NEED, or "short" text anywhere in RecipeDisplay
- [ ] At 390px: outer padding is 16px, stepper sits beside the "What to gather" heading
- [ ] Structured recipe (with steps): numbered step cards render correctly
- [ ] Legacy recipe (no steps): Streamdown markdown fallback renders
- [ ] `pnpm test RecipeDisplay` → 16 passed

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)