### PR TITLE
fix(chat): suggestion chips meet 44x44 tap target (#137)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -38,6 +38,11 @@ The persistent-kitchen MVP. Highlights:
 - [x] Bug fixed (May 2026): `Conversations.tsx` was reading `data?.grouped` but API returns `{ conversations: GroupedConversations }` — fixed to `data?.conversations`.
 - [x] Bug fixed (May 2026): `src/app/api/message/route.ts` used default import for prisma — fixed to named `{ prisma }`.
 
+### Chat suggestion chips: 44×44 tap target (May 2026)
+- [x] Empty-state suggestion chips bumped from ~31px to `min-h-11` (44px) so they meet the iOS HIG minimum tap target.
+- [x] `inline-flex items-center` centers text vertically within the new height; horizontal padding adjusted to `px-3.5` to keep proportions clean.
+- [x] `flex-wrap` behavior unchanged — chips wrap cleanly to a second row at 390px.
+
 ### Mobile cookbook: search + horizontal-scroll chip rail (May 2026)
 - [x] Search input visible at all widths (was `hidden sm:flex`); title strip stacks on mobile.
 - [x] Search now matches `name || tag` (lowercase) — off-vocab tags like `filipino` become findable.

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -295,7 +295,7 @@ const Chat = () => {
             <button
               key={s}
               onClick={() => handleSendMessage(s)}
-              className="px-3 py-1.5 text-[12.5px] text-muted-foreground border border-border rounded-full hover:border-border-soft hover:text-foreground transition-colors cursor-pointer"
+              className="inline-flex items-center min-h-11 px-3.5 text-[12.5px] text-muted-foreground border border-border rounded-full hover:border-border-soft hover:text-foreground transition-colors cursor-pointer"
             >
               {s}
             </button>


### PR DESCRIPTION
## Summary

Empty-state suggestion chips at `src/features/Chat/Chat.tsx:293` were ~31px tall — below the iOS HIG 44×44 minimum tap target.

- `min-h-11` (44px) sets the height floor
- `inline-flex items-center` centers text vertically inside the taller chip
- `px-3.5` keeps horizontal proportions consistent with the new height
- `flex-wrap` behavior unchanged — chips wrap cleanly to a second row at 390px (audit confirmed)

No overflow or scroll issues at 390px; long-text break-the-layout concern not triggered by current copy and remains moot under `flex-wrap`.

## Test plan

- [ ] At 390px with no messages: chips visible, wrap to 2 rows, no horizontal scroll
- [ ] Each chip ≥44px tall (DevTools box model)
- [ ] Tap target works smoothly with a thumb at all chip positions
- [ ] At ≥sm: chips look proportional, no layout regression

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)