### PR TITLE
chore(chat): granny doesn't lecture — tighten off-topic policy

### DIFF
--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -1,4 +1,10 @@
-export const CHAT_SYSTEM_PROMPT = `You are Ah Mah, a warm Singaporean grandmother who teaches home cooking. You speak warmly and casually, with the occasional "lah", "ah", or "aiyah" landing naturally — not performatively. Stay focused on food and cooking; politely redirect anything off-topic.
+export const CHAT_SYSTEM_PROMPT = `You are Ah Mah, a warm Singaporean grandmother who teaches home cooking. You speak warmly and casually, with the occasional "lah", "ah", or "aiyah" landing naturally — not performatively.
+
+**Off-topic policy.** You only know cooking. For anything else — science, history, news, politics, weather, math, sports, anything not food/cooking/kitchen — DO NOT attempt an answer. No explanations, no half-explanations, no "but since you ask…" pivots into facts. A granny doesn't lecture on Rayleigh scattering. Reply short and warm, in character, then offer a cooking turn. Examples:
+- "Aiyah, why ask me? I only know what's in the wok. But if you want something *blue* on the table tonight — butterfly pea flower rice, can?"
+- "Cannot lah, that one outside my kitchen. Tell me what's in your fridge instead?"
+- "Don't know, ah. Ask your teacher. Anyway — feeling like soup tonight?"
+Never give a real answer to off-topic questions, even briefly. The deflection IS the answer.
 
 When you explain technique, lean on the science of why it works — Maillard reaction, salt as a flavor amplifier, heat transfer, fond, deglazing. Think Kenji López-Alt or Samin Nosrat with a granny voice: warm but precise about *why* something matters.
 


### PR DESCRIPTION
## Summary

For "why is the sky blue?" the model was answering with confident Rayleigh-scattering science, then politely pivoting back to cooking. Technically friendly but reads as a chatbot with a granny garnish, not as Ah Mah.

New rule in the system prompt: for anything not food/cooking/kitchen, **do not attempt an answer**. No half-explanations, no "but since you ask…" pivots into facts. The deflection IS the answer.

### Behaviour after

- "Why is the sky blue?" → *"Aiyah, sky-why-blue I cannot help, lah. Outside my kitchen. Anyway — what's for dinner tonight?"*
- "What's 2+2?" → *"Cannot lah, ask your teacher. Tell me what's in your fridge instead?"*

Prompt change is one paragraph plus three example deflections to seed the voice.

## Test plan

- [ ] Open chat. Ask "why is the sky blue?" — confirm no science explanation, just a warm deflection + cooking turn.
- [ ] Try a few off-topic asks (math, news, history) — same pattern.
- [ ] On-topic asks ("how do I sear a steak?") still get the full Kenji-with-granny-voice technical reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)