### PR TITLE
fix(nav): improve sidebar button contrast and icon visibility

### DIFF
--- a/src/features/shared/components/AppSidebar.tsx
+++ b/src/features/shared/components/AppSidebar.tsx
@@ -8,7 +8,7 @@ import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 const ChatIcon = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
   </svg>
 );
@@ -20,7 +20,7 @@ const ChatIconFilled = () => (
 );
 
 const PantryIcon = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
     <line x1="3" y1="6" x2="21" y2="6" />
     <path d="M16 10a4 4 0 01-8 0" />
@@ -34,7 +34,7 @@ const PantryIconFilled = () => (
 );
 
 const CookbookIcon = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
     <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
   </svg>
@@ -109,7 +109,7 @@ export function AppSidebar() {
                 "flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-[13.5px] font-medium transition-colors text-left cursor-pointer",
                 isActive
                   ? "bg-card text-foreground font-semibold"
-                  : "text-ink-faint hover:text-foreground hover:bg-card/70",
+                  : "text-muted-foreground hover:text-foreground hover:bg-card/70",
               ].join(" ")}
             >
               <span className={isActive ? "text-primary" : ""}>


### PR DESCRIPTION
## Summary
- Raise inactive nav text from `text-ink-faint` (L=0.605) to `text-muted-foreground` (L=0.46) — much more legible
- Bump outline icon stroke weight from 1.7 to 2 for better visibility
- Fixes: inactive nav items no longer read as disabled; clear active/inactive hierarchy

## Test plan
- Sidebar nav at all tab states (Pantry, Cookbook, New Chat active)
- Verify unselected buttons are clearly clickable-looking and not ghosted

🤖 Generated with [Claude Code](https://claude.com/claude-code)