### PR TITLE
fix(chat): restore contained layout with capped message width

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -43,7 +43,7 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
   - Active nav text is `text-foreground`; only the icon gets the terracotta `text-primary` tint.
   - "New Chat" nav item is only highlighted in Staging State (`activeConversationId === null`). Once a conversation is active, the nav item unhighlights and the conversation row highlights instead.
   - `Conversation` rows are only created on first message, not on "New Chat" click — see ADR-0002. Clicking "New Chat" enters Staging State (client-only); the DB row is created in `useChatSession` when the first message is sent.
-  - Chat panel is bounded by `xl:container` (~1280px, centered); messages fill that width.
+  - Chat panel is full-width (removed `xl:container` cap); message content is capped at `max-w-3xl mx-auto`.
 
 ## V2 — In Progress
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -43,7 +43,7 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
   - Active nav text is `text-foreground`; only the icon gets the terracotta `text-primary` tint.
   - "New Chat" nav item is only highlighted in Staging State (`activeConversationId === null`). Once a conversation is active, the nav item unhighlights and the conversation row highlights instead.
   - `Conversation` rows are only created on first message, not on "New Chat" click — see ADR-0002. Clicking "New Chat" enters Staging State (client-only); the DB row is created in `useChatSession` when the first message is sent.
-  - Chat panel is full-width (removed `xl:container` cap); message content is capped at `max-w-3xl mx-auto`.
+  - Chat panel uses `xl:container mx-auto` for side gutters at xl+ screens; message content is capped at `max-w-5xl mx-auto`.
 
 ## V2 — In Progress
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ function HomeContent() {
 
   return (
     <div className="bg-background h-full lg:h-full flex flex-col">
-      <main className="h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] lg:flex-1 lg:min-h-0">
+      <main className="xl:container mx-auto h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] lg:flex-1 lg:min-h-0">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col pt-2 lg:pt-0">
           {/* Tab strip — hidden on desktop (sidebar handles nav) */}
           <TabsList className="lg:hidden">

--- a/src/features/Chat/components/MessageInput.tsx
+++ b/src/features/Chat/components/MessageInput.tsx
@@ -24,7 +24,7 @@ export const MessageInput = ({
       }}
       className="p-4"
     >
-      <div className="flex gap-1 items-center bg-muted/50 rounded-xl border border-border/60 px-3 py-1">
+      <div className="flex gap-1 items-center bg-muted/50 rounded-xl border border-border/60 px-3 py-1 max-w-5xl mx-auto">
         <Input
           value={input}
           onChange={(e) => setInput(e.target.value)}

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -4,10 +4,7 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
-import {
-  Message,
-  MessageContent,
-} from "@/components/ai-elements/message";
+import { Message, MessageContent } from "@/components/ai-elements/message";
 import { Response } from "@/components/ai-elements/response";
 import { Button } from "@/components/ui/button";
 import {
@@ -240,7 +237,7 @@ export const MessageList = ({
       <ConversationContent>
         <div
           ref={containerRef}
-          className="space-y-4 overscroll-contain max-w-3xl mx-auto w-full"
+          className="space-y-4 overscroll-contain max-w-5xl mx-auto w-full"
           onScroll={handleScroll}
           data-conversation-content
         >


### PR DESCRIPTION
## Summary
- Restore `xl:container mx-auto` on `<main>` so the full layout (sidebar + chat) caps at 1280px with `bg-background` side gutters at xl+ screens
- Cap message list and input bar at `max-w-5xl` for a comfortable reading width
- Reverts the full-width change from #211

## Test plan
- View chat at wide viewport (≥1280px) — should see side gutters and contained column
- Verify input bar and messages are constrained, not edge-to-edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined chat interface layout with full-width chat panel and centered content alignment
  * Added responsive height adjustments for improved visual presentation across screen sizes

* **Documentation**
  * Updated documentation reflecting UI layout improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->