### PR TITLE
feat(cookbook): paste recipe text to save as structured recipe

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -33,6 +33,8 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Pantry fills horizontally**: `max-w-[1200px]` dropped; CSS columns (masonry) replace the rigid grid so short categories don't leave dark gaps.
 - **CookingMode lifted to consumer**: cooking state lives in `RecipeList` (and chat) rather than inside `RecipeDisplay`. Cookbook closes the dialog before mounting `CookingMode` at the top level — Radix Dialog's `pointer-events: none` on siblings was killing the Next-step button when CookingMode rendered inside / portalled from the dialog.
 
+- **Paste-to-cookbook**: `+ Add recipe` button in cookbook header opens a two-step modal — paste raw recipe text, LLM extracts it into full `RecipeBlock` (structured steps, scalable amounts, prep, tags), preview via `RecipeDisplay`, then save. Failure guard rejects non-recipe text. Empty-state gets a secondary "or paste one you've found" CTA. Extraction via new `POST /api/recipe/extract` (no-persist preview endpoint); save uses existing structured `POST /api/recipe` path.
+
 ## V2 — In Progress
 
 ### Shopping list from shortfalls

--- a/src/app/api/recipe/extract/route.ts
+++ b/src/app/api/recipe/extract/route.ts
@@ -1,0 +1,29 @@
+import { parseRecipeText } from "@/lib/recipes/parseRecipeText";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { text } = body;
+
+  if (!text || typeof text !== "string" || !text.trim()) {
+    return NextResponse.json({ error: "text is required" }, { status: 400 });
+  }
+
+  try {
+    const block = await parseRecipeText(text.trim());
+
+    if (!block.ingredients.length || !block.steps.length) {
+      return NextResponse.json(
+        { error: "Hmm, couldn't find a recipe in that text. Try cleaning it up?" },
+        { status: 422 },
+      );
+    }
+
+    return NextResponse.json(block);
+  } catch {
+    return NextResponse.json(
+      { error: "Couldn't read that as a recipe. Try again?" },
+      { status: 422 },
+    );
+  }
+}

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -249,9 +249,10 @@ interface RecipeDisplayProps {
   recipe: RecipeWithId;
   onBack: () => void;
   onStartCooking?: () => void;
+  hideBackButton?: boolean;
 }
 
-export default function RecipeDisplay({ recipe, onBack, onStartCooking }: RecipeDisplayProps) {
+export default function RecipeDisplay({ recipe, onBack, onStartCooking, hideBackButton }: RecipeDisplayProps) {
   const [cooking, setCooking] = useState(false);
 
   const steps = (recipe.steps ?? []) as RecipeStep[];
@@ -281,13 +282,15 @@ export default function RecipeDisplay({ recipe, onBack, onStartCooking }: Recipe
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-3xl px-4 sm:px-6 pt-4 sm:pt-5 pb-8">
           <div className="flex items-center justify-between mb-3 sm:mb-4">
-            <button
-              onClick={onBack}
-              className="font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
-              aria-label="Back to cookbook"
-            >
-              ← Back to cookbook
-            </button>
+            {!hideBackButton && (
+              <button
+                onClick={onBack}
+                className="font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
+                aria-label="Back to cookbook"
+              >
+                ← Back to cookbook
+              </button>
+            )}
             {canCook && (
               <button
                 onClick={handleStartCooking}

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
 import RecipeCard from "./components/RecipeCard";
+import { AddRecipeModal } from "./components/AddRecipeModal";
 
 const HIDE_SCROLLBAR =
   "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden";
@@ -25,6 +26,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
   const [search, setSearch] = useState("");
   const [openRecipe, setOpenRecipe] = useState<RecipeWithId | null>(null);
   const [cookingRecipe, setCookingRecipe] = useState<RecipeWithId | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
 
   const { data: recipes, isLoading } = useSWR<RecipeWithId[]>(
     userId ? `/api/recipe?userId=${userId}` : null,
@@ -93,20 +95,31 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
                 })()}
           </p>
         </div>
-        {!isEmpty && (
-          <label className="flex items-center gap-2 px-3 py-[7px] bg-card border border-border rounded-full sm:min-w-[200px] w-full sm:w-auto text-muted-foreground cursor-text shrink-0">
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="shrink-0">
-              <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.4" />
-              <path d="m10.5 10.5 3 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+        <div className="flex items-center gap-2 w-full sm:w-auto shrink-0">
+          {!isEmpty && (
+            <label className="flex items-center gap-2 px-3 py-[7px] bg-card border border-border rounded-full sm:min-w-[200px] flex-1 sm:flex-none text-muted-foreground cursor-text">
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="shrink-0">
+                <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.4" />
+                <path d="m10.5 10.5 3 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+              </svg>
+              <input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search your cookbook…"
+                className="flex-1 bg-transparent border-none outline-none text-[13px] placeholder:text-muted-foreground text-foreground min-w-0"
+              />
+            </label>
+          )}
+          <button
+            onClick={() => setShowAdd(true)}
+            className="shrink-0 flex items-center gap-1.5 px-3 py-[7px] font-sans text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-full shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity cursor-pointer"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <path d="M6 1v10M1 6h10" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
             </svg>
-            <input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search your cookbook…"
-              className="flex-1 bg-transparent border-none outline-none text-[13px] placeholder:text-muted-foreground text-foreground min-w-0"
-            />
-          </label>
-        )}
+            Add recipe
+          </button>
+        </div>
       </div>
 
       {/* Tag chip rail — horizontal scroll on mobile, wraps at sm+ */}
@@ -170,6 +183,8 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
           </div>
         )}
       </div>
+
+      <AddRecipeModal open={showAdd} onOpenChange={setShowAdd} />
 
       <Dialog
         open={!!openRecipe && !cookingRecipe}

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -163,7 +163,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
             {[0, 1, 2].map((i) => <SkeletonCard key={i} />)}
           </div>
         ) : isEmpty ? (
-          <CookbookEmpty onChatClick={onChatClick} />
+          <CookbookEmpty onChatClick={onChatClick} onPasteClick={() => setShowAdd(true)} />
         ) : filtered.length === 0 ? (
           <p className="font-display italic text-[14px] text-muted-foreground">
             {activeTag
@@ -222,7 +222,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
   );
 }
 
-function CookbookEmpty({ onChatClick }: { onChatClick?: () => void }) {
+function CookbookEmpty({ onChatClick, onPasteClick }: { onChatClick?: () => void; onPasteClick?: () => void }) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[18px]">
       {/* Instructional card — spans 2 rows on desktop */}
@@ -240,12 +240,20 @@ function CookbookEmpty({ onChatClick }: { onChatClick?: () => void }) {
             When something&rsquo;s worth a second go, tap <em>Save</em>. Ah Mah keeps it tidy.
           </div>
         </div>
-        <button
-          onClick={onChatClick}
-          className="self-start px-3.5 py-2 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
-        >
-          Ask Ah Mah for a recipe →
-        </button>
+        <div className="flex flex-col gap-2">
+          <button
+            onClick={onChatClick}
+            className="self-start px-3.5 py-2 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
+          >
+            Ask Ah Mah for a recipe →
+          </button>
+          <button
+            onClick={onPasteClick}
+            className="self-start font-sans text-[12px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+          >
+            or paste one you&rsquo;ve found
+          </button>
+        </div>
       </div>
 
       {/* Ghost cards */}

--- a/src/features/RecipeList/components/AddRecipeModal.tsx
+++ b/src/features/RecipeList/components/AddRecipeModal.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import RecipeDisplay from "@/features/RecipeDisplay/RecipeDisplay";
+import { type RecipeBlock } from "@/lib/recipes/schemas";
+import { type RecipeWithId } from "@/lib/recipes/schemas";
+import { useSessionContext } from "@/contexts/SessionContext";
+import { VisuallyHidden } from "radix-ui";
+import { useState } from "react";
+import { toast } from "sonner";
+import { mutate } from "swr";
+
+interface AddRecipeModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function blockToPreviewRecipe(block: RecipeBlock): RecipeWithId {
+  return {
+    id: "preview",
+    userId: "",
+    name: block.title,
+    instructions: block.description ?? "",
+    description: block.description,
+    totalTimeMinutes: block.totalTimeMinutes,
+    baseServings: block.baseServings,
+    ingredients: block.ingredients.map((ing) => ({
+      name: ing.name,
+      category: ing.category ?? "Misc",
+      amount: ing.amount ? parseFloat(ing.amount) || undefined : undefined,
+      unit: ing.unit,
+      note: ing.note,
+    })),
+    prep: block.prep ?? [],
+    steps: block.steps,
+    tags: block.tags ?? [],
+    imageUrl: null,
+  };
+}
+
+export function AddRecipeModal({ open, onOpenChange }: AddRecipeModalProps) {
+  const { userId } = useSessionContext();
+  const [text, setText] = useState("");
+  const [step, setStep] = useState<"paste" | "preview">("paste");
+  const [preview, setPreview] = useState<RecipeBlock | null>(null);
+  const [extracting, setExtracting] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setText("");
+    setStep("paste");
+    setPreview(null);
+    setError(null);
+  };
+
+  const handleOpenChange = (o: boolean) => {
+    if (!o) reset();
+    onOpenChange(o);
+  };
+
+  const handleExtract = async () => {
+    setError(null);
+    setExtracting(true);
+    try {
+      const res = await fetch("/api/recipe/extract", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Something went wrong. Try again?");
+        return;
+      }
+      setPreview(data);
+      setStep("preview");
+    } catch {
+      setError("Couldn't connect. Check your network and try again.");
+    } finally {
+      setExtracting(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!preview || !userId) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/recipe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, recipe: preview }),
+      });
+      if (!res.ok) throw new Error("Save failed");
+      mutate(`/api/recipe?userId=${userId}`);
+      toast.success("Recipe saved to your cookbook");
+      handleOpenChange(false);
+    } catch {
+      toast.error("Failed to save recipe");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        showCloseButton={step === "paste"}
+        className="max-w-3xl w-[95vw] sm:w-[92vw] h-[92vh] p-0 overflow-hidden bg-background flex flex-col"
+      >
+        <VisuallyHidden.Root>
+          <DialogTitle>{step === "paste" ? "Add a recipe" : "Preview recipe"}</DialogTitle>
+        </VisuallyHidden.Root>
+
+        {step === "paste" ? (
+          <>
+            <div className="px-6 pt-6 pb-4 border-b border-border shrink-0">
+              <h2 className="font-display font-semibold text-[22px] text-foreground tracking-tight leading-tight">
+                Add a recipe
+              </h2>
+              <p className="font-display italic text-[13px] text-muted-foreground mt-1">
+                Paste recipe text you found — blog post, Reddit comment, anything.
+              </p>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-6 py-5 flex flex-col gap-3">
+              <textarea
+                value={text}
+                onChange={(e) => { setText(e.target.value); setError(null); }}
+                placeholder="Paste a recipe you found…"
+                className="w-full flex-1 min-h-[280px] resize-none rounded-lg border border-border bg-card px-4 py-3 font-sans text-[13.5px] text-foreground placeholder:text-muted-foreground leading-relaxed outline-none focus:ring-1 focus:ring-primary transition-shadow"
+              />
+              {error && (
+                <p className="font-sans text-[12.5px] text-destructive">{error}</p>
+              )}
+            </div>
+
+            <div className="px-6 py-4 border-t border-border shrink-0">
+              <button
+                onClick={handleExtract}
+                disabled={!text.trim() || extracting}
+                className="w-full py-3 font-sans text-sm font-semibold text-white bg-primary border border-[oklch(0.405_0.130_32)] rounded-xl shadow-[0_2px_0_oklch(0.405_0.130_32)] hover:bg-[oklch(0.50_0.130_32)] transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none"
+              >
+                {extracting ? "Extracting…" : "Extract →"}
+              </button>
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-col h-full overflow-hidden">
+            {/* Custom header overriding RecipeDisplay's internal back button */}
+            <div className="px-5 py-3 border-b border-border flex items-center justify-between shrink-0">
+              <button
+                onClick={() => setStep("paste")}
+                className="font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
+              >
+                ← Back to edit
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto">
+              {preview && (
+                <RecipeDisplay
+                  recipe={blockToPreviewRecipe(preview)}
+                  onBack={() => setStep("paste")}
+                  hideBackButton
+                />
+              )}
+            </div>
+
+            <div className="px-6 py-4 border-t border-border flex items-center gap-3 shrink-0">
+              <button
+                onClick={() => handleOpenChange(false)}
+                className="flex-1 py-3 font-sans text-sm font-semibold text-foreground bg-card border border-border rounded-xl shadow-[0_1px_0_var(--border-soft)] hover:bg-muted/50 transition-colors cursor-pointer"
+              >
+                Discard
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={saving}
+                className="flex-[2] py-3 font-sans text-sm font-semibold text-white bg-primary border border-[oklch(0.405_0.130_32)] rounded-xl shadow-[0_2px_0_oklch(0.405_0.130_32)] hover:bg-[oklch(0.50_0.130_32)] transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none"
+              >
+                {saving ? "Saving…" : "Save to cookbook"}
+              </button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/recipes/parseRecipeText.ts
+++ b/src/lib/recipes/parseRecipeText.ts
@@ -1,0 +1,45 @@
+import { openai } from "@ai-sdk/openai";
+import { generateObject } from "ai";
+import { RecipeBlockSchema, type RecipeBlock } from "./schemas";
+import { TAG_SETS } from "./tagColors";
+import { normalizeTags } from "./normalizeTags";
+
+const TAG_CATEGORIES = Object.entries(TAG_SETS)
+  .map(([cat, tags]) => `${cat.toUpperCase()}: ${tags.join(", ")}`)
+  .join("\n");
+
+export async function parseRecipeText(text: string): Promise<RecipeBlock> {
+  const result = await generateObject({
+    model: openai("gpt-4.1-mini"),
+    schema: RecipeBlockSchema,
+    temperature: 0.2,
+    prompt: `Extract the recipe from the text below into a structured format.
+
+FIELDS:
+- title: recipe name
+- description: one evocative sentence ≤140 chars capturing the soul of the dish (not a step list). e.g. "Sunday lunch staple — rice poached in chicken stock, finished with ginger-scallion oil."
+- baseServings: number of servings as written; infer 2–4 if unstated
+- totalTimeMinutes: total time in minutes if stated; omit if not mentioned
+- ingredients: array of { name, category, amount, unit, note }
+  - category must be one of: Protein, Carbs, Vegetable, Condiments, Spice, Misc
+  - amount is a string (e.g. "1 1/2", "200") — omit for "to taste" items
+  - unit is the unit string as written (e.g. "g", "tbsp", "cloves")
+- prep: array of short imperative strings for knife work and prep done BEFORE heat (e.g. "Dice 1 onion", "Mince 3 cloves garlic"). Empty array if no real prep.
+- steps: array of { title, body, tip? }
+  - title: short action phrase (e.g. "Sauté aromatics")
+  - body: the full step instruction
+  - tip: optional cook's note for this step
+- tags: 3–8 tags from the list below only; do not invent tags
+
+TAG CATEGORIES:
+${TAG_CATEGORIES}
+
+RECIPE TEXT:
+${text}`,
+  });
+
+  return {
+    ...result.object,
+    tags: normalizeTags(result.object.tags ?? []),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a **"+ Add recipe"** button to the cookbook header — always visible regardless of how many recipes you have
- **Two-step modal**: paste raw recipe text → LLM extracts it into a full `RecipeBlock` → preview via `RecipeDisplay` → save or discard
- Pasted recipes land as fully-structured first-class recipes: scalable amounts, prep, structured steps, tags, cooking mode — same shape as chat-generated ones
- **Failure guard**: if the model can't find ingredients or steps, the modal stays on the paste step with a friendly inline error — nothing gets saved to the cookbook
- **Empty-state CTA**: "or paste one you've found" secondary link added below "Ask Ah Mah" for discoverability when the cookbook is empty

## New files

- `src/lib/recipes/parseRecipeText.ts` — extractor using `generateObject` + `RecipeBlockSchema`
- `src/app/api/recipe/extract/route.ts` — `POST /api/recipe/extract` (preview-only, does not persist)
- `src/features/RecipeList/components/AddRecipeModal.tsx` — two-step paste/preview modal

## Closes

Closes #193
Closes #194

## Test plan

- [ ] `+ Add recipe` button visible in the cookbook header
- [ ] Paste a recipe (blog post, Reddit comment) → extract → preview shows title, ingredients with amounts, prep, steps, tags
- [ ] Save → recipe appears in cookbook grid, opens correctly, "Start cooking" works
- [ ] Back to edit → pasted text is preserved
- [ ] Discard → modal closes, nothing saved
- [ ] Non-recipe text → inline error, no save
- [ ] Empty textarea → "Extract" button disabled
- [ ] Empty cookbook → secondary CTA opens the same modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)