### PR TITLE
feat(recipe): normalize imperial units to metric on paste-import

### DIFF
--- a/src/lib/recipes/parseRecipeText.ts
+++ b/src/lib/recipes/parseRecipeText.ts
@@ -23,13 +23,56 @@ FIELDS:
 - ingredients: array of { name, category, amount, unit, note }
   - category must be one of: Protein, Carbs, Vegetable, Condiments, Spice, Misc
   - amount is a string (e.g. "1 1/2", "200") — omit for "to taste" items
-  - unit is the unit string as written (e.g. "g", "tbsp", "cloves")
+  - unit is the normalised unit string after applying the UNIT NORMALIZATION rules below
 - prep: array of short imperative strings for knife work and prep done BEFORE heat (e.g. "Dice 1 onion", "Mince 3 cloves garlic"). Empty array if no real prep.
 - steps: array of { title, body, tip? }
   - title: short action phrase (e.g. "Sauté aromatics")
-  - body: the full step instruction
+  - body: the full step instruction — apply UNIT NORMALIZATION to all measurements in body text
   - tip: optional cook's note for this step
 - tags: 3–8 tags from the list below only; do not invent tags
+
+UNIT NORMALIZATION:
+Convert all imperial measurements to metric house style. Apply to every ingredient and every step body.
+
+Weights — always convert to grams (g):
+  - 1 oz = 28 g  (round to nearest 5 g)
+  - 1 lb = 454 g (round to nearest 5 g)
+  Examples:
+    "8 ounces unsalted butter" → { amount: "225", unit: "g", name: "unsalted butter" }
+    "1 pound ground beef"      → { amount: "455", unit: "g", name: "ground beef" }
+
+Cups — convert to grams using these densities (1 cup values):
+  - all-purpose / bread / cake flour: 120 g
+  - granulated / white sugar: 200 g
+  - brown sugar (packed): 220 g
+  - butter: 227 g
+  - rolled oats: 90 g
+  - chocolate chips / chopped chocolate: 170 g
+  - water, milk, stock, oil, vinegar, other liquids: keep as ml (1 cup = 240 ml)
+  - unfamiliar or ambiguous ingredient: keep "cup" unit, add note with source value
+  Example:
+    "2 cups all-purpose flour" → { amount: "240", unit: "g", name: "all-purpose flour" }
+    "1/2 cup granulated sugar" → { amount: "100", unit: "g", name: "granulated sugar" }
+    "1 cup whole milk"         → { amount: "240", unit: "ml", name: "whole milk" }
+
+Volume abbreviations — always use abbreviated form:
+  - teaspoon / teaspoons → tsp
+  - tablespoon / tablespoons → tbsp
+  Example:
+    "2 teaspoons vanilla extract" → { amount: "2", unit: "tsp", name: "vanilla extract" }
+    "1 tablespoon soy sauce"      → { amount: "1", unit: "tbsp", name: "soy sauce" }
+
+Natural-count items — strip size adjectives from unit into note:
+  Example:
+    "2 large eggs" → { amount: "2", unit: "eggs", note: "large", name: "eggs" }
+
+Temperatures in step bodies — convert °F to °C (formula: (F−32)×5/9, round to nearest 5°C):
+  Examples:
+    "350°F" → "175°C"
+    "400°F" → "205°C"
+    "preheat to 375 degrees Fahrenheit" → "preheat to 190°C"
+
+Fallback — if you are not confident about a conversion, keep the source unit and add a brief note explaining the original value.
 
 TAG CATEGORIES:
 ${TAG_CATEGORIES}


### PR DESCRIPTION
## Summary

- Extends the `parseRecipeText` extractor prompt with a `UNIT NORMALIZATION` section
- oz/lb → g (rounded to nearest 5 g)
- Cups → g for common baking ingredients (flour 120 g, white sugar 200 g, brown sugar 220 g, butter 227 g, oats 90 g, chocolate chips 170 g); liquids stay as ml (240 ml/cup)
- teaspoon/tablespoon → tsp/tbsp
- °F → °C in step bodies
- Size adjectives on natural-count items (e.g. "large eggs") moved to `note`
- Fallback: keep source unit + note when density is ambiguous

Closes #196.

## Test plan

- [ ] With dev server running, paste a US recipe with ounces, cups, teaspoons, and a °F oven temp via Add recipe → all weights render in g, abbreviations are tsp/tbsp, temp is °C
- [ ] Paste a recipe with liquid cups (milk, water) → shows ml not g
- [ ] Paste a recipe with an unusual cup ingredient (e.g. dried coconut) → keeps cup unit with note
- [ ] Save and confirm recipe looks consistent next to a chat-generated recipe in the cookbook grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)