### PR TITLE
feat(chat): deferred conversation creation + sidebar UX polish

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,57 @@
+# Context — Ask Ah Mah
+
+Glossary of canonical terms for this codebase.
+
+---
+
+## Conversation
+
+A thread that contains at least one **Message**. A `Conversation` row exists in the database only when a message has been sent. An "empty conversation" is not a Conversation — it is the **Staging State** of the chat.
+
+**Why this matters:** clicking "New Chat" does not create a DB row. The row is created server-side when the first message is sent.
+
+Related: [ADR-0002](docs/adr/0002-conversation-requires-at-least-one-message.md)
+
+---
+
+## Staging State
+
+The UI state where the user is on the Chat tab but has not yet sent a message. Indicated by `activeConversationId === null`. The greeting and suggestions are shown; no `Conversation` row exists yet.
+
+When the user sends the first message, the staging path in `useChatSession` creates the `Conversation` row via `POST /api/conversation`, then transitions to **Pending State**.
+
+---
+
+## Pending State
+
+The transient state between the first message being sent and the assistant stream completing. The conversation row exists in the DB, but is tracked via `pendingConversationId` in `ConversationContext` rather than `activeConversationId`. The sidebar entry appears optimistically during this window.
+
+When the stream finishes (`onFinish`), `commitConversation(id)` flips `pendingConversationId → activeConversationId`.
+
+---
+
+## Nav Selection
+
+"You are in this tab." Shown on the primary navigation items in `AppSidebar` (Chat / Pantry / Cookbook). Visual treatment: `bg-card` background, `text-foreground` label, terracotta (`text-primary`) filled icon.
+
+The Chat nav item is highlighted whenever the panel shows a new/empty chat experience: staging state (`activeConversationId === null`), or when the active conversation has no messages. Once a pending or committed conversation has messages, the Chat nav unhighlights and **Thread Selection** takes over.
+
+Related: [ADR-0003](docs/adr/0003-nav-and-thread-selection-are-distinct.md)
+
+---
+
+## Thread Selection
+
+"You are reading this conversation." Shown on conversation rows in the `Conversations` sidebar list. Visual treatment: **butter** (`oklch(0.86 0.10 88)`) background.
+
+Applies when `conv.id === activeConversationId || conv.id === pendingConversationId`.
+
+Related: [ADR-0001](docs/adr/0001-butter-is-where-you-are.md), [ADR-0003](docs/adr/0003-nav-and-thread-selection-are-distinct.md)
+
+---
+
+## Butter
+
+The visual token reserved for "you, here, now" — the thing the user is currently reading or acting on. Applied to the active conversation row and the user's own message bubbles. Never applied to navigation items (those use `bg-card`).
+
+See [ADR-0001](docs/adr/0001-butter-is-where-you-are.md) for the full rationale.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,7 +34,7 @@ When the stream finishes (`onFinish`), `commitConversation(id)` flips `pendingCo
 
 "You are in this tab." Shown on the primary navigation items in `AppSidebar` (Chat / Pantry / Cookbook). Visual treatment: `bg-card` background, `text-foreground` label, terracotta (`text-primary`) filled icon.
 
-The Chat nav item is highlighted whenever the panel shows a new/empty chat experience: staging state (`activeConversationId === null`), or when the active conversation has no messages. Once a pending or committed conversation has messages, the Chat nav unhighlights and **Thread Selection** takes over.
+The Chat nav item is highlighted only in **Staging State** (`activeConversationId === null && pendingConversationId === null`). Once a conversation becomes pending or committed, the Chat nav unhighlights and **Thread Selection** takes over.
 
 Related: [ADR-0003](docs/adr/0003-nav-and-thread-selection-are-distinct.md)
 

--- a/docs/adr/0002-conversation-requires-at-least-one-message.md
+++ b/docs/adr/0002-conversation-requires-at-least-one-message.md
@@ -1,0 +1,33 @@
+# ADR-0002 — A Conversation requires at least one Message
+
+**Status:** Accepted
+
+---
+
+## Context
+
+Previously, clicking "New Chat" immediately created an empty `Conversation` row via `POST /api/conversation`. This empty row appeared in the sidebar list under "Conversations" before the user had typed anything, polluting the list with placeholder entries and conflating "navigation intent" with "data creation."
+
+---
+
+## Decision
+
+A `Conversation` row is only created when the first message is sent. Clicking "New Chat" enters **Staging State** (`activeConversationId === null`) — a purely client-side condition, no DB write. The `POST /api/conversation` call happens inside `useChatSession.handleSendMessage` on the staging path, immediately before `sendMessage` is called.
+
+---
+
+## Consequences
+
+**Benefits:**
+- The conversations list only contains threads with real content.
+- Clicking "New Chat" repeatedly never accumulates empty rows.
+- The UI concept of "staging" maps cleanly to "no DB row yet."
+
+**Trade-offs:**
+- The first message path is slightly more complex: create conversation → optimistic list insert → save user message → start stream.
+- The `ChatWrapper` can no longer gate rendering on `activeConversationId !== null`; it must render the chat input in staging state.
+- `DELETE` of the last conversation must go to staging state rather than auto-creating a new empty row.
+
+**Alternatives considered:**
+- Deferred creation on stream start (not first message): rejected because we need the `conversationId` to exist before saving the user message.
+- Keeping eager creation but filtering the list: rejected because ghost rows in the DB create confusion for debugging and data audits.

--- a/docs/adr/0003-nav-and-thread-selection-are-distinct.md
+++ b/docs/adr/0003-nav-and-thread-selection-are-distinct.md
@@ -1,0 +1,45 @@
+# ADR-0003 — Nav Selection and Thread Selection are distinct concepts
+
+**Status:** Accepted
+
+---
+
+## Context
+
+The app has two "you are here" surfaces:
+
+1. The primary nav (Chat / Pantry / Cookbook) — indicates which app *mode* the user is in.
+2. The conversation list — indicates which *thread* the user is reading.
+
+Initially both used the same visual treatment (highlight + foreground text). This caused the Chat nav item to stay highlighted while a conversation was active, creating the appearance of two simultaneous selections.
+
+---
+
+## Decision
+
+Nav selection and Thread selection are **mutually exclusive**:
+
+- **Nav selection** uses `bg-card + text-foreground + filled icon (text-primary)`. Applied to a nav item only when no thread is selected.
+  - The Chat nav item is highlighted only in Staging State (`activeConversationId === null && pendingConversationId === null`).
+  - Pantry and Cookbook are highlighted whenever their tab is active (they have no "thread" concept).
+
+- **Thread selection** uses **butter** (`oklch(0.86 0.10 88)`). Applied to a conversation row when it is the active or pending conversation.
+
+While a conversation is active, the Chat nav item is *not* highlighted — the conversation row carries the "you are here" signal.
+
+---
+
+## Consequences
+
+**Benefits:**
+- A user looking at the sidebar understands their location from a single highlighted element, not two.
+- The visual grammar is consistent: butter = "what you're reading," bg-card = "what mode you're in."
+- New contributors cannot accidentally apply the butter pattern to nav items (ADR-0001 covers butter; this ADR covers nav).
+
+**Trade-offs:**
+- The Chat nav item being un-highlighted while a conversation is open may feel counterintuitive — the user is still "in Chat." Accepted: the conversation row is sufficient context.
+- Requires tracking `pendingConversationId` to correctly unhighlight Chat during the stream (before `commitConversation` fires).
+
+**Alternatives considered:**
+- Single unified selection surface: rejected because nav and thread live at different levels of hierarchy.
+- Highlight both simultaneously: rejected — tested in practice and caused visual confusion.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -36,6 +36,15 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 
 - **Paste-to-cookbook**: `+ Add recipe` button in cookbook header opens a two-step modal — paste raw recipe text, LLM extracts it into full `RecipeBlock` (structured steps, scalable amounts, prep, tags), preview via `RecipeDisplay`, then save. Failure guard rejects non-recipe text. Empty-state gets a secondary "or paste one you've found" CTA. Extraction via new `POST /api/recipe/extract` (no-persist preview endpoint); save uses existing structured `POST /api/recipe` path.
 
+- **Gemini-style sidebar**: replaced mobile tab bar with a persistent left sidebar on desktop (`AppSidebar`). Primary nav (Chat / Pantry / Cookbook) at top; `Conversations` list always visible below.
+
+- **Sidebar UX polish + deferred conversation creation** (May 2026):
+  - Nav selection (mode) and Thread selection (conversation row) are now distinct — see ADR-0003.
+  - Active nav text is `text-foreground`; only the icon gets the terracotta `text-primary` tint.
+  - "New Chat" nav item is only highlighted in Staging State (`activeConversationId === null`). Once a conversation is active, the nav item unhighlights and the conversation row highlights instead.
+  - `Conversation` rows are only created on first message, not on "New Chat" click — see ADR-0002. Clicking "New Chat" enters Staging State (client-only); the DB row is created in `useChatSession` when the first message is sent.
+  - Chat panel is full-width (removed `xl:container` cap); message content is capped at `max-w-3xl mx-auto`.
+
 ## V2 — In Progress
 
 ### Shopping list from shortfalls

--- a/src/app/api/conversation/route.ts
+++ b/src/app/api/conversation/route.ts
@@ -1,5 +1,4 @@
 import {
-  getOrCreateActiveConversation,
   getOrCreateEmptyConversation,
   listConversations,
 } from "@/lib/conversations";
@@ -9,12 +8,6 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET(req: NextRequest) {
   const userId = req.nextUrl.searchParams.get("userId");
   if (!userId) return missingUserId();
-
-  const active = req.nextUrl.searchParams.get("active");
-  if (active === "true") {
-    const conversation = await getOrCreateActiveConversation(userId);
-    return NextResponse.json({ conversation });
-  }
 
   const conversations = await listConversations(userId);
   return NextResponse.json({ conversations }); // flat array, ordered by updatedAt desc

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ function HomeContent() {
 
   return (
     <div className="bg-background h-full lg:h-full flex flex-col">
-      <main className="xl:container mx-auto h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] lg:flex-1 lg:min-h-0">
+      <main className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] lg:flex-1 lg:min-h-0">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col pt-2 lg:pt-0">
           {/* Tab strip — hidden on desktop (sidebar handles nav) */}
           <TabsList className="lg:hidden">

--- a/src/contexts/ConversationContext.tsx
+++ b/src/contexts/ConversationContext.tsx
@@ -6,7 +6,6 @@ import {
   createContext,
   ReactNode,
   useContext,
-  useEffect,
   useState,
 } from "react";
 import { toast } from "sonner";
@@ -20,12 +19,15 @@ type ConversationListResponse = {
 
 interface ConversationContextType {
   activeConversationId: string | null;
+  pendingConversationId: string | null;
   activeConversation: ConversationEntity | null;
   conversations: ConversationEntity[];
   conversationsLoading: boolean;
   isLoading: boolean;
   setActiveConversation: (id: string) => void;
-  startNewConversation: () => Promise<void>;
+  startNewConversation: () => void;
+  setPendingConversation: (conversation: ConversationEntity) => void;
+  commitConversation: (id: string) => void;
   renameConversation: (id: string, title: string) => Promise<void>;
   autoTitleActiveConversation: (title: string) => Promise<boolean>;
   deleteConversation: (id: string) => Promise<void>;
@@ -45,23 +47,9 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
     return localStorage.getItem(LOCAL_STORAGE_KEY);
   });
 
-  // Only fetch from API if we don't already have a stored conversation id
-  const shouldFetch = userId && !activeConversationId;
-  const swrKey = shouldFetch
-    ? `/api/conversation?active=true&userId=${userId}`
-    : null;
+  const [pendingConversationId, setPendingConversationId] = useState<string | null>(null);
 
-  const { data, isLoading } = useSWR<{ conversation: ConversationEntity }>(
-    swrKey,
-    async (url: string) => {
-      const res = await fetch(url);
-      if (!res.ok) throw new Error("Failed to fetch active conversation");
-      return res.json();
-    },
-    { revalidateOnFocus: false }
-  );
-
-  // Always fetch the conversations list so activeConversation reflects title updates
+  // Fetch the conversations list
   const listKey = userId ? `/api/conversation?userId=${userId}` : null;
 
   const { data: listData, isLoading: listLoading } = useSWR<ConversationListResponse>(
@@ -73,14 +61,6 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
     },
     { revalidateOnFocus: false }
   );
-
-  // When the API returns a conversation, store it
-  useEffect(() => {
-    if (data?.conversation?.id && !activeConversationId) {
-      setActiveConversationId(data.conversation.id);
-      localStorage.setItem(LOCAL_STORAGE_KEY, data.conversation.id);
-    }
-  }, [data, activeConversationId]);
 
   // Derive activeConversation from the list so title updates reflect immediately
   const activeConversation = activeConversationId
@@ -107,35 +87,33 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
         typeof key === "string" && key.includes("/api/conversation"),
     );
 
-  const startNewConversation = async (options?: { revalidate?: boolean }) => {
-    if (!userId) return;
-    const res = await fetch("/api/conversation", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userId }),
-    });
-    if (!res.ok) throw new Error("Failed to create conversation");
-    const { conversation } = await res.json();
-    setActiveConversation(conversation.id);
+  // Clear active conversation and enter staging state — no API call
+  const startNewConversation = () => {
+    persistActiveConversation(null);
+    setPendingConversationId(null);
+  };
+
+  // Called when the first message is sent: optimistically add to list, track pending id
+  const setPendingConversation = (conversation: ConversationEntity) => {
+    setPendingConversationId(conversation.id);
     if (listKey) {
-      await globalMutate(
+      globalMutate(
         listKey,
         (current?: ConversationListResponse) => {
           const existing = current?.conversations ?? [];
-          const withoutConversation = existing.filter(
-            (item) => item.id !== conversation.id
-          );
-
-          return {
-            conversations: [conversation, ...withoutConversation],
-          };
+          const without = existing.filter(c => c.id !== conversation.id);
+          return { conversations: [conversation, ...without] };
         },
         false
       );
     }
-    if (options?.revalidate !== false) {
-      await revalidateConversationKeys();
-    }
+  };
+
+  // Called in onFinish after stream completes: commit the pending conversation as active
+  const commitConversation = (id: string) => {
+    persistActiveConversation(id);
+    setPendingConversationId(null);
+    revalidateConversationKeys();
   };
 
   const renameConversation = async (id: string, title: string) => {
@@ -181,16 +159,11 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
     );
 
     if (id === activeConversationId) {
-      // Active conversation delete — same flow as before
       const previousActiveConversationId = activeConversationId;
       const nextConversation =
         optimisticConversations.find(
           (c) => (c._count?.messages ?? 0) > 0
-        ) ??
-        optimisticConversations.find(
-          (c) => c.title === null && (c._count?.messages ?? 0) === 0
-        ) ??
-        null;
+        ) ?? null;
 
       if (listKey) {
         await globalMutate(
@@ -203,8 +176,8 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
       if (nextConversation) {
         persistActiveConversation(nextConversation.id);
       } else {
+        // No next conversation — go to staging state
         persistActiveConversation(null);
-        await startNewConversation({ revalidate: false });
       }
 
       try {
@@ -263,19 +236,19 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
     }
   };
 
-  const contextIsLoading =
-    isLoading || (!!userId && !activeConversationId && !data);
-
   return (
     <ConversationContext.Provider
       value={{
         activeConversationId,
+        pendingConversationId,
         activeConversation,
         conversations: listData?.conversations ?? [],
         conversationsLoading: listLoading,
-        isLoading: contextIsLoading,
+        isLoading: false,
         setActiveConversation,
         startNewConversation,
+        setPendingConversation,
+        commitConversation,
         renameConversation,
         autoTitleActiveConversation,
         deleteConversation,

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -56,7 +56,6 @@ const Chat = () => {
 
   return (
     <div
-      key={activeConversationId}
       className="flex flex-col animate-in fade-in duration-300 h-full"
     >
       {/* Mobile bar — hidden when persistent rail is present */}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -16,7 +16,6 @@ const Chat = () => {
     allMessages,
     status,
     submittedAt,
-    messagesLoading,
     handleSendMessage,
     handleRecipeDetected,
   } = useChatSession();
@@ -45,7 +44,7 @@ const Chat = () => {
     mobileCommittingRef.current = false;
   };
 
-  if (messagesLoading || !userId || !activeConversationId) {
+  if (!userId) {
     return (
       <div className="flex h-[600px] items-center justify-center">
         <div className="animate-pulse">

--- a/src/features/Chat/components/ChatWrapper.tsx
+++ b/src/features/Chat/components/ChatWrapper.tsx
@@ -6,11 +6,10 @@ import { LOADING_MESSAGES } from "../constants";
 
 export default function ChatWrapper() {
   const { userId, isLoading: sessionLoading } = useSessionContext();
-  const { activeConversationId, isLoading: convLoading } =
+  const { activeConversationId } =
     useConversationContext();
 
-  const isLoading =
-    sessionLoading || convLoading || !userId || !activeConversationId;
+  const isLoading = sessionLoading || !userId;
 
   return (
     <>
@@ -25,7 +24,7 @@ export default function ChatWrapper() {
           </div>
         </div>
       ) : (
-        <Chat />
+        <Chat key={activeConversationId ?? "staging"} />
       )}
     </>
   );

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -240,7 +240,7 @@ export const MessageList = ({
       <ConversationContent>
         <div
           ref={containerRef}
-          className="space-y-4 overscroll-contain"
+          className="space-y-4 overscroll-contain max-w-3xl mx-auto w-full"
           onScroll={handleScroll}
           data-conversation-content
         >

--- a/src/features/Chat/hooks/useChatSession.ts
+++ b/src/features/Chat/hooks/useChatSession.ts
@@ -19,19 +19,48 @@ import { convertToUIMessage } from "../utils";
 
 export function useChatSession() {
   const { userId } = useSessionContext();
-  const { activeConversationId, autoTitleActiveConversation } =
-    useConversationContext();
+  const {
+    activeConversationId,
+    setPendingConversation,
+    commitConversation,
+    autoTitleActiveConversation,
+  } = useConversationContext();
 
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
   const autoTitledConversations = useRef<Set<string>>(new Set());
   const autoTitlingConversations = useRef<Set<string>>(new Set());
 
-  const { messages, sendMessage, status } = useChat({
-    id: activeConversationId ?? undefined,
-    transport: new DefaultChatTransport({
+  // Tracks the conversation id to inject at request time (may be null in staging).
+  // Synced via effect (not during render) so an explicit set in handleSendMessage
+  // isn't overwritten by a re-render triggered by setPendingConversation.
+  const convIdRef = useRef<string | null>(activeConversationId);
+  useEffect(() => {
+    convIdRef.current = activeConversationId;
+  }, [activeConversationId]);
+
+  // Holds the pending conversation id during the first-message stream
+  const pendingConvIdRef = useRef<string | null>(null);
+
+  // Stable transport that reads convIdRef at send time via prepareSendMessagesRequest.
+  // prepareSendMessagesRequest returns the COMPLETE body (not merged), so messages
+  // must be explicitly included alongside our dynamic fields.
+  const transport = useRef(
+    new DefaultChatTransport({
       api: "/api/chat",
-      body: { userId, conversationId: activeConversationId },
-    }),
+      prepareSendMessagesRequest: ({ messages, body }) => ({
+        body: {
+          messages,
+          ...body,
+          userId,
+          conversationId: convIdRef.current,
+        },
+      }),
+    })
+  ).current;
+
+  const { messages, sendMessage, status } = useChat({
+    id: activeConversationId ?? "staging",
+    transport,
     onError: (error) => {
       console.error("Chat error:", error);
       if (error.message.includes("503")) {
@@ -44,13 +73,14 @@ export function useChatSession() {
     },
     onFinish: async (options) => {
       const { message } = options;
+      const convId = convIdRef.current;
 
       if (message.role === "assistant") {
         const content = message.parts
           .filter((part) => part.type === "text")
           .map((part) => part.text)
           .join("");
-        if (content) await saveMessage("assistant", content);
+        if (content && convId) await saveMessage("assistant", content, convId);
       }
 
       message.parts.forEach((part) => {
@@ -81,6 +111,13 @@ export function useChatSession() {
           }
         }
       });
+
+      // Commit pending conversation after stream completes
+      const pendingId = pendingConvIdRef.current;
+      if (pendingId) {
+        pendingConvIdRef.current = null;
+        commitConversation(pendingId);
+      }
     },
   });
 
@@ -92,19 +129,25 @@ export function useChatSession() {
     { shouldRetryOnError: true, revalidateOnMount: true }
   );
 
-  const saveMessage = async (role: "user" | "assistant", content: string) => {
+  const saveMessage = async (
+    role: "user" | "assistant",
+    content: string,
+    convId?: string | null
+  ) => {
+    const targetConvId = convId ?? convIdRef.current;
+    if (!targetConvId) return;
     try {
       await fetch("/api/message", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           userId,
-          conversationId: activeConversationId,
+          conversationId: targetConvId,
           role,
           content,
         }),
       });
-      mutate(`/api/message?conversationId=${activeConversationId}`);
+      mutate(`/api/message?conversationId=${targetConvId}`);
     } catch (error) {
       console.error("Failed to save message:", error);
     }
@@ -149,7 +192,33 @@ export function useChatSession() {
 
   const handleSendMessage = async (message: string) => {
     setSubmittedAt(Date.now());
-    await saveMessage("user", message);
+
+    if (!activeConversationId) {
+      // Staging path: create conversation before sending
+      const res = await fetch("/api/conversation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId }),
+      });
+      if (!res.ok) {
+        toast.error("Aiyah, could not start a new conversation. Try again!");
+        return;
+      }
+      const { conversation } = await res.json();
+
+      // Update ref so transport injects the right id
+      convIdRef.current = conversation.id;
+      pendingConvIdRef.current = conversation.id;
+
+      // Optimistically show in sidebar with pending state
+      setPendingConversation(conversation);
+
+      // Save user message under the new conversation id
+      await saveMessage("user", message, conversation.id);
+    } else {
+      await saveMessage("user", message);
+    }
+
     sendMessage({ text: message });
   };
 

--- a/src/features/Chat/hooks/useChatSession.ts
+++ b/src/features/Chat/hooks/useChatSession.ts
@@ -41,7 +41,11 @@ export function useChatSession() {
   // Holds the pending conversation id during the first-message stream
   const pendingConvIdRef = useRef<string | null>(null);
 
-  // Stable transport that reads convIdRef at send time via prepareSendMessagesRequest.
+  // Snapshot of the conversation id at send time — used in onFinish and transport
+  // so mid-stream navigation cannot redirect messages to a different conversation.
+  const inFlightConvIdRef = useRef<string | null>(null);
+
+  // Stable transport that reads inFlightConvIdRef at send time via prepareSendMessagesRequest.
   // prepareSendMessagesRequest returns the COMPLETE body (not merged), so messages
   // must be explicitly included alongside our dynamic fields.
   const transport = useRef(
@@ -52,7 +56,7 @@ export function useChatSession() {
           messages,
           ...body,
           userId,
-          conversationId: convIdRef.current,
+          conversationId: inFlightConvIdRef.current,
         },
       }),
     })
@@ -73,7 +77,7 @@ export function useChatSession() {
     },
     onFinish: async (options) => {
       const { message } = options;
-      const convId = convIdRef.current;
+      const convId = inFlightConvIdRef.current;
 
       if (message.role === "assistant") {
         const content = message.parts
@@ -137,7 +141,7 @@ export function useChatSession() {
     const targetConvId = convId ?? convIdRef.current;
     if (!targetConvId) return;
     try {
-      await fetch("/api/message", {
+      const response = await fetch("/api/message", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -147,9 +151,14 @@ export function useChatSession() {
           content,
         }),
       });
+      if (!response.ok)
+        throw new Error(
+          `Save failed: ${response.status} (conversationId: ${targetConvId})`
+        );
       mutate(`/api/message?conversationId=${targetConvId}`);
     } catch (error) {
       console.error("Failed to save message:", error);
+      throw error;
     }
   };
 
@@ -206,9 +215,10 @@ export function useChatSession() {
       }
       const { conversation } = await res.json();
 
-      // Update ref so transport injects the right id
+      // Update refs so transport injects the right id
       convIdRef.current = conversation.id;
       pendingConvIdRef.current = conversation.id;
+      inFlightConvIdRef.current = conversation.id;
 
       // Optimistically show in sidebar with pending state
       setPendingConversation(conversation);
@@ -216,6 +226,7 @@ export function useChatSession() {
       // Save user message under the new conversation id
       await saveMessage("user", message, conversation.id);
     } else {
+      inFlightConvIdRef.current = activeConversationId;
       await saveMessage("user", message);
     }
 

--- a/src/features/Conversations/Conversations.tsx
+++ b/src/features/Conversations/Conversations.tsx
@@ -40,6 +40,7 @@ function groupConversations(conversations: ConversationEntity[]) {
 export function Conversations({ onItemClick }: ConversationsProps) {
   const {
     activeConversationId,
+    pendingConversationId,
     conversations: allConversations,
     conversationsLoading: isLoading,
     setActiveConversation,
@@ -48,11 +49,16 @@ export function Conversations({ onItemClick }: ConversationsProps) {
   } = useConversationContext();
   const [search, setSearch] = useState("");
 
+  // Only show conversations that have at least one message
+  const committedConversations = allConversations.filter(
+    (c) => (c._count?.messages ?? 0) > 0 || c.id === pendingConversationId
+  );
+
   const filtered = search.trim()
-    ? allConversations.filter((c) =>
+    ? committedConversations.filter((c) =>
         (c.title ?? "New chat").toLowerCase().includes(search.toLowerCase())
       )
-    : allConversations;
+    : committedConversations;
 
   const groups = groupConversations(filtered);
 
@@ -112,7 +118,7 @@ export function Conversations({ onItemClick }: ConversationsProps) {
                     <ConversationItem
                       key={conv.id}
                       conversation={conv}
-                      isActive={conv.id === activeConversationId}
+                      isActive={conv.id === activeConversationId || conv.id === pendingConversationId}
                       onClick={() => handleItemClick(conv.id)}
                       onRename={(newTitle) => renameConversation(conv.id, newTitle)}
                       onDelete={() => deleteConversation(conv.id)}

--- a/src/features/shared/components/AppSidebar.tsx
+++ b/src/features/shared/components/AppSidebar.tsx
@@ -56,7 +56,7 @@ export function AppSidebar() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const { activeConversationId, conversations, startNewConversation } = useConversationContext();
+  const { activeConversationId, pendingConversationId, conversations, startNewConversation } = useConversationContext();
 
   const VALID_TABS = ["chat", "pantry", "cookbook"] as const;
   const raw = searchParams.get("tab");
@@ -70,21 +70,20 @@ export function AppSidebar() {
     router.replace(`/?tab=${tab}`, { scroll: false });
   };
 
-  const activeConvIsEmpty = (() => {
-    const active = conversations.find((c) => c.id === activeConversationId);
-    return (active?._count?.messages ?? 1) === 0;
-  })();
-
-  const handleNavClick = async (id: string) => {
-    try {
-      if (id === "chat" && !activeConvIsEmpty) {
-        await startNewConversation();
-      }
-      navigate(id);
-    } catch (error) {
-      console.error("Failed to start a new conversation", error);
+  const handleNavClick = (id: string) => {
+    if (id === "chat") {
+      startNewConversation();
     }
+    navigate(id);
   };
+
+  // "New Chat" nav is highlighted whenever the panel shows an empty/new chat experience:
+  // staging (no active id), OR active id points to a conversation with no messages yet.
+  const activeConvHasMessages = activeConversationId
+    ? (conversations.find(c => c.id === activeConversationId)?._count?.messages ?? 0) > 0
+    : false;
+  const isNewChatActive =
+    activeTab === "chat" && !activeConvHasMessages && pendingConversationId === null;
 
   return (
     <aside className="hidden lg:flex flex-col w-[240px] shrink-0 bg-muted paper border-r border-border h-dvh sticky top-0 overflow-hidden">
@@ -101,7 +100,7 @@ export function AppSidebar() {
       {/* Primary nav */}
       <nav className="px-2 pb-2 flex flex-col gap-0.5 shrink-0">
         {NAV_ITEMS.map(({ id, label, Icon, IconFilled }) => {
-          const isActive = activeTab === id;
+          const isActive = id === "chat" ? isNewChatActive : activeTab === id;
           return (
             <button
               key={id}
@@ -109,11 +108,13 @@ export function AppSidebar() {
               className={[
                 "flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-[13.5px] font-medium transition-colors text-left cursor-pointer",
                 isActive
-                  ? "bg-card text-primary font-semibold"
+                  ? "bg-card text-foreground font-semibold"
                   : "text-ink-faint hover:text-foreground hover:bg-card/70",
               ].join(" ")}
             >
-              {isActive ? <IconFilled /> : <Icon />}
+              <span className={isActive ? "text-primary" : ""}>
+                {isActive ? <IconFilled /> : <Icon />}
+              </span>
               {label}
             </button>
           );


### PR DESCRIPTION
## Summary

- **Deferred conversation creation** — clicking "New Chat" no longer creates a DB row. The `Conversation` is created on the first message send. Until then, the app is in *staging state* (`activeConversationId === null`). See ADR-0002.
- **Nav vs thread selection** — "New Chat" nav is highlighted only while the panel shows an empty/new chat experience (staging, or active conv has no messages). Once a conversation has messages, the nav unhighlights and the conversation row highlights instead. See ADR-0003.
- **Active nav text fix** — active nav label uses `text-foreground`; only the icon gets `text-primary` (terracotta) tint.
- **Full-width chat panel** — removed `xl:container` cap from the main wrapper; message content is capped at `max-w-3xl mx-auto` instead.
- **Pending state** — first message send optimistically inserts the conversation row in the sidebar; `commitConversation()` flips it to active after `onFinish`.
- **Docs** — added `CONTEXT.md` (glossary), ADR-0002, ADR-0003, updated `progress.md`.

## Test plan

- [ ] Fresh visit (no localStorage): "New Chat" nav highlighted, no conversation rows, chat input ready
- [ ] Send first message: conversation appears in sidebar mid-stream, "New Chat" nav unhighlights, row highlights
- [ ] After stream: hard refresh — conversation still active and in list
- [ ] Delete last conversation: returns to staging state, "New Chat" nav highlights again
- [ ] Clicking "New Chat" repeatedly: no rows accumulate in DB
- [ ] Existing conversation active: "New Chat" nav not highlighted, conversation row highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent left sidebar with navigation and continuous conversations list
  * Distinct visual grammar for nav selection vs. conversation/thread selection
  * Staged "New Chat" flow showing a pending conversation while composing the first message

* **Changes**
  * Conversations are created only when the first message is sent; pending conversations appear selected during streaming
  * Conversation list filters to show only conversations with messages (pending conversation still shown)
  * Adjusted chat layout and message width for improved readability

* **Documentation**
  * Added glossary, interaction-state definitions, and ADRs describing these behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->