### PR TITLE
fix(cookbook): show all tags on recipe cards, truncate overflow

### DIFF
--- a/src/features/RecipeList/components/RecipeCard.tsx
+++ b/src/features/RecipeList/components/RecipeCard.tsx
@@ -86,7 +86,7 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
         )}
 
         {/* Footer */}
-        <div className="mt-auto pt-2.5 border-t border-dashed border-border flex items-center gap-2.5 flex-wrap">
+        <div className="mt-auto pt-2.5 border-t border-dashed border-border flex items-center gap-2.5 flex-nowrap overflow-hidden">
           {recipe.totalTimeMinutes && (
             <span className="flex items-center gap-1 font-mono text-[11px] text-ink-faint shrink-0">
               <svg width="11" height="11" viewBox="0 0 16 16" fill="none" className="shrink-0">
@@ -96,10 +96,10 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
               {formatDuration(recipe.totalTimeMinutes)}
             </span>
           )}
-          {recipe.tags?.slice(0, 3).map((tag) => (
+          {recipe.tags?.map((tag) => (
             <span
               key={tag}
-              className="text-[11px] font-medium px-2 py-0.5 border border-border rounded-full text-muted-foreground"
+              className="shrink-0 text-[11px] font-medium px-2 py-0.5 border border-border rounded-full text-muted-foreground"
             >
               {tag}
             </span>

--- a/src/features/RecipeList/components/RecipeCard.tsx
+++ b/src/features/RecipeList/components/RecipeCard.tsx
@@ -86,7 +86,10 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
         )}
 
         {/* Footer */}
-        <div className="mt-auto pt-2.5 border-t border-dashed border-border flex items-center gap-2.5 flex-nowrap overflow-hidden">
+        <div
+          className="mt-auto pt-2.5 border-t border-dashed border-border flex items-center gap-2.5 flex-nowrap overflow-hidden"
+          style={{ maskImage: "linear-gradient(to right, black calc(100% - 28px), transparent 100%)" }}
+        >
           {recipe.totalTimeMinutes && (
             <span className="flex items-center gap-1 font-mono text-[11px] text-ink-faint shrink-0">
               <svg width="11" height="11" viewBox="0 0 16 16" fill="none" className="shrink-0">

--- a/src/features/RecipeList/components/RecipeCard.tsx
+++ b/src/features/RecipeList/components/RecipeCard.tsx
@@ -99,9 +99,9 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
               {formatDuration(recipe.totalTimeMinutes)}
             </span>
           )}
-          {recipe.tags?.map((tag) => (
+          {recipe.tags?.map((tag, i) => (
             <span
-              key={tag}
+              key={`${tag}-${i}`}
               className="shrink-0 text-[11px] font-medium px-2 py-0.5 border border-border rounded-full text-muted-foreground"
             >
               {tag}


### PR DESCRIPTION
## Summary

- Removes the `slice(0, 3)` cap — all tags now render
- Switches the footer row from `flex-wrap` to `flex-nowrap overflow-hidden`
- Adds `shrink-0` to each tag pill so tags keep their natural width and clip cleanly at the card's right edge instead of wrapping to a second row
- Time badge is already `shrink-0` and always renders first, so it's never clipped

## Test plan

- [ ] Open Cookbook — cards with 4+ tags show all tags on a single line, with the rightmost tag clipped if it overflows
- [ ] Cards with 1–2 tags render normally
- [ ] Mobile: footer row clips cleanly, no horizontal scroll on the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted recipe card layout to prevent tag wrapping in narrow views.
  * All tags now display in recipe cards instead of being limited to a subset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->