### PR TITLE
feat(chat): hold AI loader until first visible content

### DIFF
--- a/src/features/Chat/components/MessageList.test.tsx
+++ b/src/features/Chat/components/MessageList.test.tsx
@@ -449,7 +449,7 @@ describe("MessageList", () => {
       expect(screen.queryByTestId("loader-ghost")).not.toBeInTheDocument();
     });
 
-    it("should not show loader ghost bubble during streaming", () => {
+    it("should not show loader ghost bubble during streaming with content", () => {
       const streamingMessage = createMockMessage({
         role: "assistant",
         parts: [{ type: "text", text: "Let me think about that..." }],
@@ -464,6 +464,24 @@ describe("MessageList", () => {
       );
 
       expect(screen.queryByTestId("loader-ghost")).not.toBeInTheDocument();
+    });
+
+    it("should show loader ghost bubble during streaming when last assistant message is empty (tool-call gap)", () => {
+      const emptyAssistant = createMockMessage({
+        role: "assistant",
+        parts: [{ type: "text", text: "" }],
+      });
+
+      render(
+        <MessageList
+          {...defaultProps}
+          messages={[emptyAssistant]}
+          status="streaming"
+          submittedAt={Date.now()}
+        />
+      );
+
+      expect(screen.getByTestId("loader-ghost")).toBeInTheDocument();
     });
 
   });

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -38,6 +38,27 @@ interface MessageListProps {
 
 // ── Parsed block types ────────────────────────────────────────────────────────
 
+// Loader stays visible while submitted, and while streaming until the last
+// assistant message has emitted visible content (text, parsed block, or open
+// recipe fence). Closes the empty-bubble gap during tool-call-first turns.
+function shouldShowLoader(status: string, messages: UIMessage[]): boolean {
+  if (status === "submitted") return true;
+  if (status !== "streaming") return false;
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== "assistant") return true;
+  const text = last.parts
+    .filter(
+      (p): p is { type: "text"; text: string } =>
+        p.type === "text" && typeof (p as { text?: string }).text === "string",
+    )
+    .map((p) => p.text)
+    .join("");
+  if (stripFences(text).trim().length > 0) return false;
+  if (extractRecipeBlocks(text).length > 0) return false;
+  if (getOpenRecipeFenceIdx(text) !== -1) return false;
+  return true;
+}
+
 // ── SWR fetcher for save ──────────────────────────────────────────────────────
 
 const saveRecipeCall = async (
@@ -397,12 +418,11 @@ export const MessageList = ({
             );
           })}
 
-          {/* Ghost loader bubble — visible only during submitted state */}
-          {status === "submitted" && (
+          {/* Ghost loader bubble — visible while submitted, and while
+              streaming until the assistant has emitted visible content. */}
+          {shouldShowLoader(status, messages) && (
             <div className="py-4">
-              <ChatLoader
-                submittedAt={submittedAt}
-              />
+              <ChatLoader submittedAt={submittedAt} />
             </div>
           )}
 


### PR DESCRIPTION
Closes #179

## Summary
- Added `shouldShowLoader()` that keeps `ChatLoader` visible while `status === "streaming"` AND the last assistant message has no visible content (text, parsed block, or open recipe fence).
- Closes the empty-bubble gap during tool-call-first turns: `getInventory`, `proposeRecipe`, `addInventoryItem` etc. all run before the model emits text — previously this left a blank space after `status` flipped from `submitted` to `streaming`.
- Pre-existing `MessageList.test.tsx` ESM failure (unrelated auth-client import issue) blocks unit tests; new test case added but can't be run until that's fixed.

## Test plan
- [ ] Send "what's in my pantry?" — dot-bubble stays visible through the tool call and disappears when first text appears
- [ ] Send a normal message — dot-bubble disappears immediately when first text token streams in
- [ ] Send a recipe request — dot-bubble stays until SkeletonRecipeCard or prose appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)