### PR TITLE
feat(rail): butter bubble treatment for active conversation row

### DIFF
--- a/src/features/Conversations/components/ConversationItem.test.tsx
+++ b/src/features/Conversations/components/ConversationItem.test.tsx
@@ -12,21 +12,23 @@ const baseConv: ConversationEntity = {
 };
 
 describe("ConversationItem", () => {
-  it("renders active state with primary border", () => {
+  it("renders active state with butter bubble treatment", () => {
     const { container } = render(
       <ConversationItem conversation={baseConv} isActive={true} onClick={() => {}} />
     );
     const card = container.firstChild as HTMLElement;
-    expect(card.className).toContain("border-primary");
+    expect(card.className).toContain("bg-secondary");
+    expect(card.className).toContain("border-[oklch(0.78_0.10_88)]");
   });
 
-  it("renders inactive state without primary border", () => {
+  it("renders inactive state with stripped chrome", () => {
     const { container } = render(
       <ConversationItem conversation={baseConv} isActive={false} onClick={() => {}} />
     );
     const card = container.firstChild as HTMLElement;
-    expect(card.className).not.toContain("border-primary");
-    expect(card.className).toContain("border-border");
+    expect(card.className).not.toContain("bg-secondary");
+    expect(card.className).toContain("bg-transparent");
+    expect(card.className).toContain("border-transparent");
   });
 
   it("calls onClick when clicked", () => {

--- a/src/features/Conversations/components/ConversationItem.tsx
+++ b/src/features/Conversations/components/ConversationItem.tsx
@@ -34,10 +34,10 @@ export function ConversationItem({ conversation, isActive, onClick }: Conversati
     <div
       onClick={onClick}
       className={cn(
-        "rounded-[10px] p-3 cursor-pointer shadow-[0_1px_0_oklch(0.87_0.03_72)]",
+        "rounded-[10px] p-3 cursor-pointer border transition-colors",
         isActive
-          ? "bg-chat border border-primary border-l-[3px]"
-          : "bg-card border border-border"
+          ? "bg-secondary border-[oklch(0.78_0.10_88)] shadow-[0_1px_0_oklch(0.78_0.10_88)]"
+          : "bg-transparent border-transparent hover:border-[oklch(0.78_0.10_88)]/40"
       )}
     >
       {/* Title row */}


### PR DESCRIPTION
Closes #173

## Summary
- Active conversation row mirrors the user-message bubble: `bg-secondary` fill, `border-[oklch(0.78_0.10_88)]`, and matching shadow.
- Inactive rows shed all chrome (`bg-transparent`, `border-transparent`); hover adds a soft butter outline.
- Same padding/radius on both states keeps layout stable.
- Treatment propagates to mobile sheet via shared `ConversationItem`.

Establishes butter as a load-bearing semantic across surfaces: "you, here, now." ADR follows in #174.

## Test plan
- [x] `ConversationItem.test.tsx` updated and passing (9/9)
- [ ] Visual check: active row chrome moves with selection, not stacked
- [ ] Mobile sheet renders the same treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined conversation item styling with updated active and inactive state appearances. Active items now feature a distinctive background and border treatment with improved visual feedback. Inactive items use a cleaner, more minimal appearance with transparent styling and smooth color transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->