### PR TITLE
feat(cookbook): recipe modal + start-cooking lifted out of Dialog

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -26,6 +26,13 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **NEED pill → clickable add**: clicking a NEED pill POSTs to `/api/inventory`, revalidates SWR, shows toast.
 - **Better Auth**: Google OAuth + email magic link (Resend); `useSession` bridges auth session with localStorage guest fallback; guests unchanged.
 
+## V2 — Polish (May 2026)
+
+- **Cookbook → recipe is a modal**, not a route: `RecipeList` opens `RecipeDisplay` inside a Radix `Dialog`. `/recipe/[id]` route kept for direct links.
+- **Recipe layout**: centred max-w-3xl card on the app background (no full-bleed); Copy button removed; Back navigates to `?tab=cookbook` (read by `app/page.tsx` via `useSearchParams`).
+- **Pantry fills horizontally**: `max-w-[1200px]` dropped; CSS columns (masonry) replace the rigid grid so short categories don't leave dark gaps.
+- **CookingMode lifted to consumer**: cooking state lives in `RecipeList` (and chat) rather than inside `RecipeDisplay`. Cookbook closes the dialog before mounting `CookingMode` at the top level — Radix Dialog's `pointer-events: none` on siblings was killing the Next-step button when CookingMode rendered inside / portalled from the dialog.
+
 ## V2 — In Progress
 
 ### Shopping list from shortfalls

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,10 +5,17 @@ import ChatWrapper from "@/features/Chat/components/ChatWrapper";
 import { ConversationsRail } from "@/features/Conversations";
 import InventoryWrapper from "@/features/Inventory/components/InventoryWrapper";
 import RecipeList from "@/features/RecipeList/RecipeList";
-import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
+
+const VALID_TABS = ["chat", "pantry", "cookbook"] as const;
 
 function HomeContent() {
-  const [activeTab, setActiveTab] = useState("chat");
+  const searchParams = useSearchParams();
+  const initialTab = searchParams.get("tab");
+  const [activeTab, setActiveTab] = useState(
+    initialTab && (VALID_TABS as readonly string[]).includes(initialTab) ? initialTab : "chat",
+  );
 
   return (
     <div className="bg-background">
@@ -54,7 +61,9 @@ function HomeContent() {
 export default function Home() {
   return (
     <ConversationProvider>
-      <HomeContent />
+      <Suspense fallback={null}>
+        <HomeContent />
+      </Suspense>
     </ConversationProvider>
   );
 }

--- a/src/app/recipe/[id]/page.tsx
+++ b/src/app/recipe/[id]/page.tsx
@@ -21,7 +21,7 @@ export default function RecipePage() {
 
   if (isLoading) {
     return (
-      <div className="h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)] flex items-center justify-center bg-chat paper">
+      <div className="h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)] flex items-center justify-center">
         <p className="font-display italic text-muted-foreground">Pulling out the recipe…</p>
       </div>
     );
@@ -29,7 +29,7 @@ export default function RecipePage() {
 
   if (!recipe) {
     return (
-      <div className="h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col items-center justify-center gap-4 bg-chat paper">
+      <div className="h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col items-center justify-center gap-4">
         <p className="font-display italic text-muted-foreground">
           Can&rsquo;t find that one, lah.
         </p>
@@ -44,8 +44,8 @@ export default function RecipePage() {
   }
 
   return (
-    <div className="h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)] bg-chat paper overflow-hidden">
-      <RecipeDisplay recipe={recipe} onBack={() => router.back()} />
+    <div className="h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)] overflow-hidden">
+      <RecipeDisplay recipe={recipe} onBack={() => router.push("/?tab=cookbook")} />
     </div>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -48,8 +48,11 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
+  showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
   return (
     <DialogPortal>
       <DialogOverlay />
@@ -65,10 +68,12 @@ function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-ink-faint hover:text-foreground transition-colors focus:outline-none">
-          <X size={15} />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {showCloseButton && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-ink-faint hover:text-foreground transition-colors focus:outline-none">
+            <X size={15} />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   )

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -144,7 +144,7 @@ const Inventory = () => {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="px-4 sm:px-9 pt-4 sm:pt-7 pb-5 max-w-[1200px] mx-auto">
+      <div className="px-4 sm:px-9 pt-4 sm:pt-7 pb-5">
         {/* Header — hidden on mobile (tab strip already labels this surface) */}
         <div className="hidden sm:flex sm:items-end sm:justify-between sm:gap-6 mb-5">
           <div>
@@ -247,9 +247,9 @@ const Inventory = () => {
           </p>
         )}
 
-        {/* Category grid — 2-column on lg+, 1-column on mobile/tablet */}
+        {/* Category masonry — CSS columns let cards flow and pack vertical gaps */}
         {totalCount > 0 && (
-          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
+          <div className="columns-1 sm:columns-2 lg:columns-3 xl:columns-4 gap-3 [&>*]:break-inside-avoid [&>*]:mb-3">
             {ingredientGroups.map((group) => (
               <CategoryCard
                 key={group.label}

--- a/src/features/RecipeDisplay/RecipeDisplay.test.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.test.tsx
@@ -1,60 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { toast } from "sonner";
+import { fireEvent, render, screen } from "@testing-library/react";
 import RecipeDisplay from "./RecipeDisplay";
-
-jest.mock("sonner", () => ({
-  toast: { success: jest.fn(), error: jest.fn() },
-}));
 
 jest.mock("streamdown", () => ({
   Streamdown: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="streamdown">{children}</div>
   ),
-}));
-
-jest.mock("@/components/ui/button", () => ({
-  Button: ({
-    children,
-    onClick,
-    className,
-    variant,
-    disabled,
-    "aria-label": ariaLabel,
-  }: {
-    children: React.ReactNode;
-    onClick?: () => void;
-    className?: string;
-    variant?: string;
-    disabled?: boolean;
-    "aria-label"?: string;
-  }) => (
-    <button
-      onClick={onClick}
-      className={className}
-      data-variant={variant}
-      data-testid="button"
-      aria-label={ariaLabel}
-      disabled={disabled}
-    >
-      {children}
-    </button>
-  ),
-}));
-
-jest.mock("@/components/ui/badge", () => ({
-  Badge: ({ children }: { children: React.ReactNode }) => (
-    <span data-testid="badge">{children}</span>
-  ),
-}));
-
-const mockSelectedRecipe = jest.fn();
-
-jest.mock("@/contexts/RecipeContext", () => ({
-  useRecipeContext: () => ({
-    selectedRecipe: mockSelectedRecipe(),
-    setSelectedRecipe: jest.fn(),
-    exitRecipe: jest.fn(),
-  }),
 }));
 
 const baseRecipe = {
@@ -72,73 +22,50 @@ const baseRecipe = {
   ],
 };
 
-const mockClipboard = { writeText: jest.fn() };
-Object.assign(navigator, { clipboard: mockClipboard });
+const renderRecipe = (overrides: Partial<typeof baseRecipe> = {}) =>
+  render(<RecipeDisplay recipe={{ ...baseRecipe, ...overrides } as never} onBack={jest.fn()} />);
 
 describe("RecipeDisplay", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockClipboard.writeText.mockResolvedValue(undefined);
-    mockSelectedRecipe.mockReturnValue(baseRecipe);
-  });
-
   describe("Basic Rendering", () => {
-    it("returns nothing when no recipe is selected", () => {
-      mockSelectedRecipe.mockReturnValue(null);
-      const { container } = render(<RecipeDisplay />);
-      expect(container.firstChild).toBeNull();
-    });
-
     it("renders recipe instructions via Streamdown for legacy recipes", () => {
-      render(<RecipeDisplay />);
+      renderRecipe();
       const method = screen.getByTestId("streamdown");
       expect(method).toHaveTextContent("Heat butter");
-      expect(method).not.toHaveTextContent("Scrambled Eggs");
       expect(method).not.toHaveTextContent("Ingredients");
       expect(method).not.toHaveTextContent("-----");
     });
 
     it("renders tags", () => {
-      render(<RecipeDisplay />);
+      renderRecipe();
       expect(screen.getByText("breakfast")).toBeInTheDocument();
       expect(screen.getByText("easy")).toBeInTheDocument();
     });
 
     it("renders structured ingredients", () => {
-      render(<RecipeDisplay />);
+      renderRecipe();
       expect(screen.getAllByText(/3 piece/).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/2 tbsp/).length).toBeGreaterThan(0);
     });
 
-    it("renders the copy button", () => {
-      render(<RecipeDisplay />);
-      expect(screen.getByText("Copy")).toBeInTheDocument();
-    });
-
-    it("renders no pantry badges or inventory-based UI", () => {
-      render(<RecipeDisplay />);
-      expect(screen.queryByText(/in pantry/i)).not.toBeInTheDocument();
-      expect(screen.queryByText(/\bNEED\b/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/\bHAVE\b/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/short/i)).not.toBeInTheDocument();
+    it("does not render a Copy button", () => {
+      renderRecipe();
+      expect(screen.queryByText("Copy")).not.toBeInTheDocument();
     });
 
     it("renders the ingredients section as 'What to gather'", () => {
-      render(<RecipeDisplay />);
+      renderRecipe();
       expect(screen.getByText("What to gather")).toBeInTheDocument();
     });
   });
 
   describe("Structured steps", () => {
     it("renders step title and body when steps are present", () => {
-      mockSelectedRecipe.mockReturnValue({
-        ...baseRecipe,
+      renderRecipe({
         steps: [
           { title: "Heat the pan", body: "Put butter in a pan on medium heat.", tip: "Don't let it brown." },
           { title: "Add eggs", body: "Beat and pour in eggs." },
         ],
-      });
-      render(<RecipeDisplay />);
+      } as never);
       expect(screen.getByText("Heat the pan")).toBeInTheDocument();
       expect(screen.getByText("Put butter in a pan on medium heat.")).toBeInTheDocument();
       expect(screen.getByText("Don't let it brown.")).toBeInTheDocument();
@@ -147,32 +74,31 @@ describe("RecipeDisplay", () => {
     });
 
     it("falls back to Streamdown when steps array is empty", () => {
-      mockSelectedRecipe.mockReturnValue({ ...baseRecipe, steps: [] });
-      render(<RecipeDisplay />);
+      renderRecipe({ steps: [] } as never);
       expect(screen.getByTestId("streamdown")).toBeInTheDocument();
     });
   });
 
   describe("Servings stepper", () => {
     it("starts at the recipe's baseServings", () => {
-      render(<RecipeDisplay />);
+      renderRecipe();
       expect(screen.getByText("2")).toBeInTheDocument();
     });
 
     it("scales ingredient amounts when servings increase", () => {
-      render(<RecipeDisplay />);
+      renderRecipe();
       fireEvent.click(screen.getByLabelText("Increase servings"));
       expect(screen.getByText(/4\.5 piece/)).toBeInTheDocument();
     });
 
     it("scales ingredient amounts when servings decrease", () => {
-      render(<RecipeDisplay />);
+      renderRecipe();
       fireEvent.click(screen.getByLabelText("Decrease servings"));
       expect(screen.getByText(/1\.5 piece/)).toBeInTheDocument();
     });
 
     it("does not go below 1 serving", () => {
-      render(<RecipeDisplay />);
+      renderRecipe();
       const dec = screen.getByLabelText("Decrease servings");
       fireEvent.click(dec);
       fireEvent.click(dec);
@@ -180,30 +106,48 @@ describe("RecipeDisplay", () => {
     });
   });
 
-  describe("Copy button", () => {
-    it("writes the recipe instructions to the clipboard", async () => {
-      render(<RecipeDisplay />);
-      fireEvent.click(screen.getByText("Copy"));
-      await waitFor(() => {
-        expect(mockClipboard.writeText).toHaveBeenCalledWith(baseRecipe.instructions);
-      });
+  describe("Start cooking", () => {
+    const recipeWithSteps = {
+      ...baseRecipe,
+      steps: [
+        { title: "Heat the pan", body: "Put butter in a pan on medium heat." },
+        { title: "Add eggs", body: "Beat and pour in eggs." },
+      ],
+    } as never;
+
+    it("calls onStartCooking when provided and does not render CookingMode internally", () => {
+      const onStartCooking = jest.fn();
+      render(
+        <RecipeDisplay
+          recipe={recipeWithSteps}
+          onBack={jest.fn()}
+          onStartCooking={onStartCooking}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText(/Start cooking/));
+      expect(onStartCooking).toHaveBeenCalledTimes(1);
+      // CookingMode header (e.g. "Exit cooking mode") should NOT appear
+      expect(screen.queryByText(/Exit cooking mode/i)).not.toBeInTheDocument();
     });
 
-    it("shows a success toast on copy", async () => {
-      render(<RecipeDisplay />);
-      fireEvent.click(screen.getByText("Copy"));
-      await waitFor(() => {
-        expect(toast.success).toHaveBeenCalledWith("Recipe copied to clipboard!");
-      });
+    it("falls back to internal cooking mode when onStartCooking is not provided", () => {
+      render(<RecipeDisplay recipe={recipeWithSteps} onBack={jest.fn()} />);
+      fireEvent.click(screen.getByLabelText(/Start cooking/));
+      expect(screen.getByText(/Exit cooking mode/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("Before you start (mise en place)", () => {
+    it("renders prep items when present", () => {
+      renderRecipe({ prep: ["Dice the onion", "Mince the garlic"] } as never);
+      expect(screen.getByText("Before you start")).toBeInTheDocument();
+      expect(screen.getByText("Dice the onion")).toBeInTheDocument();
+      expect(screen.getByText("Mince the garlic")).toBeInTheDocument();
     });
 
-    it("shows an error toast when clipboard fails", async () => {
-      mockClipboard.writeText.mockRejectedValueOnce(new Error("denied"));
-      render(<RecipeDisplay />);
-      fireEvent.click(screen.getByText("Copy"));
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith("Failed to copy recipe");
-      });
+    it("omits the section when prep is empty", () => {
+      renderRecipe();
+      expect(screen.queryByText("Before you start")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -1,9 +1,7 @@
-import { Button } from "@/components/ui/button";
 import { CookingMode } from "@/features/Chat/components/recipe/CookingMode";
 import { RecipeIngredient, RecipeStep, RecipeWithId } from "@/lib/recipes/schemas";
 import Image from "next/image";
 import { useState } from "react";
-import { toast } from "sonner";
 import { Streamdown } from "streamdown";
 
 const formatAmount = (n: number) => {
@@ -38,7 +36,7 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
     <>
       {/* Hero strip */}
       <div
-        className="relative h-[180px] sm:h-[220px] border-b border-border flex items-end overflow-hidden"
+        className="relative h-[180px] sm:h-[260px] border-b border-border flex items-end overflow-hidden"
         style={!selectedRecipe.imageUrl ? { background: "linear-gradient(135deg, oklch(0.55 0.13 35) 0%, oklch(0.42 0.10 30) 100%)" } : undefined}
       >
         {selectedRecipe.imageUrl ? (
@@ -250,22 +248,22 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
 interface RecipeDisplayProps {
   recipe: RecipeWithId;
   onBack: () => void;
+  onStartCooking?: () => void;
 }
 
-export default function RecipeDisplay({ recipe, onBack }: RecipeDisplayProps) {
+export default function RecipeDisplay({ recipe, onBack, onStartCooking }: RecipeDisplayProps) {
   const [cooking, setCooking] = useState(false);
-
-  const copyRecipe = async () => {
-    try {
-      await navigator.clipboard.writeText(recipe.instructions || "");
-      toast.success("Recipe copied to clipboard!");
-    } catch {
-      toast.error("Failed to copy recipe");
-    }
-  };
 
   const steps = (recipe.steps ?? []) as RecipeStep[];
   const canCook = steps.length > 0;
+
+  const handleStartCooking = () => {
+    if (onStartCooking) {
+      onStartCooking();
+    } else {
+      setCooking(true);
+    }
+  };
 
   if (cooking) {
     return (
@@ -279,42 +277,33 @@ export default function RecipeDisplay({ recipe, onBack }: RecipeDisplayProps) {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Top strip — Back / Copy + Start cooking */}
-      <div className="flex items-center justify-between px-4 sm:px-6 py-3 border-b border-dashed border-border shrink-0">
-        <button
-          onClick={onBack}
-          className="font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
-          aria-label="Back to cookbook"
-        >
-          ← Back to cookbook
-        </button>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="cursor-pointer"
-            onClick={copyRecipe}
-            aria-label="Copy recipe to clipboard"
-          >
-            Copy
-          </Button>
-          {canCook && (
-            <button
-              onClick={() => setCooking(true)}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12.5px] font-semibold text-primary-foreground bg-primary border border-primary rounded-md cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
-              aria-label="Start cooking — step-by-step view with screen stay-on"
-            >
-              <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
-                <path d="M5 3l8 5-8 5V3z" fill="currentColor" />
-              </svg>
-              Start cooking
-            </button>
-          )}
-        </div>
-      </div>
-
       <div className="flex-1 overflow-y-auto">
-        <RecipeBody selectedRecipe={recipe} />
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 pt-4 sm:pt-5 pb-8">
+          <div className="flex items-center justify-between mb-3 sm:mb-4">
+            <button
+              onClick={onBack}
+              className="font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
+              aria-label="Back to cookbook"
+            >
+              ← Back to cookbook
+            </button>
+            {canCook && (
+              <button
+                onClick={handleStartCooking}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12.5px] font-semibold text-primary-foreground bg-primary border border-primary rounded-md cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
+                aria-label="Start cooking — step-by-step view with screen stay-on"
+              >
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+                  <path d="M5 3l8 5-8 5V3z" fill="currentColor" />
+                </svg>
+                Start cooking
+              </button>
+            )}
+          </div>
+          <div className="rounded-xl border border-border bg-card overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
+            <RecipeBody selectedRecipe={recipe} />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/features/RecipeList/RecipeList.test.tsx
+++ b/src/features/RecipeList/RecipeList.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import RecipeList from "./RecipeList";
+
+jest.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="streamdown">{children}</div>
+  ),
+}));
+
+jest.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => ({ userId: "user-1" }),
+}));
+
+const mockRecipes = [
+  {
+    id: "r1",
+    userId: "user-1",
+    name: "Test Recipe",
+    instructions: "",
+    tags: ["easy"],
+    recipeId: "msg-1",
+    baseServings: 2,
+    ingredients: [{ name: "egg", amount: 2, unit: "piece" }],
+    steps: [
+      { title: "Step one", body: "Do the first thing." },
+      { title: "Step two", body: "Do the second thing." },
+    ],
+  },
+];
+
+jest.mock("swr", () => {
+  const actual = jest.requireActual("swr");
+  return {
+    __esModule: true,
+    ...actual,
+    default: () => ({ data: mockRecipes, isLoading: false }),
+    mutate: jest.fn(),
+  };
+});
+
+describe("RecipeList — start cooking flow", () => {
+  it("closes the recipe modal and surfaces CookingMode when Start cooking is clicked", () => {
+    render(<RecipeList />);
+
+    // Open the recipe modal
+    fireEvent.click(screen.getByText("Test Recipe"));
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByLabelText(/Start cooking/)).toBeInTheDocument();
+
+    // Click Start cooking
+    fireEvent.click(within(dialog).getByLabelText(/Start cooking/));
+
+    // Dialog should be gone, CookingMode should be visible
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByText(/Exit cooking mode/i)).toBeInTheDocument();
+    expect(screen.getByText("Step one")).toBeInTheDocument();
+  });
+
+  it("advances to the next step when Next step is clicked from CookingMode", () => {
+    render(<RecipeList />);
+    fireEvent.click(screen.getByText("Test Recipe"));
+    fireEvent.click(within(screen.getByRole("dialog")).getByLabelText(/Start cooking/));
+
+    expect(screen.getByText("Step one")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Next step/i }));
+    expect(screen.getByText("Step two")).toBeInTheDocument();
+  });
+});

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { useSessionContext } from "@/contexts/SessionContext";
-import { RecipeWithId } from "@/lib/recipes/schemas";
+import { CookingMode } from "@/features/Chat/components/recipe/CookingMode";
+import RecipeDisplay from "@/features/RecipeDisplay/RecipeDisplay";
+import { RecipeStep, RecipeWithId } from "@/lib/recipes/schemas";
 import { fetcher } from "@/lib/utils/index";
-import { useRouter } from "next/navigation";
+import { VisuallyHidden } from "radix-ui";
 import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
@@ -18,9 +21,10 @@ interface RecipeListProps {
 
 export default function RecipeList({ onChatClick }: RecipeListProps) {
   const { userId } = useSessionContext();
-  const router = useRouter();
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [openRecipe, setOpenRecipe] = useState<RecipeWithId | null>(null);
+  const [cookingRecipe, setCookingRecipe] = useState<RecipeWithId | null>(null);
 
   const { data: recipes, isLoading } = useSWR<RecipeWithId[]>(
     userId ? `/api/recipe?userId=${userId}` : null,
@@ -159,13 +163,45 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
               <RecipeCard
                 key={recipe.id}
                 recipe={recipe}
-                onSelect={(r) => router.push(`/recipe/${r.id}`)}
+                onSelect={(r) => setOpenRecipe(r)}
                 onDelete={deleteRecipe}
               />
             ))}
           </div>
         )}
       </div>
+
+      <Dialog
+        open={!!openRecipe && !cookingRecipe}
+        onOpenChange={(o) => !o && setOpenRecipe(null)}
+      >
+        <DialogContent
+          showCloseButton={false}
+          className="max-w-3xl w-[95vw] sm:w-[92vw] h-[92vh] p-0 overflow-hidden bg-background"
+        >
+          <VisuallyHidden.Root>
+            <DialogTitle>{openRecipe?.name ?? "Recipe"}</DialogTitle>
+          </VisuallyHidden.Root>
+          {openRecipe && (
+            <RecipeDisplay
+              recipe={openRecipe}
+              onBack={() => setOpenRecipe(null)}
+              onStartCooking={() => {
+                setCookingRecipe(openRecipe);
+                setOpenRecipe(null);
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {cookingRecipe && (
+        <CookingMode
+          title={cookingRecipe.name}
+          steps={(cookingRecipe.steps ?? []) as RecipeStep[]}
+          onExit={() => setCookingRecipe(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Cookbook tab opens recipes in a Radix Dialog instead of routing to `/recipe/[id]`.
- `CookingMode` lifted from `RecipeDisplay` to its consumer (`RecipeList`, chat). Cookbook closes the dialog before mounting CookingMode at the top level — Radix Dialog's `pointer-events: none` on siblings was killing the Next-step button when CookingMode rendered inside or portalled from the dialog.
- Recipe layout: centred `max-w-3xl` card on app background, Copy button dropped, Back navigates to `?tab=cookbook`.
- Pantry: drop `max-w-[1200px]`, switch to CSS columns (masonry) so short categories don't leave dark gaps.

## Test plan
- [ ] Cookbook → open a recipe → modal renders centred card.
- [ ] In modal, click **Start cooking** → modal closes, CookingMode takes over viewport, **Next step** advances.
- [ ] In modal, click **Back to cookbook** → modal closes.
- [ ] Chat flow: assistant proposes recipe → save → Start cooking still works (internal cooking state fallback).
- [ ] `/recipe/[id]` direct link still works; Back lands on Cookbook tab.
- [ ] Pantry: no dark gutters on left/right; short categories don't leave tall gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipe viewing now uses modal dialogs instead of page navigation for seamless browsing.
  * Home tab selection now persists via URL query parameters.

* **UI/UX Improvements**
  * Inventory pantry layout switched to column-based design to eliminate spacing gaps.
  * Refined recipe header styling and dialog close button controls.
  * Improved cooking mode state management for better modal interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->