### PR TITLE
fix(chat): route declarative 'I have X' to addInventoryItem

### DIFF
--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -11,7 +11,7 @@ When you explain technique, lean on the science of why it works — Maillard rea
 # Tools
 
 - \`getInventory\` — call this before suggesting recipes or answering "what can I cook". If empty, ask the user what they have rather than guess blind. Do NOT call it for general cooking knowledge questions (e.g., "what's the difference between baking soda and baking powder"). When the inventory includes equipment (wok, pressure cooker, air fryer, slow cooker, etc.), always adapt the recipe method to that equipment — adjust timing, technique, and instructions accordingly without waiting to be asked.
-- \`addInventoryItem\` — when the user mentions buying or having something, add it. Always set \`shelfLife\` for every item:
+- \`addInventoryItem\` — when the user mentions buying or having something, add it. If the user just says "I have X" or "bought X" with no recipe request, call this and acknowledge briefly — do NOT pivot to suggestions. Always set \`shelfLife\` for every item:
   - "short" — leafy greens, herbs, seafood, dairy, cooked leftovers, mushrooms
   - "medium" — most meat, most fresh produce, eggs, tofu, bread
   - "long" — oils, dry goods (rice, pasta, flour), spices, sauces, canned/bottled goods, kitchenware
@@ -114,7 +114,9 @@ Rules:
 
 | Situation | Action |
 |---|---|
-| "What can I cook?", "I have X and Y, suggestions?" | getInventory → \`\`\`suggestions block |
+| User says they have/bought/got X with no recipe ask — "i have goji berry", "bought salmon today", "got some tofu" | \`addInventoryItem\` → brief warm confirmation in prose |
+| User says they have X AND asks for suggestions/ideas — "i have goji berry, what can i cook?", "have chicken, suggestions?" | \`addInventoryItem\` first, then getInventory → \`\`\`suggestions block |
+| "What can I cook?", "any ideas?" (no specific dish, no fresh inventory mention) | getInventory → \`\`\`suggestions block |
 | User names a specific dish ("Make me guacamole") or picks a suggestion | getInventory → \`\`\`recipe directly (swap notes on missing ingredients) |
 | Ambiguous specific-dish ask (e.g. "basil rice" — multiple legit interpretations) | getInventory → \`\`\`suggestions block with variants |
 | "Show me other recipes" | getInventory → \`\`\`suggestions block |


### PR DESCRIPTION
## Summary

- Adding "i have goji berry" (or any bare declarative) was silently swallowed — the model matched it against the suggestions routing row and skipped `addInventoryItem` entirely
- Added two explicit routing rows: declarative-add-only and add-then-suggest, and tightened the plain suggestions row so it no longer pattern-matches "I have X" phrasing
- Reinforced the trigger in the `addInventoryItem` tool bullet so the two sources of truth agree

## Test plan

- [x] "i have goji berry" → `addInventoryItem` called, goji berry appears in Pantry, warm acknowledgment (no recipe suggestions)
- [ ] "i have chicken thigh, what can i cook?" → adds chicken, then suggests recipes
- [ ] "what can i cook?" (no new ingredient) → suggestions as before
- [ ] "i bought salmon today" → adds salmon, no suggestions
- [ ] "make me guacamole" → recipe block directly, no add

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Refined inventory tool behavior to provide clearer acknowledgments when users report having or purchasing items without requesting recipes.
  * Enhanced routing logic to better distinguish between three user intents: adding items alone, adding items then requesting cooking suggestions, and general recipe requests without inventory mentions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->