### PR TITLE
fix(layout): tighten main height — kill empty space below mobile cookbook

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ function HomeContent() {
 
   return (
     <div className="bg-background">
-      <main className="xl:container mx-auto h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-6.5rem)] md:h-[calc(100dvh-8rem)]">
+      <main className="xl:container mx-auto h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)]">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col pt-2">
           <TabsList>
             <TabsTrigger value="chat">Chat</TabsTrigger>


### PR DESCRIPTION
## Summary

User reported a big empty cream area below the cookbook on iPhone 13. Cause: \`<main>\` height was subtracting **way more** than the actual top app bar height.

| Breakpoint | Top bar actual | Old subtract | New subtract |
|---|---|---|---|
| mobile | ~49px (h-8 image + py-2 + border) | 96px | **52px** (3.25rem) |
| md+ | ~53px (h-9 image + py-2 + border) | 128px | **56px** (3.5rem) |

Net: the cookbook/pantry panel now extends to just above Safari's URL bar instead of stopping ~50px short.

## Test plan

- [ ] iPhone Safari (or Chrome DevTools 390×844): Cookbook tab — panel reaches the URL bar with no cream gap below
- [ ] Pantry tab on mobile: same
- [ ] Chat tab on mobile: chat area fills correctly
- [ ] md/lg/xl: layout unchanged, no body scroll appears
- [ ] \`pnpm tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the layout and spacing of the main content area to improve visual presentation across all screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->