### PR TITLE
fix(rail): stop revalidation from wiping rail cache + skeleton loading

### DIFF
--- a/src/contexts/ConversationContext.tsx
+++ b/src/contexts/ConversationContext.tsx
@@ -103,8 +103,6 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
     globalMutate(
       (key: unknown) =>
         typeof key === "string" && key.includes("/api/conversation"),
-      undefined,
-      { revalidate: true }
     );
 
   const startNewConversation = async (options?: { revalidate?: boolean }) => {

--- a/src/features/Conversations/Conversations.tsx
+++ b/src/features/Conversations/Conversations.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import useSWR from "swr";
 import { CONVERSATIONS_SEARCH_PLACEHOLDER } from "./constants";
 import { ConversationItem } from "./components/ConversationItem";
+import { ConversationListSkeleton } from "./components/ConversationListSkeleton";
 
 interface ConversationsProps {
   onItemClick?: () => void;
@@ -123,8 +124,8 @@ export function Conversations({ onItemClick }: ConversationsProps) {
 
       {/* List */}
       <div className="flex-1 min-h-0 overflow-y-auto">
-        {isLoading ? (
-          <div className="italic text-ink-faint text-sm">Loading…</div>
+        {isLoading && !data ? (
+          <ConversationListSkeleton />
         ) : filtered.length === 0 ? (
           <div className="italic text-ink-faint text-sm">
             {search ? "No results" : "No conversations yet"}

--- a/src/features/Conversations/components/ConversationListSkeleton.tsx
+++ b/src/features/Conversations/components/ConversationListSkeleton.tsx
@@ -2,16 +2,40 @@
 
 import { ShimmerLine } from "@/features/Chat/components/loaders/ShimmerLine";
 
-const WIDTHS = ["72%", "58%", "80%", "64%", "52%"];
+// Section eyebrows stay visible during load so the rail's spine never collapses.
+// Widths vary 40–80% to mimic real title rhythm.
+
+function SkeletonRow({ width, delay }: { width: string; delay: number }) {
+  return (
+    <div className="rounded-[10px] p-3 border border-transparent">
+      <ShimmerLine width={width} height={14} delay={delay} />
+    </div>
+  );
+}
 
 export function ConversationListSkeleton() {
   return (
-    <div className="flex flex-col gap-2">
-      {WIDTHS.map((w, i) => (
-        <div key={i} className="rounded-[10px] p-3 border border-transparent">
-          <ShimmerLine width={w} height={16} delay={i * 0.07} />
+    <div className="flex flex-col gap-3">
+      <div>
+        <div className="font-sans text-[9.5px] font-bold tracking-[0.18em] uppercase text-ink-faint mb-1.5 px-0.5">
+          Today
         </div>
-      ))}
+        <div className="flex flex-col gap-2">
+          <SkeletonRow width="72%" delay={0} />
+          <SkeletonRow width="55%" delay={0.08} />
+        </div>
+      </div>
+      <div>
+        <div className="font-sans text-[9.5px] font-bold tracking-[0.18em] uppercase text-ink-faint mb-1.5 px-0.5">
+          Earlier
+        </div>
+        <div className="flex flex-col gap-2">
+          <SkeletonRow width="80%" delay={0.16} />
+          <SkeletonRow width="63%" delay={0.24} />
+          <SkeletonRow width="48%" delay={0.32} />
+          <SkeletonRow width="75%" delay={0.40} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/features/Conversations/components/ConversationListSkeleton.tsx
+++ b/src/features/Conversations/components/ConversationListSkeleton.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { ShimmerLine } from "@/features/Chat/components/loaders/ShimmerLine";
+
+const WIDTHS = ["72%", "58%", "80%", "64%", "52%"];
+
+export function ConversationListSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      {WIDTHS.map((w, i) => (
+        <div key={i} className="rounded-[10px] p-3 border border-transparent">
+          <ShimmerLine width={w} height={16} delay={i * 0.07} />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Root cause: `revalidateConversationKeys` was calling `globalMutate(matcher, undefined, { revalidate: true })`. The `undefined` data arg clears all matching SWR cache entries before refetch. Every first-visit to a recipe conversation triggered `autoTitleActiveConversation` → this mutate → rail's `data` became undefined → `isLoading: true` → rail blanked to "Loading…".
- Fix: drop the `undefined` arg — `globalMutate(matcher)` revalidates in the background without clearing existing data.
- UX: replace the italic "Loading…" text with a 5-row shimmer skeleton that matches `ConversationItem`'s geometry, only shown on true cold-start.

## Test plan
- [ ] Hard refresh, click a conversation that has a recipe — rail titles stay visible, no "Loading…" flash
- [ ] Repeat across multiple new conversations — no flash on any
- [ ] Cold-start (incognito): skeleton rows shimmer briefly before real list appears
- [ ] Create / rename / delete a conversation — rail still updates correctly
- [ ] 13/13 Conversations + ConversationContext tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated skeleton placeholders to the conversation list that display while fetching data, providing a more polished loading experience compared to plain text indicators.

* **Bug Fixes**
  * Refined loading state logic to show skeleton placeholders only when data is unavailable, preserving existing empty state and conversation list rendering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->