### PR TITLE
feat(recipe-letter): NEED-only ingredient badges; mobile padding (#134)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -40,7 +40,7 @@ The persistent-kitchen MVP. Highlights:
 
 ### RecipeLetter (chat-inline): NEED-only badges + mobile padding (May 2026)
 - [x] Outer padding: `px-4 sm:px-[26px]` (was fixed `26px` — gives 16px horizontal on mobile).
-- [x] HAVE badge removed from ingredient rows; only NEED button (click-to-add) remains for missing items.
+- [x] HAVE badge removed from ingredient rows; missing items now show a small cart-icon button (click-to-add) instead of the ambiguous "NEED" text label.
 - [x] Servings stepper already inline with "What to gather" heading — no change needed.
 - [x] Shortfall card unchanged.
 - [x] RecipeLetter test updated: HAVE assertion flipped to confirm badge is absent; all 13 tests pass.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -38,7 +38,7 @@ The persistent-kitchen MVP. Highlights:
 - [x] Bug fixed (May 2026): `Conversations.tsx` was reading `data?.grouped` but API returns `{ conversations: GroupedConversations }` — fixed to `data?.conversations`.
 - [x] Bug fixed (May 2026): `src/app/api/message/route.ts` used default import for prisma — fixed to named `{ prisma }`.
 
-### RecipeLetter (chat-inline): NEED-only badges + mobile padding (May 2026)
+### RecipeLetter (chat-inline): cart-icon add button + mobile padding (May 2026)
 - [x] Outer padding: `px-4 sm:px-[26px]` (was fixed `26px` — gives 16px horizontal on mobile).
 - [x] HAVE badge removed from ingredient rows; missing items now show a small cart-icon button (click-to-add) instead of the ambiguous "NEED" text label.
 - [x] Servings stepper already inline with "What to gather" heading — no change needed.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -38,6 +38,13 @@ The persistent-kitchen MVP. Highlights:
 - [x] Bug fixed (May 2026): `Conversations.tsx` was reading `data?.grouped` but API returns `{ conversations: GroupedConversations }` — fixed to `data?.conversations`.
 - [x] Bug fixed (May 2026): `src/app/api/message/route.ts` used default import for prisma — fixed to named `{ prisma }`.
 
+### RecipeLetter (chat-inline): NEED-only badges + mobile padding (May 2026)
+- [x] Outer padding: `px-4 sm:px-[26px]` (was fixed `26px` — gives 16px horizontal on mobile).
+- [x] HAVE badge removed from ingredient rows; only NEED button (click-to-add) remains for missing items.
+- [x] Servings stepper already inline with "What to gather" heading — no change needed.
+- [x] Shortfall card unchanged.
+- [x] RecipeLetter test updated: HAVE assertion flipped to confirm badge is absent; all 13 tests pass.
+
 ### RecipeDisplay (cookbook): strip pantry awareness + mobile padding (May 2026)
 - [x] `RecipeDisplay` no longer fetches inventory or shows HAVE/NEED badges — cookbook is recipe storage, not meal planning.
 - [x] `LegacyRecipeBody` and the `RecipeLetter`-based structured path collapsed into a single `RecipeBody`: legacy recipes use `Streamdown` markdown fallback; structured recipes (with `steps`) render numbered step cards.

--- a/src/features/Chat/components/recipe/RecipeLetter.test.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.test.tsx
@@ -132,10 +132,10 @@ describe('NEED pill click-to-add', () => {
     expect(screen.getByLabelText('Add bok choy to pantry')).toBeInTheDocument();
   });
 
-  it('renders HAVE (non-interactive) for ingredient already in pantry', () => {
+  it('renders no badge for ingredient already in pantry (HAVE removed)', () => {
     render(<RecipeLetter recipe={RECIPE} />);
     expect(screen.queryByLabelText('Add chicken thigh to pantry')).not.toBeInTheDocument();
-    expect(screen.getByText('HAVE')).toBeInTheDocument();
+    expect(screen.queryByText('HAVE')).not.toBeInTheDocument();
   });
 
   it('posts correct body and shows success toast on NEED click', async () => {

--- a/src/features/Chat/components/recipe/RecipeLetter.test.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.test.tsx
@@ -132,6 +132,13 @@ describe('NEED pill click-to-add', () => {
     expect(screen.getByLabelText('Add bok choy to pantry')).toBeInTheDocument();
   });
 
+  it('renders a cart icon (not text) inside the add-to-pantry button', () => {
+    render(<RecipeLetter recipe={RECIPE} />);
+    const button = screen.getByLabelText('Add bok choy to pantry');
+    expect(button.textContent).toBe('');
+    expect(button.querySelector('svg.lucide-shopping-cart')).toBeInTheDocument();
+  });
+
   it('renders no badge for ingredient already in pantry (HAVE removed)', () => {
     render(<RecipeLetter recipe={RECIPE} />);
     expect(screen.queryByLabelText('Add chicken thigh to pantry')).not.toBeInTheDocument();

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -254,7 +254,7 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
   }
 
   return (
-    <div className=" border-y border-border-soft p-[20px_26px_22px] relative">
+    <div className="border-y border-border-soft px-4 sm:px-[26px] pt-5 pb-[22px] relative">
       {/* Title */}
       <div className="font-display text-3xl font-semibold text-foreground leading-[1.05] tracking-tight mb-2">
         {recipe.title}
@@ -371,11 +371,11 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
                       </span>
                     )}
                   </span>
-                  {userId && inventoryItems.length > 0 && (
+                  {userId && inventoryItems.length > 0 && !have && (
                     <HaveTag
-                      have={have}
+                      have={false}
                       ingredientName={ing.name}
-                      onAdd={have ? undefined : () => addToPantry(ing)}
+                      onAdd={() => addToPantry(ing)}
                       pending={inFlight.has(ing.name)}
                     />
                   )}

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -9,7 +9,7 @@ import {
 import { ingredientMatches } from "@/lib/recipes/matchIngredient";
 import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils/index";
-import { TimerIcon } from "lucide-react";
+import { ShoppingCart, TimerIcon } from "lucide-react";
 import { useState } from "react";
 import { CookingMode } from "./CookingMode";
 import { toast } from "sonner";
@@ -91,46 +91,30 @@ function ServingsStepper({
   );
 }
 
-function HaveTag({
-  have,
+function NeedCartButton({
   ingredientName,
   onAdd,
   pending,
 }: {
-  have: boolean;
   ingredientName: string;
-  onAdd?: () => void;
+  onAdd: () => void;
   pending?: boolean;
 }) {
-  const BASE =
-    "font-sans text-[9.5px] font-bold px-1.5 py-0.5 rounded-full tracking-wider shrink-0";
-  if (have) {
-    return (
-      <span
-        className={cn(
-          BASE,
-          "text-jade bg-[oklch(0.94_0.04_168)] border border-[oklch(0.78_0.07_168)]",
-        )}
-      >
-        HAVE
-      </span>
-    );
-  }
   return (
     <button
       type="button"
       onClick={onAdd}
       disabled={pending}
       aria-label={`Add ${ingredientName} to pantry`}
+      title={`Add ${ingredientName} to pantry`}
       className={cn(
-        BASE,
-        "text-muted-foreground bg-transparent border border-border transition-colors",
+        "shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full text-muted-foreground bg-transparent border border-border transition-colors",
         pending
           ? "opacity-50 cursor-not-allowed"
           : "cursor-pointer hover:bg-muted hover:text-foreground",
       )}
     >
-      NEED
+      <ShoppingCart className="w-3 h-3" strokeWidth={1.8} />
     </button>
   );
 }
@@ -372,8 +356,7 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
                     )}
                   </span>
                   {userId && inventoryItems.length > 0 && !have && (
-                    <HaveTag
-                      have={false}
+                    <NeedCartButton
                       ingredientName={ing.name}
                       onAdd={() => addToPantry(ing)}
                       pending={inFlight.has(ing.name)}


### PR DESCRIPTION
## Summary

- **Mobile padding**: `px-4 sm:px-[26px]` — 16px horizontal on mobile, existing 26px on sm+ (was fixed 26px everywhere)
- **HAVE badge removed**: ingredient rows no longer show a green HAVE tag for items already in pantry. Only the NEED button (click-to-add) remains for missing items — cleaner signal, less visual noise
- Servings stepper was already inline with "What to gather" heading — no change needed
- Shortfall card ("You're almost there") unchanged

## Test plan

- [ ] At 390px: recipe card has 16px left/right padding
- [ ] Ingredient row for an item in pantry: no badge at all
- [ ] Ingredient row for a missing item: NEED button still present and clickable
- [ ] Shortfall card still renders and both buttons work
- [ ] `pnpm test RecipeLetter` → 13 passed

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quick-add cart button for missing ingredients in recipes.

* **Improvements**
  * Removed ingredient status badge for a cleaner interface.
  * Optimized mobile layout and padding.

* **Tests**
  * Updated test assertions to verify new ingredient display behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->