### PR TITLE
feat(recipe): hero image, tag normalization, extended vocab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DATABASE_URL="postgresql://user:password@localhost:5432/ask-ah-mah"
 
 # AI
-OPENAI_API_KEY="sk-..."
+OPENAI_API_KEY=your_openai_api_key_here
 
 # Images
 UNSPLASH_ACCESS_KEY=

--- a/src/app/api/recipe/route.ts
+++ b/src/app/api/recipe/route.ts
@@ -1,5 +1,6 @@
 import { deleteRecipe, getRecipes, saveRecipe } from "@/lib/recipes";
 import { processRecipe } from "@/lib/recipes/recipeProcessor";
+import { normalizeTags } from "@/lib/recipes/normalizeTags";
 import { RecipeIngredientModel } from "@/lib/recipes/schemas";
 import { fetchRecipePhoto } from "@/lib/unsplash/fetchPhoto";
 import { NextRequest, NextResponse } from "next/server";
@@ -24,7 +25,7 @@ export async function POST(req: NextRequest) {
   // New structured path: body.recipe contains the fully-structured object
   if (body.recipe) {
     const r = body.recipe;
-    const tags = r.tags ?? [];
+    const tags = normalizeTags(r.tags ?? []);
     const photo = await fetchRecipePhoto(r.title, tags);
     const recipe = await saveRecipe(
       {

--- a/src/app/api/recipe/route.ts
+++ b/src/app/api/recipe/route.ts
@@ -25,6 +25,9 @@ export async function POST(req: NextRequest) {
   // New structured path: body.recipe contains the fully-structured object
   if (body.recipe) {
     const r = body.recipe;
+    if (r.tags != null && (!Array.isArray(r.tags) || r.tags.some((t: unknown) => typeof t !== "string"))) {
+      return NextResponse.json({ error: "recipe.tags must be an array of strings" }, { status: 400 });
+    }
     const tags = normalizeTags(r.tags ?? []);
     const photo = await fetchRecipePhoto(r.title, tags);
     const recipe = await saveRecipe(

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -60,9 +60,9 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
         >
           {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-2.5">
-              {selectedRecipe.tags.map((tag) => (
+              {selectedRecipe.tags.map((tag, i) => (
                 <span
-                  key={tag}
+                  key={`${tag}-${i}`}
                   className="text-[10.5px] font-semibold tracking-wide px-[9px] py-[3px] rounded-full text-white border border-white/35 bg-white/[0.18] backdrop-blur-[4px]"
                 >
                   {tag}

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -37,20 +37,30 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
     <>
       {/* Hero strip */}
       <div
-        className="relative h-[180px] sm:h-[220px] border-b border-border flex items-end"
-        style={{ background: "linear-gradient(135deg, oklch(0.55 0.13 35) 0%, oklch(0.42 0.10 30) 100%)" }}
+        className="relative h-[180px] sm:h-[220px] border-b border-border flex items-end overflow-hidden"
+        style={!selectedRecipe.imageUrl ? { background: "linear-gradient(135deg, oklch(0.55 0.13 35) 0%, oklch(0.42 0.10 30) 100%)" } : undefined}
       >
-        <div
-          className="absolute inset-0"
-          style={{ backgroundImage: "repeating-linear-gradient(135deg, oklch(1 0 0 / 0.04) 0 12px, transparent 12px 24px)" }}
-        />
+        {selectedRecipe.imageUrl ? (
+          <Image
+            src={selectedRecipe.imageUrl}
+            alt={selectedRecipe.name}
+            fill
+            className="object-cover"
+            sizes="(max-width: 640px) 100vw, 900px"
+          />
+        ) : (
+          <div
+            className="absolute inset-0"
+            style={{ backgroundImage: "repeating-linear-gradient(135deg, oklch(1 0 0 / 0.04) 0 12px, transparent 12px 24px)" }}
+          />
+        )}
         <div
           className="relative w-full px-4 sm:px-9 pt-6 pb-5 text-white"
-          style={{ background: "linear-gradient(to top, oklch(0 0 0 / 0.3), transparent)" }}
+          style={{ background: "linear-gradient(to top, oklch(0 0 0 / 0.5), transparent)" }}
         >
           {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-2.5">
-              {selectedRecipe.tags.slice(0, 4).map((tag) => (
+              {selectedRecipe.tags.map((tag) => (
                 <span
                   key={tag}
                   className="text-[10.5px] font-semibold tracking-wide px-[9px] py-[3px] rounded-full text-white border border-white/35 bg-white/[0.18] backdrop-blur-[4px]"
@@ -67,6 +77,17 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
             {selectedRecipe.name}
           </h1>
         </div>
+        {selectedRecipe.imageUrl && selectedRecipe.photographerName && selectedRecipe.photographerUrl && (
+          <a
+            href={selectedRecipe.photographerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="absolute bottom-2 right-3 font-sans text-[10px] text-white/70 hover:text-white transition-colors leading-none"
+            style={{ textShadow: "0 1px 2px rgba(0,0,0,0.6)" }}
+          >
+            Photo by {selectedRecipe.photographerName}
+          </a>
+        )}
       </div>
 
       {/* Body */}

--- a/src/features/RecipeList/components/RecipeCard.tsx
+++ b/src/features/RecipeList/components/RecipeCard.tsx
@@ -51,18 +51,6 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
             className="object-cover"
             sizes="(max-width: 640px) 100vw, 320px"
           />
-          {recipe.photographerName && recipe.photographerUrl && (
-            <a
-              href={recipe.photographerUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
-              className="absolute bottom-1 right-2 font-sans text-[9px] text-white/70 hover:text-white transition-colors leading-none"
-              style={{ textShadow: "0 1px 2px rgba(0,0,0,0.6)" }}
-            >
-              Photo by {recipe.photographerName}
-            </a>
-          )}
         </div>
       ) : (
         <div

--- a/src/lib/recipes/normalizeTags.test.ts
+++ b/src/lib/recipes/normalizeTags.test.ts
@@ -1,0 +1,44 @@
+import { normalizeTags } from "./normalizeTags";
+
+describe("normalizeTags", () => {
+  it("passes through valid canonical tags", () => {
+    expect(normalizeTags(["pork", "stir-fried", "spicy"])).toEqual(["pork", "stir-fried", "spicy"]);
+  });
+
+  it("maps known synonyms to canonical form", () => {
+    expect(normalizeTags(["stir-fry"])).toEqual(["stir-fried"]);
+    expect(normalizeTags(["braise"])).toEqual(["braised"]);
+    expect(normalizeTags(["pressure-cooker"])).toEqual(["pressure-cooked"]);
+    expect(normalizeTags(["quick"])).toEqual(["quick (under 30 min)"]);
+    expect(normalizeTags(["comfort food"])).toEqual(["comfort"]);
+  });
+
+  it("drops tags in the DROP list", () => {
+    expect(normalizeTags(["rice", "onion", "protein", "budget"])).toEqual([]);
+  });
+
+  it("drops tags not in TAG_SETS (off-vocab)", () => {
+    expect(normalizeTags(["numbing-heat", "fusion-whatever"])).toEqual([]);
+  });
+
+  it("deduplicates — keeps first occurrence", () => {
+    expect(normalizeTags(["pork", "pork", "stir-fry", "stir-fried"])).toEqual(["pork", "stir-fried"]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(normalizeTags(["Pork", "STIR-FRY", "Spicy"])).toEqual(["pork", "stir-fried", "spicy"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(normalizeTags([])).toEqual([]);
+  });
+
+  it("accepts new canonical tags: filipino, asian, western, african, latin-american", () => {
+    expect(normalizeTags(["filipino", "asian", "western", "african", "latin-american"]))
+      .toEqual(["filipino", "asian", "western", "african", "latin-american"]);
+  });
+
+  it("accepts new canonical tags: stew, comfort, numbing", () => {
+    expect(normalizeTags(["stew", "comfort", "numbing"])).toEqual(["stew", "comfort", "numbing"]);
+  });
+});

--- a/src/lib/recipes/normalizeTags.ts
+++ b/src/lib/recipes/normalizeTags.ts
@@ -1,0 +1,32 @@
+import { getTagCategory } from "./tagColors";
+
+const SYNONYMS: Record<string, string> = {
+  "stir-fry":        "stir-fried",
+  "braise":          "braised",
+  "pressure-cooker": "pressure-cooked",
+  "quick":           "quick (under 30 min)",
+  "comfort food":    "comfort",
+};
+
+const DROP = new Set(["rice", "onion", "protein", "budget"]);
+
+export function normalizeTags(raw: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const t of raw) {
+    const lower = t.trim().toLowerCase();
+    if (!lower) continue;
+    if (DROP.has(lower)) continue;
+
+    const canonical = SYNONYMS[lower] ?? lower;
+
+    if (getTagCategory(canonical) === "other") continue;
+    if (seen.has(canonical)) continue;
+
+    seen.add(canonical);
+    result.push(canonical);
+  }
+
+  return result;
+}

--- a/src/lib/recipes/recipeProcessor.ts
+++ b/src/lib/recipes/recipeProcessor.ts
@@ -2,6 +2,7 @@ import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { z } from "zod";
 import { TAG_SETS } from "./tagColors";
+import { normalizeTags } from "./normalizeTags";
 import { CategorySchema } from "@/lib/inventory/schemas";
 
 // Extract metadata from a recipe. We don't ask the model to re-emit the
@@ -101,5 +102,8 @@ ${recipeInstructions}`;
     temperature: 0.2,
   });
 
-  return result.object;
+  return {
+    ...result.object,
+    tags: normalizeTags(result.object.tags),
+  };
 }

--- a/src/lib/recipes/tagColors.ts
+++ b/src/lib/recipes/tagColors.ts
@@ -15,7 +15,8 @@ export const TAG_SETS: Record<Exclude<TagCategory, "other">, readonly string[]> 
   cuisine: [
     "italian", "chinese", "japanese", "mexican", "indian", "thai", "french",
     "mediterranean", "american", "korean", "vietnamese", "middle-eastern",
-    "greek", "spanish", "moroccan", "malaysian", "singaporean",
+    "greek", "spanish", "moroccan", "malaysian", "singaporean", "filipino",
+    "asian", "western", "african", "latin-american",
   ],
   protein: [
     "chicken", "beef", "pork", "fish", "seafood", "vegetarian", "vegan",
@@ -24,7 +25,7 @@ export const TAG_SETS: Record<Exclude<TagCategory, "other">, readonly string[]> 
   method: [
     "baked", "fried", "grilled", "steamed", "boiled", "roasted", "sauteed",
     "stir-fried", "braised", "slow-cooked", "pressure-cooked", "air-fried",
-    "no-cook", "raw", "marinated", "fermented", "pickled",
+    "no-cook", "raw", "marinated", "fermented", "pickled", "stew",
   ],
   meal: [
     "breakfast", "lunch", "dinner", "snack", "appetizer", "dessert",
@@ -36,7 +37,7 @@ export const TAG_SETS: Record<Exclude<TagCategory, "other">, readonly string[]> 
   ],
   style: [
     "crispy", "creamy", "spicy", "sweet", "savory", "tangy", "hearty",
-    "light", "refreshing", "warming",
+    "light", "refreshing", "warming", "comfort", "numbing",
   ],
   equipment: [
     "wok", "instant-pot", "cast-iron", "slow-cooker", "blender", "oven-free",


### PR DESCRIPTION
## Summary

- **Hero image in recipe detail**: `RecipeDisplay` now renders `imageUrl` as the hero background when present. Photographer credit moves to the detail view only (removed from cookbook card thumbnails). Falls back to the burnt-sienna gradient + stripe for recipes without a photo.
- **Show all tags**: removed `slice(0, 4)` cap in `RecipeDisplay` — all tags now visible in the detail hero.
- **Tag normalization on save**: new `normalizeTags` function maps known synonyms (`stir-fry→stir-fried`, `braise→braised`, `pressure-cooker→pressure-cooked`, `quick→quick (under 30 min)`, `comfort food→comfort`), drops off-vocab noise (`rice`, `onion`, `protein`, `budget`), and discards anything not in `TAG_SETS`. Wired into both the legacy (`processRecipe`) and structured save paths.
- **Extended `TAG_SETS`**: added `filipino`, `asian`, `western`, `african`, `latin-american` (cuisine); `stew` (method); `comfort`, `numbing` (style). Broad cuisine tags serve as filterable fallbacks in the chip rail.
- **API boundary guard**: `recipe.tags` validated as `string[]` before normalization; returns 400 on malformed payload.

## Notes

- Re-processing existing recipe rows (issue #138 part 3) is deferred — run after confirming normalization on new saves.
- `fetchPhoto.ts` throw-swallows-fallback bug is a separate issue (not in this PR).

## Test plan

- [ ] `pnpm jest src/lib/recipes/normalizeTags.test.ts` — 9 tests pass
- [ ] Open a recipe with a saved `imageUrl` — photo fills hero, credit visible bottom-right
- [ ] Open a recipe without `imageUrl` — gradient + stripe fallback shows
- [ ] Recipe with 6 DB tags shows all 6 in the detail hero
- [ ] Save a new recipe via chat → inspect DB — only canonical tags present

Closes #138 (normalization + vocab; re-process deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)