### PR TITLE
feat(recipe): prep steps in cooking mode + Before you start in chat

### DIFF
--- a/src/features/Chat/components/recipe/CookingMode.tsx
+++ b/src/features/Chat/components/recipe/CookingMode.tsx
@@ -12,13 +12,28 @@ interface Step {
 interface CookingModeProps {
   title: string;
   steps: Step[];
+  prep?: string[];
   onExit: () => void;
 }
 
-export function CookingMode({ title, steps, onExit }: CookingModeProps) {
+function prepToStep(item: string): Step {
+  const commaIdx = item.indexOf(",");
+  const title =
+    commaIdx > 0 && commaIdx <= 40
+      ? item.slice(0, commaIdx)
+      : item.split(" ").slice(0, 4).join(" ");
+  const body = title === item ? "" : item;
+  return { title, body };
+}
+
+export function CookingMode({ title, steps, prep, onExit }: CookingModeProps) {
+  const allSteps: Step[] = [
+    ...(prep ?? []).map(prepToStep),
+    ...steps,
+  ];
   const [current, setCurrent] = useState(0);
   const wakeLockRef = useRef<WakeLockSentinel | null>(null);
-  const total = steps.length;
+  const total = allSteps.length;
 
   const requestWakeLock = useCallback(async () => {
     if (!("wakeLock" in navigator)) return;
@@ -51,7 +66,7 @@ export function CookingMode({ title, steps, onExit }: CookingModeProps) {
 
   if (total === 0) return null;
 
-  const step = steps[Math.min(current, total - 1)];
+  const step = allSteps[Math.min(current, total - 1)];
   const prev = () => setCurrent((c) => Math.max(0, c - 1));
   const next = () => setCurrent((c) => Math.min(total - 1, c + 1));
 

--- a/src/features/Chat/components/recipe/CookingMode.tsx
+++ b/src/features/Chat/components/recipe/CookingMode.tsx
@@ -17,12 +17,13 @@ interface CookingModeProps {
 }
 
 function prepToStep(item: string): Step {
-  const commaIdx = item.indexOf(",");
+  const normalized = item.trim();
+  const commaIdx = normalized.indexOf(",");
   const title =
-    commaIdx > 0 && commaIdx <= 40
-      ? item.slice(0, commaIdx)
-      : item.split(" ").slice(0, 4).join(" ");
-  const body = title === item ? "" : item;
+    commaIdx > 0
+      ? normalized.slice(0, commaIdx).trim()
+      : normalized.split(/\s+/).slice(0, 4).join(" ");
+  const body = normalized;
   return { title, body };
 }
 

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -37,6 +37,7 @@ interface RecipeData {
   totalTimeMinutes?: number;
   baseServings: number;
   ingredients: Ingredient[];
+  prep?: string[];
   steps: Step[];
   tags?: string[];
 }
@@ -232,6 +233,7 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
       <CookingMode
         title={recipe.title}
         steps={recipe.steps}
+        prep={recipe.prep}
         onExit={() => setCooking(false)}
       />
     );
@@ -366,6 +368,21 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
               );
             })}
           </div>
+        </div>
+      )}
+
+      {/* Before you start — mise en place */}
+      {recipe.prep && recipe.prep.length > 0 && (
+        <div className="mb-5">
+          <span className={cn(EYEBROW_BASE, "text-muted-foreground block mb-2")}>Before you start</span>
+          <ul className="list-none p-0 m-0 flex flex-col">
+            {recipe.prep.map((item, i) => (
+              <li key={i} className="flex gap-2.5 items-baseline py-2 border-b border-dashed border-border last:border-none">
+                <span className="font-mono text-[11px] font-bold text-ink-faint shrink-0">·</span>
+                <span className="font-display text-sm text-foreground leading-[1.45]">{item}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -270,6 +270,7 @@ export default function RecipeDisplay({ recipe, onBack, onStartCooking }: Recipe
       <CookingMode
         title={recipe.name}
         steps={steps}
+        prep={(recipe.prep ?? []) as string[]}
         onExit={() => setCooking(false)}
       />
     );

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -199,6 +199,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
         <CookingMode
           title={cookingRecipe.name}
           steps={(cookingRecipe.steps ?? []) as RecipeStep[]}
+          prep={(cookingRecipe.prep ?? []) as string[]}
           onExit={() => setCookingRecipe(null)}
         />
       )}


### PR DESCRIPTION
## Summary
- **Before you start in chat**: `RecipeLetter` now renders the `prep` section between "What to gather" and the steps. The data was already being parsed — it just wasn't wired into the component.
- **Prep in CookingMode**: all three CookingMode call sites now pass `prep` through. CookingMode converts each prep string to a step (title = text before first comma, body = full string) and prepends them before the cooking steps. Technique-critical steps like scoring pork skin and applying a rub are now part of the step-by-step flow.

## Test plan
- [ ] Chat recipe with prep (e.g. air fryer pork belly) shows "Before you start" section with scoring/rub steps.
- [ ] Start cooking from chat — prep items appear as steps 1, 2, 3… before cooking steps.
- [ ] Start cooking from cookbook modal — same.
- [ ] Recipe without prep: no "Before you start" section rendered, step count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Before you start" section displaying pre-preparation items in recipe view
  * Integrated preparation steps into cooking mode for a comprehensive, sequential cooking experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->