### PR TITLE
feat(nav): filled icons + New Chat + conversations always visible

### DIFF
--- a/src/features/Conversations/Conversations.tsx
+++ b/src/features/Conversations/Conversations.tsx
@@ -43,7 +43,6 @@ export function Conversations({ onItemClick }: ConversationsProps) {
     conversations: allConversations,
     conversationsLoading: isLoading,
     setActiveConversation,
-    startNewConversation,
     renameConversation,
     deleteConversation,
   } = useConversationContext();
@@ -62,35 +61,14 @@ export function Conversations({ onItemClick }: ConversationsProps) {
     onItemClick?.();
   };
 
-  const activeConvIsEmpty = (() => {
-    const active = allConversations.find((c) => c.id === activeConversationId);
-    return (active?._count?.messages ?? 1) === 0;
-  })();
-
-  const handleNewConversation = () => {
-    if (activeConvIsEmpty) return;
-    startNewConversation();
-  };
-
   return (
     <div className="flex flex-col h-full gap-3">
       {/* Header */}
-      <div className="flex items-start justify-between gap-2">
-        <div>
-          <div className="font-display italic font-medium text-[22px] text-foreground leading-tight">
-            Conversations
-          </div>
-          <div className="text-xs text-ink-faint mt-0.5">Each kitchen session, kept</div>
+      <div>
+        <div className="font-display italic font-medium text-[22px] text-foreground leading-tight">
+          Conversations
         </div>
-        <button
-          onClick={handleNewConversation}
-          disabled={activeConvIsEmpty}
-          className="w-8 h-8 rounded-lg bg-primary text-white flex items-center justify-center text-lg font-medium shrink-0 hover:bg-primary/90 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-primary"
-          aria-label="New conversation"
-          title={activeConvIsEmpty ? "Already in a new conversation" : "Start a new conversation"}
-        >
-          +
-        </button>
+        <div className="text-xs text-ink-faint mt-0.5">Each kitchen session, kept</div>
       </div>
 
       {/* Search */}

--- a/src/features/shared/components/AppSidebar.tsx
+++ b/src/features/shared/components/AppSidebar.tsx
@@ -75,11 +75,15 @@ export function AppSidebar() {
     return (active?._count?.messages ?? 1) === 0;
   })();
 
-  const handleNavClick = (id: string) => {
-    if (id === "chat" && !activeConvIsEmpty) {
-      startNewConversation();
+  const handleNavClick = async (id: string) => {
+    try {
+      if (id === "chat" && !activeConvIsEmpty) {
+        await startNewConversation();
+      }
+      navigate(id);
+    } catch (error) {
+      console.error("Failed to start a new conversation", error);
     }
-    navigate(id);
   };
 
   return (

--- a/src/features/shared/components/AppSidebar.tsx
+++ b/src/features/shared/components/AppSidebar.tsx
@@ -3,11 +3,18 @@
 import AboutPopOver from "@/components/AboutPopOver";
 import { AuthButton } from "@/features/Auth";
 import { Conversations } from "@/features/Conversations/Conversations";
+import { useConversationContext } from "@/contexts/ConversationContext";
 import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 const ChatIcon = () => (
   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
+const ChatIconFilled = () => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
   </svg>
 );
@@ -20,6 +27,12 @@ const PantryIcon = () => (
   </svg>
 );
 
+const PantryIconFilled = () => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
+  </svg>
+);
+
 const CookbookIcon = () => (
   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
     <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
@@ -27,16 +40,23 @@ const CookbookIcon = () => (
   </svg>
 );
 
+const CookbookIconFilled = () => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
+  </svg>
+);
+
 const NAV_ITEMS = [
-  { id: "chat",     label: "Chat",     Icon: ChatIcon },
-  { id: "pantry",   label: "Pantry",   Icon: PantryIcon },
-  { id: "cookbook", label: "Cookbook", Icon: CookbookIcon },
+  { id: "chat",     label: "New Chat",  Icon: ChatIcon,     IconFilled: ChatIconFilled },
+  { id: "pantry",   label: "Pantry",    Icon: PantryIcon,   IconFilled: PantryIconFilled },
+  { id: "cookbook", label: "Cookbook",  Icon: CookbookIcon, IconFilled: CookbookIconFilled },
 ] as const;
 
 export function AppSidebar() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { activeConversationId, conversations, startNewConversation } = useConversationContext();
 
   const VALID_TABS = ["chat", "pantry", "cookbook"] as const;
   const raw = searchParams.get("tab");
@@ -50,7 +70,17 @@ export function AppSidebar() {
     router.replace(`/?tab=${tab}`, { scroll: false });
   };
 
-  const showConversations = pathname === "/" && activeTab === "chat";
+  const activeConvIsEmpty = (() => {
+    const active = conversations.find((c) => c.id === activeConversationId);
+    return (active?._count?.messages ?? 1) === 0;
+  })();
+
+  const handleNavClick = (id: string) => {
+    if (id === "chat" && !activeConvIsEmpty) {
+      startNewConversation();
+    }
+    navigate(id);
+  };
 
   return (
     <aside className="hidden lg:flex flex-col w-[240px] shrink-0 bg-muted paper border-r border-border h-dvh sticky top-0 overflow-hidden">
@@ -66,34 +96,30 @@ export function AppSidebar() {
 
       {/* Primary nav */}
       <nav className="px-2 pb-2 flex flex-col gap-0.5 shrink-0">
-        {NAV_ITEMS.map(({ id, label, Icon }) => {
+        {NAV_ITEMS.map(({ id, label, Icon, IconFilled }) => {
           const isActive = activeTab === id;
           return (
             <button
               key={id}
-              onClick={() => navigate(id)}
+              onClick={() => handleNavClick(id)}
               className={[
                 "flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-[13.5px] font-medium transition-colors text-left cursor-pointer",
                 isActive
-                  ? "bg-card text-foreground font-semibold"
+                  ? "bg-card text-primary font-semibold"
                   : "text-ink-faint hover:text-foreground hover:bg-card/70",
               ].join(" ")}
             >
-              <Icon />
+              {isActive ? <IconFilled /> : <Icon />}
               {label}
             </button>
           );
         })}
       </nav>
 
-      {/* Conversations list (chat only) */}
-      {showConversations ? (
-        <div className="flex-1 min-h-0 px-3 pt-3 flex flex-col overflow-hidden border-t border-border">
-          <Conversations />
-        </div>
-      ) : (
-        <div className="flex-1 border-t border-border" />
-      )}
+      {/* Conversations — always visible */}
+      <div className="flex-1 min-h-0 px-3 pt-3 flex flex-col overflow-hidden border-t border-border">
+        <Conversations onItemClick={() => navigate("chat")} />
+      </div>
 
       {/* Footer */}
       <div className="shrink-0 px-4 py-3 border-t border-border flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Active nav items show a filled icon + primary colour (previously just a background card)
- "Chat" renamed to "New Chat" — clicking always creates a new conversation and switches to the chat tab; guards against stacking empty sessions
- Conversations list now always visible in the sidebar regardless of active tab; clicking a conversation from Pantry/Cookbook auto-switches to chat
- Removed the `+` button from the Conversations header — superseded by New Chat

## Test plan

- [ ] Click New Chat while on Pantry/Cookbook — switches to chat tab with a fresh conversation
- [ ] Click New Chat while already on Chat — creates a new conversation
- [ ] Click New Chat again immediately (empty conversation) — no duplicate empty conversation created
- [ ] Click a conversation while on Pantry — switches to chat tab and opens that conversation
- [ ] Verify filled icon + primary colour appears on the active nav item; outline + muted on inactive items
- [ ] Verify Conversations list shows on all three tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Conversations section in sidebar is now permanently visible, improving accessibility across the app
  * Navigation icons updated with filled and outlined variants to clearly indicate the currently active tab
  * Conversations view header simplified for a cleaner interface
  * Conversation creation flow refined when navigating to the chat section from the sidebar

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->