### PR TITLE
fix(cookbook): hide title strip on mobile

### DIFF
--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -64,9 +64,10 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
 
   return (
     <div className="h-full flex flex-col bg-muted">
-      {/* Title strip */}
-      <div className="px-4 sm:px-9 pt-6 pb-[18px] border-b border-border flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 sm:gap-6 shrink-0">
-        <div>
+      {/* Title strip — hidden on mobile; Cookbook tab below the app header
+          already labels this surface and the chip rail carries `All · N`. */}
+      <div className="px-4 sm:px-9 pt-3 sm:pt-6 pb-[18px] sm:border-b sm:border-border flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 sm:gap-6 shrink-0">
+        <div className="hidden sm:block">
           <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground mb-1.5">
             Yours, kept
           </div>


### PR DESCRIPTION
## Summary

Mobile cookbook header was ~225px tall before any recipe card showed. Hide the eyebrow + big title + subtitle block at `<sm` to free that space. The Cookbook tab already labels this surface and the chip rail carries `All · N`, so no information is lost.

- Title block: `hidden sm:block`
- Border-b moved to `sm:` so mobile doesn't have an orphan divider
- Top padding `pt-3` on mobile, `pt-6` on desktop

Desktop visually identical to before.

Closes #155

## Test plan

- [ ] Mobile (<640px): no `YOURS, KEPT` eyebrow, no `My Cookbook` heading, no "N saved recipes" subtitle
- [ ] Mobile: search input + chip rail still visible and functional
- [ ] Desktop (≥640px): no visual change
- [ ] Empty state (mobile): `CookbookEmpty` renders cleanly in the grid area

🤖 Generated with [Claude Code](https://claude.com/claude-code)