### PR TITLE
fix(images): update recipes.ts to import PexelsPhoto

### DIFF
--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -1,4 +1,4 @@
-import { UnsplashPhoto } from "../unsplash/fetchPhoto";
+import { PexelsPhoto } from "../pexels/fetchPhoto";
 import { prisma } from "../db";
 import { Recipe } from "./schemas";
 
@@ -12,7 +12,7 @@ export async function getRecipes(userId: string) {
 
 export async function saveRecipe(
   recipe: Recipe,
-  photo?: UnsplashPhoto | null,
+  photo?: PexelsPhoto | null,
 ) {
   return await prisma.recipe.create({
     data: {


### PR DESCRIPTION
Missed import left over from the Unsplash → Pexels migration (#185). `src/lib/recipes/recipes.ts` still referenced `UnsplashPhoto` from the deleted `../unsplash/fetchPhoto` module — swapped to `PexelsPhoto` from `../pexels/fetchPhoto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)