### PR TITLE
feat(chat): upright Fraunces body + prose typography + italic asides

### DIFF
--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -128,6 +128,6 @@ Rules:
 - If a recipe needs something the user doesn't have, suggest a realistic substitute or note it as something to grab next shop. Don't dwell on what's missing.
 - For "what can I cook" on an empty inventory, ask warmly what they have rather than recommending blind.
 - Keep responses tight and conversational — short sentences, not lectures. End with a small encouraging nudge or question when it fits.
-- Use *italic* (markdown `*phrase*`) for short warm personality beats — a granny aside, a knowing remark, a term of endearment. e.g. "*Aiya, that's the classic mistake lah.*" or "*You have vegetable oil — that one works perfectly.*" Keep italics to a phrase or one sentence, never a full paragraph.
+- Use *italic* (markdown \`*phrase*\`) for short warm personality beats — a granny aside, a knowing remark, a term of endearment. e.g. "*Aiya, that's the classic mistake lah.*" or "*You have vegetable oil — that one works perfectly.*" Keep italics to a phrase or one sentence, never a full paragraph.
 - **Never ask "do you have X?" in prose.** Check inventory with \`getInventory\` and handle it in the recipe output. If the dish name is ambiguous (e.g. "basil rice" could be Thai or Italian), emit a \`\`\`suggestions block with variants so the user can pick by clicking, not typing.
 `;

--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -128,5 +128,6 @@ Rules:
 - If a recipe needs something the user doesn't have, suggest a realistic substitute or note it as something to grab next shop. Don't dwell on what's missing.
 - For "what can I cook" on an empty inventory, ask warmly what they have rather than recommending blind.
 - Keep responses tight and conversational — short sentences, not lectures. End with a small encouraging nudge or question when it fits.
+- Use *italic* (markdown `*phrase*`) for short warm personality beats — a granny aside, a knowing remark, a term of endearment. e.g. "*Aiya, that's the classic mistake lah.*" or "*You have vegetable oil — that one works perfectly.*" Keep italics to a phrase or one sentence, never a full paragraph.
 - **Never ask "do you have X?" in prose.** Check inventory with \`getInventory\` and handle it in the recipe output. If the dish name is ambiguous (e.g. "basil rice" could be Thai or Italian), emit a \`\`\`suggestions block with variants so the user can pick by clicking, not typing.
 `;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ const fontDisplay = Fraunces({
   variable: "--font-var-display",
   subsets: ["latin"],
   weight: ["400", "600", "700"],
+  style: ["normal", "italic"],
 });
 
 const fontLogo = Nunito({

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -31,7 +31,7 @@ const messageContentVariants = cva(
         ],
         flat: [
           "group-[.is-user]:max-w-[80%] group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-2.5 group-[.is-user]:text-secondary-foreground group-[.is-user]:border group-[.is-user]:border-[oklch(0.78_0.10_88)] group-[.is-user]:rounded-tl-[14px] group-[.is-user]:rounded-tr-[14px] group-[.is-user]:rounded-br-[4px] group-[.is-user]:rounded-bl-[14px] group-[.is-user]:shadow-[0_1px_0_oklch(0.78_0.10_88)]",
-          "group-[.is-assistant]:text-foreground group-[.is-assistant]:font-display group-[.is-assistant]:italic",
+          "group-[.is-assistant]:text-foreground group-[.is-assistant]:font-display group-[.is-assistant]:text-[15px] group-[.is-assistant]:leading-relaxed",
         ],
       },
     },

--- a/src/components/ai-elements/response.tsx
+++ b/src/components/ai-elements/response.tsx
@@ -11,6 +11,13 @@ export const Response = memo(
     <Streamdown
       className={cn(
         "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        "max-w-[65ch]",
+        "[&_p+p]:mt-[0.65em]",
+        "[&_ul]:pl-5 [&_ul]:mt-2 [&_ul]:mb-1 [&_li]:mb-1",
+        "[&_ol]:pl-5 [&_ol]:mt-2 [&_ol]:mb-1",
+        "[&_em]:italic [&_em]:font-display",
+        "[&_strong]:font-semibold [&_strong]:not-italic",
+        "[&_code]:font-mono [&_code]:not-italic [&_code]:text-[13px] [&_code]:bg-card [&_code]:border [&_code]:border-border [&_code]:rounded [&_code]:px-1",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Readability audit found four issues; this PR addresses all of them:

- **Italic body → upright body**: assistant prose was `font-display italic text-sm` (italic Fraunces 14px). Now `font-display text-[15px] leading-relaxed` — upright, slightly larger, breathable. Italic Fraunces is reserved for short warm asides marked with `*phrase*` in markdown.
- **Max-width**: added `max-w-[65ch]` to the Streamdown prose wrapper. Assistant paragraphs no longer stretch the full chat column at wide viewports.
- **Prose hierarchy**: added paragraph spacing, list indent, and `code`/`strong` resets to the Streamdown className so markdown structure is legible.
- **True italic**: `layout.tsx` now loads `style: ["normal", "italic"]` for Fraunces so `<em>` renders real Fraunces italic, not synthesized oblique.
- **System prompt**: Ah Mah is instructed to use `*italic*` for short personality beats ("*Aiya, that's the classic mistake lah.*") — keeping the granny warmth through marked moments rather than whole-page italic.

## Test plan

- [ ] Open chat — assistant prose is upright Fraunces, 15px, comfortable line length
- [ ] Multi-paragraph technique explanation reads clearly at a wide window
- [ ] Bullet lists have visible indent and spacing
- [ ] Inline `code` renders in monospace (not italic serif)
- [ ] A response with `*phrase*` renders as italic Fraunces (not synthesized slant)
- [ ] User bubble unchanged — still butter background, same size
- [ ] Regression: suggestion cards and recipe letters unaffected (they don't use Streamdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced AI response formatting with italicized personality beats
  * Added italic font support to improve text styling options
  * Updated assistant message styling with improved typography and spacing
  * Added width constraints to response content for enhanced readability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->