### PR TITLE
chore(copy): voice sweep — Ah Mah narrates the kitchen

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,11 +25,11 @@ const fontLogo = Nunito({
 
 export const metadata: Metadata = {
   title: {
-    default: "Ask Ah Mah - Your Friendly Cooking Assistant",
+    default: "Ask Ah Mah — Cook with Ah Mah",
     template: "%s | Ask Ah Mah",
   },
   description:
-    "Discover delicious recipes with Ask Ah Mah! Get personalized cooking suggestions based on your available ingredients. Perfect for cooking beginners and food enthusiasts.",
+    "Ah Mah remembers what's in your kitchen and cooks alongside you. No forms, no spreadsheets — just chat.",
   keywords: [
     "cooking assistant",
     "recipe suggestions",
@@ -56,9 +56,9 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   openGraph: {
-    title: "Ask Ah Mah - Your Friendly Cooking Assistant",
+    title: "Ask Ah Mah — Cook with Ah Mah",
     description:
-      "Discover delicious recipes with Ask Ah Mah! Get personalized cooking suggestions based on your available ingredients.",
+      "Ah Mah remembers what's in your kitchen and cooks alongside you. No forms, no spreadsheets — just chat.",
     url: "https://ask-ah-mah.vercel.app",
     siteName: "Ask Ah Mah",
     images: [
@@ -74,9 +74,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Ask Ah Mah - Your Friendly Cooking Assistant",
+    title: "Ask Ah Mah — Cook with Ah Mah",
     description:
-      "Discover delicious recipes with Ask Ah Mah! Get personalized cooking suggestions based on your available ingredients.",
+      "Ah Mah remembers what's in your kitchen and cooks alongside you. No forms, no spreadsheets — just chat.",
     images: ["/og-image.png"],
   },
   robots: {

--- a/src/features/Chat/components/ConversationTitle.tsx
+++ b/src/features/Chat/components/ConversationTitle.tsx
@@ -171,7 +171,7 @@ export function ConversationActionsMenu({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem disabled={!canStartNew} onClick={onNewConversation}>
-            New conversation
+            Start fresh
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={onStartRename}>Rename</DropdownMenuItem>
@@ -190,7 +190,7 @@ export function ConversationActionsMenu({
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this conversation?</AlertDialogTitle>
             <AlertDialogDescription>
-              This cannot be undone. Saved recipes are kept.
+              Gone for good. Your saved recipes stay safe.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/features/Chat/components/MessageInput.tsx
+++ b/src/features/Chat/components/MessageInput.tsx
@@ -29,7 +29,7 @@ export const MessageInput = ({
           value={input}
           onChange={(e) => setInput(e.target.value)}
           disabled={disabled}
-          placeholder={disabled ? "Sending your question…" : "Ask Ah Mah a question…"}
+          placeholder={disabled ? "Sending…" : "Ask Ah Mah…"}
           className="flex-1 border-none shadow-none bg-transparent focus-visible:ring-0 px-0"
         />
         <Button

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -384,7 +384,7 @@ export const MessageList = ({
                                     />
                                   </svg>
                                 )}
-                                {saved ? "Saved" : "Save"}: {recipeName}
+                                {saved ? "Kept" : "Keep this"} — {recipeName}
                               </Button>
                             );
                           })}

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -149,14 +149,14 @@ const Inventory = () => {
         <div className="hidden sm:flex sm:items-end sm:justify-between sm:gap-6 mb-5">
           <div>
             <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground mb-1.5">
-              Pantry
+              What Ah Mah sees
             </div>
             <h1 className="font-display font-semibold text-[40px] text-foreground leading-none tracking-tight">
-              Your kitchen, kept
+              Your kitchen, today
             </h1>
             <p className="font-display italic text-[15px] text-muted-foreground mt-2">
-              {totalCount} item{totalCount !== 1 ? "s" : ""} · Ah Mah updates
-              this as you chat
+              {totalCount} thing{totalCount !== 1 ? "s" : ""}. She jots them
+              down as you chat.
             </p>
           </div>
           {!isAdding && (
@@ -243,7 +243,7 @@ const Inventory = () => {
 
         {!isLoading && totalCount === 0 && !isAdding && (
           <p className="font-display italic text-[14px] text-muted-foreground">
-            Pantry&rsquo;s empty. Tell Ah Mah what you have, or add it here.
+            Nothing in yet. Tell Ah Mah what you&rsquo;ve got &mdash; &ldquo;a bit of ginger, some eggs&rdquo; is enough.
           </p>
         )}
 

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -69,23 +69,23 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
       <div className="px-4 sm:px-9 pt-3 sm:pt-6 pb-[18px] sm:border-b sm:border-border flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 sm:gap-6 shrink-0">
         <div className="hidden sm:block">
           <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground mb-1.5">
-            Yours, kept
+            Worth cooking again
           </div>
           <h1 className="font-display font-semibold text-[40px] text-foreground leading-none tracking-tight">
-            My Cookbook
+            Your kept recipes
           </h1>
           <p className="font-display italic text-[15px] text-muted-foreground mt-2">
             {isEmpty
-              ? "0 saved recipes — your shelf is waiting."
+              ? "Empty for now. Cook something with Ah Mah, then save the ones you'd cook again."
               : (() => {
-                  const base = `${allRecipes.length} saved recipe${allRecipes.length !== 1 ? "s" : ""}`;
+                  const base = `${allRecipes.length} saved`;
                   const latest = allRecipes.reduce((max, r) => {
                     const t = r.createdAt ? new Date(r.createdAt).getTime() : 0;
                     return t > max ? t : max;
                   }, 0);
-                  if (!latest) return base;
+                  if (!latest) return `${base}.`;
                   const day = new Date(latest).toLocaleDateString("en-US", { weekday: "long" });
-                  return `${base} · last added ${day}`;
+                  return `${base}. Last one in: ${day}.`;
                 })()}
           </p>
         </div>
@@ -149,7 +149,9 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
           <CookbookEmpty onChatClick={onChatClick} />
         ) : filtered.length === 0 ? (
           <p className="font-display italic text-[14px] text-muted-foreground">
-            No recipes {activeTag ? `tagged "${activeTag}"` : "matching your search"}.
+            {activeTag
+              ? `Nothing tagged "${activeTag}". Try another?`
+              : "Nothing matches. Try a different word?"}
           </p>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[18px]">
@@ -183,7 +185,7 @@ function CookbookEmpty({ onChatClick }: { onChatClick?: () => void }) {
             Your cookbook is empty.
           </div>
           <div className="font-display italic text-sm text-muted-foreground leading-relaxed">
-            When Ah Mah suggests a recipe you like, tap <em>Save to cookbook</em> and it lives here. Saved by you, ready when you need it.
+            When something&rsquo;s worth a second go, tap <em>Save</em>. Ah Mah keeps it tidy.
           </div>
         </div>
         <button


### PR DESCRIPTION
## Summary

Tighten the voice on every user-facing string across the app. The product has a clear Singaporean-granny voice in the chat itself but generic web-app copy ("Your Friendly Cooking Assistant," "0 saved recipes — your shelf is waiting," "Save: Recipe Name") on the chrome. This PR brings the chrome in line with the voice.

### Pantry header
- `PANTRY` (eyebrow) → **`WHAT AH MAH SEES`** — frames the pantry as the LLM's view of your kitchen, which is literally what `getInventory` returns
- `Your kitchen, kept` → **`Your kitchen, today`** — drops the archive-y "kept"
- `N items · Ah Mah updates this as you chat` → **`N things. She jots them down as you chat.`** — shorter, more conversational
- Empty state rewritten with an example: *"Nothing in yet. Tell Ah Mah what you've got — 'a bit of ginger, some eggs' is enough."*

### Cookbook header
- `YOURS, KEPT` → **`WORTH COOKING AGAIN`** — states the actual reason a recipe is here
- `My Cookbook` → **`Your kept recipes`** — pairs with pantry's possessive voice
- `N saved recipes · last added X` → **`N saved. Last one in: X.`** — punchier
- Empty state: *"Empty for now. Cook something with Ah Mah, then save the ones you'd cook again."*
- Empty-card description: *"When something's worth a second go, tap Save. Ah Mah keeps it tidy."*
- No-match line: conversational with recovery hint

### App metadata (`layout.tsx`)
- Title: drops "Your Friendly Cooking Assistant" AI-slop frame
- Description: rewritten to name the persistence moat — *"Ah Mah remembers what's in your kitchen and cooks alongside you. No forms, no spreadsheets — just chat."*

### Microcopy
- Chat input placeholder: `Ask Ah Mah a question…` → `Ask Ah Mah…`
- Save button: `Save: X` → `Keep this — X` (matches "kept recipes" cookbook framing)
- New conversation menu: `New conversation` → `Start fresh`
- Delete dialog: `This cannot be undone. Saved recipes are kept.` → `Gone for good. Your saved recipes stay safe.`

## Net diff: +25 / -23 across 6 files

## Test plan

- [ ] Open at desktop → pantry shows new header, subtitle, empty state. Cookbook same.
- [ ] Mobile (`<sm`) → headers hidden as designed; copy applies when at `≥sm`
- [ ] Save a recipe from chat → button says "Keep this — Recipe Name"; after save, "Kept — Recipe Name"
- [ ] Open delete-conversation dialog → new copy reads correctly
- [ ] `pnpm tsc --noEmit` — no new errors beyond pre-existing test-file issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)