### PR TITLE
feat(cookbook): mobile search + horizontal-scroll chip rail (#133)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -38,6 +38,15 @@ The persistent-kitchen MVP. Highlights:
 - [x] Bug fixed (May 2026): `Conversations.tsx` was reading `data?.grouped` but API returns `{ conversations: GroupedConversations }` — fixed to `data?.conversations`.
 - [x] Bug fixed (May 2026): `src/app/api/message/route.ts` used default import for prisma — fixed to named `{ prisma }`.
 
+### Mobile cookbook: search + Cuisine/Protein facets (May 2026)
+- [x] Search input visible at all widths (was `hidden sm:flex`); title strip stacks on mobile.
+- [x] Search now matches `name || tag` (lowercase) — off-vocab tags like `filipino` become findable.
+- [x] At `<sm`: flat tag chip rail replaced by `Cuisine ▾` + `Protein ▾` facet buttons opening bottom Sheets.
+- [x] Each facet sheet lists only canonical tags from `TAG_SETS` with recipe counts, sorted desc; single-select per facet, AND across facets.
+- [x] Selected facet button shows the chosen value with primary fill; sheet has Clear option at top.
+- [x] At `≥sm`: existing chip rail unchanged (mobile facet state is independent of desktop).
+- [x] Mobile padding `px-4 sm:px-9` applied to title strip and grid.
+
 ### RecipeLetter (chat-inline): cart-icon add button + mobile padding (May 2026)
 - [x] Outer padding: `px-4 sm:px-[26px]` (was fixed `26px` — gives 16px horizontal on mobile).
 - [x] HAVE badge removed from ingredient rows; missing items now show a small cart-icon button (click-to-add) instead of the ambiguous "NEED" text label.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -38,14 +38,14 @@ The persistent-kitchen MVP. Highlights:
 - [x] Bug fixed (May 2026): `Conversations.tsx` was reading `data?.grouped` but API returns `{ conversations: GroupedConversations }` — fixed to `data?.conversations`.
 - [x] Bug fixed (May 2026): `src/app/api/message/route.ts` used default import for prisma — fixed to named `{ prisma }`.
 
-### Mobile cookbook: search + Cuisine/Protein facets (May 2026)
+### Mobile cookbook: search + horizontal-scroll chip rail (May 2026)
 - [x] Search input visible at all widths (was `hidden sm:flex`); title strip stacks on mobile.
 - [x] Search now matches `name || tag` (lowercase) — off-vocab tags like `filipino` become findable.
-- [x] At `<sm`: flat tag chip rail replaced by `Cuisine ▾` + `Protein ▾` facet buttons opening bottom Sheets.
-- [x] Each facet sheet lists only canonical tags from `TAG_SETS` with recipe counts, sorted desc; single-select per facet, AND across facets.
-- [x] Selected facet button shows the chosen value with primary fill; sheet has Clear option at top.
-- [x] At `≥sm`: existing chip rail unchanged (mobile facet state is independent of desktop).
-- [x] Mobile padding `px-4 sm:px-9` applied to title strip and grid.
+- [x] Chip rail unified across mobile and desktop: same `activeTag` single-select, same chips. `<sm` uses `overflow-x-auto flex-nowrap` for horizontal scroll; `≥sm` keeps `flex-wrap`. Last visible chip bleeds off the right edge on mobile to suggest more.
+- [x] "Filter" eyebrow label hidden on mobile (`hidden sm:inline`).
+- [x] Scrollbar hidden via `[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden`.
+- [x] Mobile padding `px-4 sm:px-9` applied to title strip, rail, and grid.
+- [x] Earlier facet-sheet design (Cuisine ▾ / Protein ▾ bottom sheets) reverted — felt too heavy and hid options behind taps; horizontal-scroll surfaces all tags at a glance.
 
 ### RecipeLetter (chat-inline): cart-icon add button + mobile padding (May 2026)
 - [x] Outer padding: `px-4 sm:px-[26px]` (was fixed `26px` — gives 16px horizontal on mobile).

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -1,90 +1,16 @@
 "use client";
 
-import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { useRecipeContext } from "@/contexts/RecipeContext";
 import { useSessionContext } from "@/contexts/SessionContext";
-import { TAG_SETS } from "@/lib/recipes/tagColors";
 import { RecipeWithId } from "@/lib/recipes/schemas";
-import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils/index";
 import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
 import RecipeCard from "./components/RecipeCard";
 
-interface FacetSheetProps {
-  label: string;
-  tags: readonly string[];
-  counts: Record<string, number>;
-  value: string | null;
-  onChange: (value: string | null) => void;
-}
-
-function FacetSheet({ label, tags, counts, value, onChange }: FacetSheetProps) {
-  const [open, setOpen] = useState(false);
-  const sorted = tags
-    .map((t) => ({ tag: t, count: counts[t] ?? 0 }))
-    .filter(({ count }) => count > 0)
-    .sort((a, b) => b.count - a.count);
-
-  // Hide the button entirely if no recipes in this cookbook match any of the canonical tags
-  if (sorted.length === 0) return null;
-
-  const buttonLabel = value ? value : label;
-
-  return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger asChild>
-        <button
-          className={cn(
-            "px-3 py-1.5 text-[12px] font-medium rounded-full border transition-colors cursor-pointer inline-flex items-center gap-1 capitalize shrink-0",
-            value
-              ? "bg-primary text-primary-foreground border-primary"
-              : "bg-card text-muted-foreground border-border hover:text-foreground",
-          )}
-          aria-label={`Filter by ${label}`}
-        >
-          {buttonLabel}
-          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-            <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        </button>
-      </SheetTrigger>
-      <SheetContent side="bottom" className="bg-muted paper max-h-[70vh] flex flex-col p-4">
-        <SheetTitle className="font-display italic font-medium text-[22px] text-foreground mb-3">
-          {label}
-        </SheetTitle>
-        <div className="flex flex-col gap-1 overflow-y-auto -mx-2">
-          <button
-            onClick={() => {
-              onChange(null);
-              setOpen(false);
-            }}
-            className="text-left py-2.5 px-3 rounded-lg hover:bg-card text-sm text-muted-foreground border-b border-dashed border-border mb-1 cursor-pointer"
-          >
-            Clear
-          </button>
-          {sorted.map(({ tag, count }) => (
-            <button
-              key={tag}
-              onClick={() => {
-                onChange(tag);
-                setOpen(false);
-              }}
-              className={cn(
-                "text-left py-2.5 px-3 rounded-lg hover:bg-card flex items-center justify-between cursor-pointer",
-                value === tag && "bg-card",
-              )}
-            >
-              <span className="text-sm capitalize text-foreground">{tag}</span>
-              <span className="text-xs text-muted-foreground tabular-nums">{count}</span>
-            </button>
-          ))}
-        </div>
-      </SheetContent>
-    </Sheet>
-  );
-}
+const HIDE_SCROLLBAR =
+  "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden";
 
 interface RecipeListProps {
   onChatClick?: () => void;
@@ -94,8 +20,6 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
   const { userId } = useSessionContext();
   const { setSelectedRecipe } = useRecipeContext();
   const [activeTag, setActiveTag] = useState<string | null>(null);
-  const [cuisineFilter, setCuisineFilter] = useState<string | null>(null);
-  const [proteinFilter, setProteinFilter] = useState<string | null>(null);
   const [search, setSearch] = useState("");
 
   const { data: recipes, isLoading } = useSWR<RecipeWithId[]>(
@@ -131,16 +55,12 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
   const searchLower = search.trim().toLowerCase();
   const filtered = allRecipes
     .filter((r) => !activeTag || r.tags?.includes(activeTag))
-    .filter((r) => !cuisineFilter || r.tags?.includes(cuisineFilter))
-    .filter((r) => !proteinFilter || r.tags?.includes(proteinFilter))
     .filter(
       (r) =>
         !searchLower ||
         r.name.toLowerCase().includes(searchLower) ||
         r.tags?.some((t) => t.toLowerCase().includes(searchLower)),
     );
-
-  const hasMobileFilter = !!cuisineFilter || !!proteinFilter;
 
   return (
     <div className="h-full flex flex-col bg-muted">
@@ -184,35 +104,17 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
         )}
       </div>
 
-      {/* Mobile facet row (<sm) */}
-      {!isEmpty && (
-        <div className="sm:hidden px-4 py-3 border-b border-border flex gap-2 items-center shrink-0">
-          <FacetSheet
-            label="Cuisine"
-            tags={TAG_SETS.cuisine}
-            counts={tagCounts}
-            value={cuisineFilter}
-            onChange={setCuisineFilter}
-          />
-          <FacetSheet
-            label="Protein"
-            tags={TAG_SETS.protein}
-            counts={tagCounts}
-            value={proteinFilter}
-            onChange={setProteinFilter}
-          />
-        </div>
-      )}
-
-      {/* Desktop flat chip rail (sm+) */}
+      {/* Tag chip rail — horizontal scroll on mobile, wraps at sm+ */}
       {!isEmpty && tagEntries.length > 0 && (
-        <div className="hidden sm:flex px-9 py-3 border-b border-border gap-2 flex-wrap items-center shrink-0">
-          <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground mr-1">
+        <div
+          className={`flex px-4 sm:px-9 py-3 border-b border-border gap-2 items-center shrink-0 flex-nowrap sm:flex-wrap overflow-x-auto sm:overflow-visible ${HIDE_SCROLLBAR}`}
+        >
+          <span className="hidden sm:inline text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground mr-1 shrink-0">
             Filter
           </span>
           <button
             onClick={() => setActiveTag(null)}
-            className={`px-3 py-1 text-[11px] font-medium rounded-full border transition-colors cursor-pointer ${
+            className={`shrink-0 px-3 py-1 text-[11px] font-medium rounded-full border transition-colors cursor-pointer ${
               !activeTag
                 ? "bg-primary text-primary-foreground border-primary"
                 : "bg-transparent text-muted-foreground border-border hover:text-foreground"
@@ -224,7 +126,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
             <button
               key={tag}
               onClick={() => setActiveTag(activeTag === tag ? null : tag)}
-              className={`px-3 py-1 text-[11px] font-medium rounded-full border transition-colors cursor-pointer ${
+              className={`shrink-0 px-3 py-1 text-[11px] font-medium rounded-full border transition-colors cursor-pointer ${
                 activeTag === tag
                   ? "bg-primary text-primary-foreground border-primary"
                   : "bg-transparent text-muted-foreground border-border hover:text-foreground"
@@ -246,13 +148,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
           <CookbookEmpty onChatClick={onChatClick} />
         ) : filtered.length === 0 ? (
           <p className="font-display italic text-[14px] text-muted-foreground">
-            No recipes{" "}
-            {activeTag
-              ? `tagged "${activeTag}"`
-              : hasMobileFilter
-              ? "match those filters"
-              : "matching your search"}
-            .
+            No recipes {activeTag ? `tagged "${activeTag}"` : "matching your search"}.
           </p>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[18px]">

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -1,13 +1,90 @@
 "use client";
 
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { useRecipeContext } from "@/contexts/RecipeContext";
 import { useSessionContext } from "@/contexts/SessionContext";
+import { TAG_SETS } from "@/lib/recipes/tagColors";
 import { RecipeWithId } from "@/lib/recipes/schemas";
+import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils/index";
 import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
 import RecipeCard from "./components/RecipeCard";
+
+interface FacetSheetProps {
+  label: string;
+  tags: readonly string[];
+  counts: Record<string, number>;
+  value: string | null;
+  onChange: (value: string | null) => void;
+}
+
+function FacetSheet({ label, tags, counts, value, onChange }: FacetSheetProps) {
+  const [open, setOpen] = useState(false);
+  const sorted = tags
+    .map((t) => ({ tag: t, count: counts[t] ?? 0 }))
+    .filter(({ count }) => count > 0)
+    .sort((a, b) => b.count - a.count);
+
+  // Hide the button entirely if no recipes in this cookbook match any of the canonical tags
+  if (sorted.length === 0) return null;
+
+  const buttonLabel = value ? value : label;
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <button
+          className={cn(
+            "px-3 py-1.5 text-[12px] font-medium rounded-full border transition-colors cursor-pointer inline-flex items-center gap-1 capitalize shrink-0",
+            value
+              ? "bg-primary text-primary-foreground border-primary"
+              : "bg-card text-muted-foreground border-border hover:text-foreground",
+          )}
+          aria-label={`Filter by ${label}`}
+        >
+          {buttonLabel}
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+            <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </SheetTrigger>
+      <SheetContent side="bottom" className="bg-muted paper max-h-[70vh] flex flex-col p-4">
+        <SheetTitle className="font-display italic font-medium text-[22px] text-foreground mb-3">
+          {label}
+        </SheetTitle>
+        <div className="flex flex-col gap-1 overflow-y-auto -mx-2">
+          <button
+            onClick={() => {
+              onChange(null);
+              setOpen(false);
+            }}
+            className="text-left py-2.5 px-3 rounded-lg hover:bg-card text-sm text-muted-foreground border-b border-dashed border-border mb-1 cursor-pointer"
+          >
+            Clear
+          </button>
+          {sorted.map(({ tag, count }) => (
+            <button
+              key={tag}
+              onClick={() => {
+                onChange(tag);
+                setOpen(false);
+              }}
+              className={cn(
+                "text-left py-2.5 px-3 rounded-lg hover:bg-card flex items-center justify-between cursor-pointer",
+                value === tag && "bg-card",
+              )}
+            >
+              <span className="text-sm capitalize text-foreground">{tag}</span>
+              <span className="text-xs text-muted-foreground tabular-nums">{count}</span>
+            </button>
+          ))}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
 
 interface RecipeListProps {
   onChatClick?: () => void;
@@ -17,6 +94,8 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
   const { userId } = useSessionContext();
   const { setSelectedRecipe } = useRecipeContext();
   const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [cuisineFilter, setCuisineFilter] = useState<string | null>(null);
+  const [proteinFilter, setProteinFilter] = useState<string | null>(null);
   const [search, setSearch] = useState("");
 
   const { data: recipes, isLoading } = useSWR<RecipeWithId[]>(
@@ -49,14 +128,24 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
   }, {} as Record<string, number>);
   const tagEntries = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]);
 
+  const searchLower = search.trim().toLowerCase();
   const filtered = allRecipes
     .filter((r) => !activeTag || r.tags?.includes(activeTag))
-    .filter((r) => !search || r.name.toLowerCase().includes(search.toLowerCase()));
+    .filter((r) => !cuisineFilter || r.tags?.includes(cuisineFilter))
+    .filter((r) => !proteinFilter || r.tags?.includes(proteinFilter))
+    .filter(
+      (r) =>
+        !searchLower ||
+        r.name.toLowerCase().includes(searchLower) ||
+        r.tags?.some((t) => t.toLowerCase().includes(searchLower)),
+    );
+
+  const hasMobileFilter = !!cuisineFilter || !!proteinFilter;
 
   return (
     <div className="h-full flex flex-col bg-muted">
       {/* Title strip */}
-      <div className="px-9 pt-6 pb-[18px] border-b border-border flex items-end justify-between gap-6 shrink-0">
+      <div className="px-4 sm:px-9 pt-6 pb-[18px] border-b border-border flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 sm:gap-6 shrink-0">
         <div>
           <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground mb-1.5">
             Yours, kept
@@ -80,7 +169,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
           </p>
         </div>
         {!isEmpty && (
-          <label className="hidden sm:flex items-center gap-2 px-3 py-[7px] bg-card border border-border rounded-full min-w-[200px] text-muted-foreground cursor-text shrink-0">
+          <label className="flex items-center gap-2 px-3 py-[7px] bg-card border border-border rounded-full sm:min-w-[200px] w-full sm:w-auto text-muted-foreground cursor-text shrink-0">
             <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="shrink-0">
               <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.4" />
               <path d="m10.5 10.5 3 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
@@ -95,9 +184,29 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
         )}
       </div>
 
-      {/* Tag filter rail */}
+      {/* Mobile facet row (<sm) */}
+      {!isEmpty && (
+        <div className="sm:hidden px-4 py-3 border-b border-border flex gap-2 items-center shrink-0">
+          <FacetSheet
+            label="Cuisine"
+            tags={TAG_SETS.cuisine}
+            counts={tagCounts}
+            value={cuisineFilter}
+            onChange={setCuisineFilter}
+          />
+          <FacetSheet
+            label="Protein"
+            tags={TAG_SETS.protein}
+            counts={tagCounts}
+            value={proteinFilter}
+            onChange={setProteinFilter}
+          />
+        </div>
+      )}
+
+      {/* Desktop flat chip rail (sm+) */}
       {!isEmpty && tagEntries.length > 0 && (
-        <div className="px-9 py-3 border-b border-border flex gap-2 flex-wrap items-center shrink-0">
+        <div className="hidden sm:flex px-9 py-3 border-b border-border gap-2 flex-wrap items-center shrink-0">
           <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground mr-1">
             Filter
           </span>
@@ -128,7 +237,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
       )}
 
       {/* Grid area */}
-      <div className="flex-1 overflow-y-auto px-9 py-5">
+      <div className="flex-1 overflow-y-auto px-4 sm:px-9 py-5">
         {isLoading ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[18px]">
             {[0, 1, 2].map((i) => <SkeletonCard key={i} />)}
@@ -137,7 +246,13 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
           <CookbookEmpty onChatClick={onChatClick} />
         ) : filtered.length === 0 ? (
           <p className="font-display italic text-[14px] text-muted-foreground">
-            No recipes {activeTag ? `tagged "${activeTag}"` : "matching your search"}.
+            No recipes{" "}
+            {activeTag
+              ? `tagged "${activeTag}"`
+              : hasMobileFilter
+              ? "match those filters"
+              : "matching your search"}
+            .
           </p>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[18px]">


### PR DESCRIPTION
## Summary

- **Search**: visible on mobile too (was `hidden sm:flex`); title strip stacks on mobile. Matching extended from `name` only to `name || tag.includes(query)` — off-vocab tags like `filipino` become findable
- **Filter chip rail unified across viewports**: same `activeTag` single-select state, same chips at every width. At `<sm`: `flex-nowrap` + `overflow-x-auto` with hidden scrollbar — last chip bleeds off the right edge to suggest more content. At `≥sm`: existing `flex-wrap` behavior unchanged
- **"Filter" eyebrow label** hidden on mobile (`hidden sm:inline`)
- Mobile padding `px-4 sm:px-9` on title strip, rail, and grid
- Earlier facet-sheet design (`Cuisine ▾` / `Protein ▾` bottom sheets) explored on this branch but reverted — felt too heavy and hid all options behind taps; the chip rail surfaces every tag at a glance

## Test plan

- [ ] At 390px: title stacks, search visible, chip rail scrolls horizontally
- [ ] Last visible chip bleeds off the right edge; swipe → more chips
- [ ] Tap a chip → primary fill, grid filters to that tag
- [ ] Tap `All · N` → clears filter
- [ ] Type `filipino` (off-vocab) in search → tagged recipe appears
- [ ] At sm+: chip rail wraps as before; "Filter" eyebrow visible
- [ ] `pnpm tsc --noEmit` clean

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)