### PR TITLE
feat(chrome): collapse two-row header — tabs inline with brand

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,7 @@
-import AboutPopOver from "@/components/AboutPopOver";
-import { AuthButton } from "@/features/Auth";
 import { Toaster } from "@/components/ui/sonner";
 import { SessionProvider } from "@/contexts/SessionContext";
 import type { Metadata } from "next";
 import { Fraunces, Inter, Nunito } from "next/font/google";
-import Image from "next/image";
 import "./globals.css";
 
 const fontSans = Inter({
@@ -115,23 +112,6 @@ export default function RootLayout({
               },
             }}
           />
-          <div className="pb-2 pt-2 border-b xl:container mx-auto px-4 flex justify-between items-center">
-            <h1 className="text-xl md:text-2xl font-bold font-logo flex items-center gap-2 text-primary">
-              <div className="relative w-8 h-8 md:w-9 md:h-9">
-                <Image
-                  src="/granny-icon.png"
-                  alt="Ask Ah Mah"
-                  fill
-                  className="object-contain"
-                />
-              </div>
-              Ask Ah Mah
-            </h1>
-            <div className="flex items-center gap-2">
-              <AboutPopOver className="hidden lg:flex" />
-              <AuthButton />
-            </div>
-          </div>
           {children}
         </SessionProvider>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { AppHeader } from "@/components/AppHeader";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ConversationProvider } from "@/contexts/ConversationContext";
 import ChatWrapper from "@/features/Chat/components/ChatWrapper";
@@ -19,13 +20,17 @@ function HomeContent() {
 
   return (
     <div className="bg-background">
-      <main className="xl:container mx-auto h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)]">
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col pt-2">
-          <TabsList>
-            <TabsTrigger value="chat">Chat</TabsTrigger>
-            <TabsTrigger value="pantry">Pantry</TabsTrigger>
-            <TabsTrigger value="cookbook">Cookbook</TabsTrigger>
-          </TabsList>
+      <main className="xl:container mx-auto h-dvh sm:h-[calc(100dvh-0.5rem)] md:h-[calc(100dvh-1rem)]">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
+          <AppHeader
+            tabs={
+              <TabsList>
+                <TabsTrigger value="chat">Chat</TabsTrigger>
+                <TabsTrigger value="pantry">Pantry</TabsTrigger>
+                <TabsTrigger value="cookbook">Cookbook</TabsTrigger>
+              </TabsList>
+            }
+          />
 
           {/* ── Chat tab ── */}
           <TabsContent

--- a/src/app/recipe/[id]/page.tsx
+++ b/src/app/recipe/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AppHeader } from "@/components/AppHeader";
 import { useSessionContext } from "@/contexts/SessionContext";
 import RecipeDisplay from "@/features/RecipeDisplay/RecipeDisplay";
 import { RecipeWithId } from "@/lib/recipes/schemas";
@@ -21,31 +22,40 @@ export default function RecipePage() {
 
   if (isLoading) {
     return (
-      <div className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] flex items-center justify-center">
-        <p className="font-display italic text-muted-foreground">Pulling out the recipe…</p>
-      </div>
+      <>
+        <AppHeader />
+        <div className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] flex items-center justify-center">
+          <p className="font-display italic text-muted-foreground">Pulling out the recipe…</p>
+        </div>
+      </>
     );
   }
 
   if (!recipe) {
     return (
-      <div className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] flex flex-col items-center justify-center gap-4">
-        <p className="font-display italic text-muted-foreground">
-          Can&rsquo;t find that one, lah.
-        </p>
-        <button
-          onClick={() => router.push("/?tab=cookbook")}
-          className="px-3.5 py-2 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
-        >
-          Back to cookbook
-        </button>
-      </div>
+      <>
+        <AppHeader />
+        <div className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] flex flex-col items-center justify-center gap-4">
+          <p className="font-display italic text-muted-foreground">
+            Can&rsquo;t find that one, lah.
+          </p>
+          <button
+            onClick={() => router.push("/?tab=cookbook")}
+            className="px-3.5 py-2 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
+          >
+            Back to cookbook
+          </button>
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] overflow-hidden">
-      <RecipeDisplay recipe={recipe} onBack={() => router.push("/?tab=cookbook")} />
-    </div>
+    <>
+      <AppHeader />
+      <div className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] overflow-hidden">
+        <RecipeDisplay recipe={recipe} onBack={() => router.push("/?tab=cookbook")} />
+      </div>
+    </>
   );
 }

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -13,7 +13,7 @@ export function AppHeader({ tabs }: AppHeaderProps) {
   return (
     <div className="pb-2 pt-2 border-b xl:container mx-auto px-4 flex items-center justify-between gap-4">
       <div className="flex items-center gap-4">
-        <h1 className="text-xl md:text-2xl font-bold font-logo flex items-center gap-2 text-primary shrink-0">
+        <h1 className="shrink-0">
           <div className="relative w-8 h-8 md:w-9 md:h-9">
             <Image
               src="/granny-icon.png"
@@ -22,7 +22,6 @@ export function AppHeader({ tabs }: AppHeaderProps) {
               className="object-contain"
             />
           </div>
-          Ask Ah Mah
         </h1>
 
         {tabs && (

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -13,15 +13,18 @@ export function AppHeader({ tabs }: AppHeaderProps) {
   return (
     <div className="pb-2 pt-2 border-b xl:container mx-auto px-4 flex items-center justify-between gap-4">
       <div className="flex items-center gap-4">
-        <h1 className="shrink-0">
+        <h1 className="flex items-center gap-2 shrink-0">
           <div className="relative w-8 h-8 md:w-9 md:h-9">
             <Image
               src="/granny-icon.png"
-              alt="Ask Ah Mah"
+              alt=""
               fill
               className="object-contain"
             />
           </div>
+          <span className="font-display italic text-[17px] md:text-[18px] font-medium tracking-[-0.015em] text-primary-ink leading-none">
+            Ask Ah Mah
+          </span>
         </h1>
 
         {tabs && (

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import AboutPopOver from "@/components/AboutPopOver";
+import { AuthButton } from "@/features/Auth";
+import Image from "next/image";
+import type { ReactNode } from "react";
+
+interface AppHeaderProps {
+  tabs?: ReactNode;
+}
+
+export function AppHeader({ tabs }: AppHeaderProps) {
+  return (
+    <div className="pb-2 pt-2 border-b xl:container mx-auto px-4 flex items-center justify-between gap-4">
+      <div className="flex items-center gap-4">
+        <h1 className="text-xl md:text-2xl font-bold font-logo flex items-center gap-2 text-primary shrink-0">
+          <div className="relative w-8 h-8 md:w-9 md:h-9">
+            <Image
+              src="/granny-icon.png"
+              alt="Ask Ah Mah"
+              fill
+              className="object-contain"
+            />
+          </div>
+          Ask Ah Mah
+        </h1>
+
+        {tabs && (
+          <>
+            <div className="w-px h-[18px] bg-border shrink-0" />
+            {tabs}
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 shrink-0">
+        <AboutPopOver className="hidden lg:flex" />
+        <AuthButton />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "relative z-10 flex items-end gap-1 pt-5 px-4",
+        "relative z-10 flex items-baseline gap-5",
         className
       )}
       {...props}
@@ -35,6 +35,7 @@ function TabsList({
 }
 
 function TabsTrigger({
+  children,
   className,
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
@@ -42,16 +43,32 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "relative px-5 py-2.5 text-sm font-medium cursor-pointer transition-colors whitespace-nowrap -mb-px",
-        "text-ink-faint hover:text-foreground",
-        "border border-transparent rounded-t-xl",
+        "group relative font-display italic text-[15px] tracking-[-0.005em] font-medium cursor-pointer whitespace-nowrap pb-1.5",
+        "text-ink-faint hover:text-foreground transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         "disabled:pointer-events-none disabled:opacity-50",
-        "data-[state=active]:bg-chat data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:border-border data-[state=active]:border-b-chat",
+        "data-[state=active]:text-primary-ink data-[state=active]:font-semibold",
         className
       )}
       {...props}
-    />
+    >
+      {children}
+      {/* pen-squiggle underline — visible only when active */}
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 80 6"
+        preserveAspectRatio="none"
+        className="absolute left-0 right-0 -bottom-0.5 w-full h-[6px] text-primary opacity-0 group-data-[state=active]:opacity-80 transition-opacity"
+      >
+        <path
+          d="M2 4 Q20 0, 40 3 T78 3"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          fill="none"
+          strokeLinecap="round"
+        />
+      </svg>
+    </TabsPrimitive.Trigger>
   )
 }
 


### PR DESCRIPTION
## Summary

- Brand + hairline + *Chat / Pantry / Cookbook* (Fraunces italic) + auth now live in a single row, recovering ~44 px of vertical space on every screen
- Active tab is marked by a hand-drawn SVG pen-squiggle in terracotta — same pen-stroke vocabulary as recipe headers and loading states
- New `AppHeader` component accepts an optional `tabs` slot; used in both `/` (with tabs) and `/recipe/[id]` (brand-only), satisfying Radix's requirement that `TabsList` be a descendant of `Tabs.Root`
- Simplified `main` height calc in `page.tsx` — no external header band to subtract anymore

## Test plan

- [ ] Cold load `/` — header is one row: logo · hairline · Chat Pantry Cookbook · About · Sign in
- [ ] Switch tabs — pen squiggle moves to active label, no layout jank
- [ ] Open `/recipe/[id]` — same one-row header without tabs, no vertical jump
- [ ] Resize to mobile — header stays one row, About hides at `lg:`, auth visible
- [ ] Chat input and pantry/cookbook lists reach the viewport bottom with no overflow or gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a modular header component used across main pages and recipe details; header includes branding, tabs slot, and auth/about controls.

* **UI/Visual Updates**
  * Refined tab styling with italic typography and dynamic underline for active state.
  * Adjusted page layout and height/spacing rules; global top header removed in favor of per-page header.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->