### PR TITLE
fix(recipe): 'to taste' fallback for unquantified ingredients

### DIFF
--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -160,10 +160,16 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
                     key={i}
                     className="flex items-baseline gap-3 py-2.5 border-b border-dashed border-border"
                   >
-                    <span className="basis-20 sm:basis-24 shrink-0 font-mono text-[13px] font-semibold text-foreground tabular-nums text-right">
+                    <span
+                      className={`basis-20 sm:basis-24 shrink-0 text-[13px] text-foreground text-right ${
+                        scaled != null
+                          ? "font-mono font-semibold tabular-nums"
+                          : "font-display italic text-muted-foreground"
+                      }`}
+                    >
                       {scaled != null
                         ? `${formatAmount(scaled)}${ing.unit ? ` ${ing.unit}` : ""}`
-                        : "—"}
+                        : "to taste"}
                     </span>
                     <span className="flex-1 font-display text-[15px] text-foreground leading-[1.4]">
                       {ing.name}


### PR DESCRIPTION
## Summary

Replaces the `—` fallback with `"to taste"` for ingredients without an explicit amount. Reads naturally for salt, pepper, chili flakes, etc. — anything the LLM leaves unquantified.

Italic display-font styling for the fallback (vs. mono for numbers) keeps the two cases visually distinct so a glance still tells you which rows have explicit amounts.

Closes #154

## Test plan

- [ ] Open a recipe with unquantified ingredients (e.g. salt, pepper) — confirm "to taste" renders instead of `—`
- [ ] Quantified rows ("500 g chicken thigh") unchanged
- [ ] No layout regression in the amount column (still fits the `basis-20 sm:basis-24` width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved ingredient display in recipes: amounts that cannot be scaled now show "to taste" for clarity
  * Enhanced visual distinction between scaled and non-scaled ingredient quantities through updated styling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->