### PR TITLE
fix(conversations): one canonical entry for new conversation

### DIFF
--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -35,7 +35,6 @@ const Chat = () => {
   const {
     activeConversationId,
     activeConversation,
-    startNewConversation,
     renameActiveConversation,
     autoTitleActiveConversation,
     deleteActiveConversation,
@@ -256,10 +255,8 @@ const Chat = () => {
           />
         </div>
 
-        {/* Overflow menu — new / rename / delete */}
+        {/* Overflow menu — rename / delete (the "+" in the conversations rail/sheet starts a new conversation) */}
         <ConversationActionsMenu
-          onNewConversation={() => startNewConversation()}
-          canStartNew={messageCount > 0}
           onStartRename={() => setTitleEditing(true)}
           onDelete={handleDeleteConversation}
           canDelete={messageCount > 0}

--- a/src/features/Chat/components/ConversationTitle.tsx
+++ b/src/features/Chat/components/ConversationTitle.tsx
@@ -14,7 +14,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useRef, useState } from "react";
@@ -138,16 +137,12 @@ export default function ConversationTitle({
 // ── ConversationActionsMenu ───────────────────────────────────────────────────
 
 interface ConversationActionsMenuProps {
-  onNewConversation: () => void;
-  canStartNew: boolean;
   onStartRename: () => void;
   onDelete: () => Promise<void>;
   canDelete: boolean;
 }
 
 export function ConversationActionsMenu({
-  onNewConversation,
-  canStartNew,
   onStartRename,
   onDelete,
   canDelete,
@@ -170,10 +165,6 @@ export function ConversationActionsMenu({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem disabled={!canStartNew} onClick={onNewConversation}>
-            Start fresh
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
           <DropdownMenuItem onClick={onStartRename}>Rename</DropdownMenuItem>
           <DropdownMenuItem
             disabled={!canDelete}

--- a/src/features/Conversations/Conversations.tsx
+++ b/src/features/Conversations/Conversations.tsx
@@ -69,9 +69,13 @@ export function Conversations({ onItemClick }: ConversationsProps) {
     onItemClick?.();
   };
 
-  const handleNewConversation = () => {
+  const activeConvIsEmpty = (() => {
     const active = allConversations.find((c) => c.id === activeConversationId);
-    if ((active?._count?.messages ?? 1) === 0) return;
+    return (active?._count?.messages ?? 1) === 0;
+  })();
+
+  const handleNewConversation = () => {
+    if (activeConvIsEmpty) return;
     startNewConversation();
   };
 
@@ -87,8 +91,10 @@ export function Conversations({ onItemClick }: ConversationsProps) {
         </div>
         <button
           onClick={handleNewConversation}
-          className="w-8 h-8 rounded-lg bg-primary text-white flex items-center justify-center text-lg font-medium shrink-0 hover:bg-primary/90 transition-colors cursor-pointer"
+          disabled={activeConvIsEmpty}
+          className="w-8 h-8 rounded-lg bg-primary text-white flex items-center justify-center text-lg font-medium shrink-0 hover:bg-primary/90 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-primary"
           aria-label="New conversation"
+          title={activeConvIsEmpty ? "Already in a new conversation" : "Start a new conversation"}
         >
           +
         </button>


### PR DESCRIPTION
## Summary

The "+" button in the conversations rail and the "Start fresh" item in the chat header's "..." menu both called the same `startNewConversation()` — two paths for one action with inconsistent feedback.

### The issues

1. **Inconsistent disabled state for the same operation.** The "+" was always visually active but silently no-op'd when the active conversation had 0 messages. The menu item correctly disabled via `canStartNew`. So clicking the "+" when "in an empty convo" looked broken; clicking the menu item didn't.
2. **Mixed scope in the "..." menu.** `Rename` and `Delete` act on the *current* conversation. `Start fresh` is about *navigation* — creating a new one. Different scope, awkward to lump together.

### The fix

- **Remove "Start fresh" from the "..." menu.** Menu becomes purely about this conversation: Rename + Delete. Cleaner.
- **Disable the rail "+" visually** when the active conversation is empty. Opacity-40, `cursor-not-allowed`, `title` attribute explains why. Matches the previous menu-item behavior.

`ConversationActionsMenu` props slimmed (drops `onNewConversation` + `canStartNew`). `Chat.tsx` no longer needs `startNewConversation` from context.

## Test plan

- [ ] Open a conversation with messages → "+" in rail is active. Click → new empty conversation opens. "..." menu shows just Rename + Delete.
- [ ] In a brand-new empty conversation → "+" in rail is grayed out, hover shows "Already in a new conversation" tooltip, clicks do nothing. Menu unchanged.
- [ ] Mobile (`<lg`): same behavior on the "+" inside `ConversationsMobileSheet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Interface Updates**
  * Consolidated new conversation initiation to a single entry point; removed "Start fresh" from chat header menu to reduce redundancy.
  * New conversation button now becomes disabled when the current conversation is empty, with updated visual feedback.
  * Chat header menu simplified to display only rename and delete options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->