### PR TITLE
fix(layout): account for body top-margin in page height calc

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ function HomeContent() {
 
   return (
     <div className="bg-background">
-      <main className="xl:container mx-auto h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)]">
+      <main className="xl:container mx-auto h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)]">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col pt-2">
           <TabsList>
             <TabsTrigger value="chat">Chat</TabsTrigger>

--- a/src/app/recipe/[id]/page.tsx
+++ b/src/app/recipe/[id]/page.tsx
@@ -21,7 +21,7 @@ export default function RecipePage() {
 
   if (isLoading) {
     return (
-      <div className="h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)] flex items-center justify-center">
+      <div className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] flex items-center justify-center">
         <p className="font-display italic text-muted-foreground">Pulling out the recipe…</p>
       </div>
     );
@@ -29,7 +29,7 @@ export default function RecipePage() {
 
   if (!recipe) {
     return (
-      <div className="h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col items-center justify-center gap-4">
+      <div className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] flex flex-col items-center justify-center gap-4">
         <p className="font-display italic text-muted-foreground">
           Can&rsquo;t find that one, lah.
         </p>
@@ -44,7 +44,7 @@ export default function RecipePage() {
   }
 
   return (
-    <div className="h-[calc(100dvh-3.25rem)] md:h-[calc(100dvh-3.5rem)] overflow-hidden">
+    <div className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] overflow-hidden">
       <RecipeDisplay recipe={recipe} onBack={() => router.push("/?tab=cookbook")} />
     </div>
   );


### PR DESCRIPTION
## Summary
- Body has `mt-2` (sm) / `mt-4` (md) but the page main was only subtracting header height (`3.25rem` / `3.5rem`).
- Total content overflowed the viewport by the margin amount, producing an unwanted outer scrollbar on top of the chat's own scrollbar.
- Subtract the margin in the same calc per breakpoint.

## Test plan
- [ ] On `md+`, no outer scrollbar on Chat / Pantry / Cookbook tabs.
- [ ] Chat input remains visible at the bottom (not clipped).
- [ ] Pantry list scrolls within its container; no double scrollbar.
- [ ] `/recipe/[id]` direct page still sized correctly with no outer scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)