### PR TITLE
feat(recipe): Recipe Tweak — AI-powered in-place recipe refinement

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,3 +55,13 @@ Related: [ADR-0001](docs/adr/0001-butter-is-where-you-are.md), [ADR-0003](docs/a
 The visual token reserved for "you, here, now" — the thing the user is currently reading or acting on. Applied to the active conversation row and the user's own message bubbles. Never applied to navigation items (those use `bg-card`).
 
 See [ADR-0001](docs/adr/0001-butter-is-where-you-are.md) for the full rationale.
+
+---
+
+## Recipe Tweak
+
+A single-turn AI modification of an existing saved recipe, initiated from the recipe page. The user types a refinement instruction (e.g. "add green chilli") and the AI streams an updated version of the same recipe in-place. A Recipe Tweak is not a full recipe prompt — it cannot generate a new, unrelated dish.
+
+The tweaked version is shown as a preview before the user confirms. On confirmation, the existing recipe is replaced (not duplicated). The AI call goes through a dedicated route (`POST /api/recipe/[id]/tweak`), separate from the chat pipeline.
+
+Related: [ADR-0004](docs/adr/0004-recipe-tweak-uses-dedicated-route.md)

--- a/docs/adr/0004-recipe-tweak-uses-dedicated-route.md
+++ b/docs/adr/0004-recipe-tweak-uses-dedicated-route.md
@@ -1,0 +1,25 @@
+# ADR-0004 — Recipe Tweak uses a dedicated API route
+
+**Status:** Accepted
+
+## Context
+
+The Recipe Tweak feature lets users refine a saved recipe via a short AI instruction (e.g. "add green chilli"). We needed to decide where the AI call should go: reuse the existing `/api/chat` route, or create a new dedicated route.
+
+## Decision
+
+Recipe Tweak uses `POST /api/recipe/[id]/tweak` — a separate, lean `streamText` call — rather than routing through `/api/chat`.
+
+## Reasons
+
+`/api/chat` carries infrastructure that a tweak does not need:
+- Conversation and message persistence
+- Inventory tool bindings (`addInventoryItem`, `getInventory`, `removeInventoryItem`)
+- Context window loading (`getMessages`, `CONTEXT_WINDOW = 15`)
+- `validateUIMessages` and multi-step logic (`stepCountIs(5)`)
+
+A Recipe Tweak is a single-turn call: "here is the recipe, here is the instruction, return an updated recipe block." Routing through chat would mean working around all of the above.
+
+## Trade-offs
+
+Using a dedicated route means a second AI entry point to maintain. The upside is that the tweak route stays small and purpose-built, and the chat route stays uncluttered.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -51,7 +51,7 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **5-state interactive flow** inside `RecipeDisplay`: resting → open → streaming → preview → saved.
 - **State 1 (Resting)**: inline dashed-border "Want Ah Mah to tweak this?" button below the Ah Mah note section.
 - **State 2 (Open)**: fixed bottom bar with granny avatar, Ah Mah voice prompt, 4 quick-tweak chips, text input + send button, ✕ dismiss.
-- **State 3 (Streaming)**: calls `POST /api/recipe/[id]/tweak` (already existed), accumulates streaming JSON, progressively updates recipe; bottom bar shows "You said + dot animation".
+- **State 3 (Streaming)**: calls `POST /api/recipe/[id]/tweak`, accumulates streaming JSON, progressively updates recipe; bottom bar shows "You said + dot animation".
 - **State 4 (Preview)**: stream done; bottom bar shows Ah Mah message + Save / Try a different tweak / Discard actions. Changed ingredients and steps get `bg-amber-50` highlight.
 - **State 5 (Saved)**: calls `PATCH /api/recipe/[id]` to persist; sonner success toast; "Tweak again" button replaces resting-state button; "tweaked just now" badge in Ah Mah note.
 - Tweak state fully contained in `RecipeDisplay` (no page-level changes needed). `userId` sourced from `useSessionContext` internally.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -47,6 +47,15 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 
 ## V2 — In Progress
 
+### Recipe Tweak UI (Direction C) — Shipped May 2026
+- **5-state interactive flow** inside `RecipeDisplay`: resting → open → streaming → preview → saved.
+- **State 1 (Resting)**: inline dashed-border "Want Ah Mah to tweak this?" button below the Ah Mah note section.
+- **State 2 (Open)**: fixed bottom bar with granny avatar, Ah Mah voice prompt, 4 quick-tweak chips, text input + send button, ✕ dismiss.
+- **State 3 (Streaming)**: calls `POST /api/recipe/[id]/tweak` (already existed), accumulates streaming JSON, progressively updates recipe; bottom bar shows "You said + dot animation".
+- **State 4 (Preview)**: stream done; bottom bar shows Ah Mah message + Save / Try a different tweak / Discard actions. Changed ingredients and steps get `bg-amber-50` highlight.
+- **State 5 (Saved)**: calls `PATCH /api/recipe/[id]` to persist; sonner success toast; "Tweak again" button replaces resting-state button; "tweaked just now" badge in Ah Mah note.
+- Tweak state fully contained in `RecipeDisplay` (no page-level changes needed). `userId` sourced from `useSessionContext` internally.
+
 ### Shopping list from shortfalls
 - [ ] Add one-click `Add missing to shopping list` from `RecipeDisplay`.
 - [ ] Add `ShoppingList` Prisma model (`id`, `userId`, `name`, `quantity?`, `unit?`, `addedAt`, `recipeId?`).

--- a/src/app/api/recipe/[id]/route.ts
+++ b/src/app/api/recipe/[id]/route.ts
@@ -1,0 +1,23 @@
+import { updateRecipe } from "@/lib/recipes";
+import { missingUserId } from "@/lib/http";
+import { prisma } from "@/lib/db";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const body = await req.json();
+  const { userId, recipe } = body;
+
+  if (!userId) return missingUserId();
+
+  const existing = await prisma.recipe.findUnique({ where: { id } });
+  if (!existing || existing.userId !== userId) {
+    return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
+  }
+
+  const updated = await updateRecipe(id, recipe);
+  return NextResponse.json(updated);
+}

--- a/src/app/api/recipe/[id]/route.ts
+++ b/src/app/api/recipe/[id]/route.ts
@@ -8,20 +8,24 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  const body = await req.json();
-  const { userId, recipe } = body;
-
-  if (!userId) return missingUserId();
-
-  const parsed = RecipeBlockSchema.safeParse(recipe);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid recipe payload" }, { status: 400 });
-  }
 
   try {
+    const body = await req.json();
+    const { userId, recipe } = body;
+
+    if (!userId) return missingUserId();
+
+    const parsed = RecipeBlockSchema.safeParse(recipe);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid recipe payload" }, { status: 400 });
+    }
+
     const updated = await updateRecipeForUser(id, userId, parsed.data);
     return NextResponse.json(updated);
   } catch (err) {
+    if (err instanceof SyntaxError) {
+      return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+    }
     if (err instanceof Error && err.message === "not found") {
       return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
     }

--- a/src/app/api/recipe/[id]/route.ts
+++ b/src/app/api/recipe/[id]/route.ts
@@ -1,6 +1,6 @@
-import { updateRecipe } from "@/lib/recipes";
+import { updateRecipeForUser } from "@/lib/recipes";
 import { missingUserId } from "@/lib/http";
-import { prisma } from "@/lib/db";
+import { RecipeBlockSchema } from "@/lib/recipes/schemas";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function PATCH(
@@ -13,11 +13,18 @@ export async function PATCH(
 
   if (!userId) return missingUserId();
 
-  const existing = await prisma.recipe.findUnique({ where: { id } });
-  if (!existing || existing.userId !== userId) {
-    return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
+  const parsed = RecipeBlockSchema.safeParse(recipe);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid recipe payload" }, { status: 400 });
   }
 
-  const updated = await updateRecipe(id, recipe);
-  return NextResponse.json(updated);
+  try {
+    const updated = await updateRecipeForUser(id, userId, parsed.data);
+    return NextResponse.json(updated);
+  } catch (err) {
+    if (err instanceof Error && err.message === "not found") {
+      return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
 }

--- a/src/app/api/recipe/[id]/tweak/route.ts
+++ b/src/app/api/recipe/[id]/tweak/route.ts
@@ -1,0 +1,58 @@
+import { missingUserId } from "@/lib/http";
+import { RecipeWithId } from "@/lib/recipes/schemas";
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
+import { NextRequest, NextResponse } from "next/server";
+
+const MAX_INSTRUCTION_LENGTH = 500;
+
+const RECIPE_FIELDS =
+  "title, description, totalTimeMinutes, baseServings, ingredients, prep, steps, tags";
+
+function buildSystemPrompt(recipe: RecipeWithId): string {
+  return `You are a recipe editor. Your task is to apply a targeted modification to the following recipe.
+
+## Current recipe
+\`\`\`json
+${JSON.stringify(recipe, null, 2)}
+\`\`\`
+
+## Instructions
+- Apply the user's instruction as a precise, minimal change — keep all unaffected fields exactly as they are.
+- Return ONLY a valid JSON object matching the RecipeBlock schema. Do not wrap it in markdown fences or add any surrounding text.
+- RecipeBlock fields: ${RECIPE_FIELDS}
+- If the user's request would produce a wholly different dish unrelated to the current recipe, politely refuse in plain text (not JSON) and explain why.`;
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  await params; // resolve dynamic segment (unused but required by Next.js App Router)
+
+  try {
+    const body: { userId?: string; instruction?: string; recipe?: RecipeWithId } =
+      await req.json();
+
+    const { userId, recipe } = body;
+    let { instruction } = body;
+
+    if (!userId) return missingUserId();
+    if (!instruction) {
+      return NextResponse.json({ error: "instruction is required" }, { status: 400 });
+    }
+
+    instruction = instruction.trim().slice(0, MAX_INSTRUCTION_LENGTH);
+
+    const result = streamText({
+      model: openai("gpt-4.1-mini"),
+      system: buildSystemPrompt(recipe as RecipeWithId),
+      messages: [{ role: "user", content: instruction }],
+    });
+
+    return result.toTextStreamResponse();
+  } catch (error) {
+    console.error("[/api/recipe/[id]/tweak]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/recipe/[id]/tweak/route.ts
+++ b/src/app/api/recipe/[id]/tweak/route.ts
@@ -1,8 +1,12 @@
 import { missingUserId } from "@/lib/http";
-import { RecipeBlockSchema, RecipeWithId } from "@/lib/recipes/schemas";
+import { RecipeBlockSchema } from "@/lib/recipes/schemas";
+import type { RecipeWithId } from "@/lib/recipes/schemas";
 import { openai } from "@ai-sdk/openai";
 import { streamText } from "ai";
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const RecipeWithIdSchema = RecipeBlockSchema.extend({ id: z.string() });
 
 const MAX_INSTRUCTION_LENGTH = 500;
 
@@ -50,7 +54,12 @@ export async function POST(
       return NextResponse.json({ error: "recipe is required" }, { status: 400 });
     }
 
-    if (recipe.id !== id) {
+    const parsedRecipe = RecipeWithIdSchema.safeParse(recipe);
+    if (!parsedRecipe.success) {
+      return NextResponse.json({ error: "Invalid recipe payload", details: parsedRecipe.error.flatten() }, { status: 400 });
+    }
+
+    if (parsedRecipe.data.id !== id) {
       return NextResponse.json({ error: "recipe id mismatch" }, { status: 400 });
     }
 

--- a/src/app/api/recipe/[id]/tweak/route.ts
+++ b/src/app/api/recipe/[id]/tweak/route.ts
@@ -1,13 +1,12 @@
 import { missingUserId } from "@/lib/http";
-import { RecipeWithId } from "@/lib/recipes/schemas";
+import { RecipeBlockSchema, RecipeWithId } from "@/lib/recipes/schemas";
 import { openai } from "@ai-sdk/openai";
 import { streamText } from "ai";
 import { NextRequest, NextResponse } from "next/server";
 
 const MAX_INSTRUCTION_LENGTH = 500;
 
-const RECIPE_FIELDS =
-  "title, description, totalTimeMinutes, baseServings, ingredients, prep, steps, tags";
+const RECIPE_FIELDS = Object.keys(RecipeBlockSchema.shape).join(", ");
 
 function buildSystemPrompt(recipe: RecipeWithId): string {
   return `You are a recipe editor. Your task is to apply a targeted modification to the following recipe.
@@ -28,7 +27,7 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  await params; // resolve dynamic segment (unused but required by Next.js App Router)
+  const { id } = await params;
 
   try {
     const body: { userId?: string; instruction?: string; recipe?: RecipeWithId } =
@@ -43,11 +42,23 @@ export async function POST(
     }
 
     instruction = instruction.trim().slice(0, MAX_INSTRUCTION_LENGTH);
+    if (!instruction) {
+      return NextResponse.json({ error: "instruction is required" }, { status: 400 });
+    }
+
+    if (!recipe) {
+      return NextResponse.json({ error: "recipe is required" }, { status: 400 });
+    }
+
+    if (recipe.id !== id) {
+      return NextResponse.json({ error: "recipe id mismatch" }, { status: 400 });
+    }
 
     const result = streamText({
       model: openai("gpt-4.1-mini"),
-      system: buildSystemPrompt(recipe as RecipeWithId),
+      system: buildSystemPrompt(recipe),
       messages: [{ role: "user", content: instruction }],
+      maxOutputTokens: 1500,
     });
 
     return result.toTextStreamResponse();

--- a/src/features/RecipeDisplay/RecipeDisplay.test.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.test.tsx
@@ -1,10 +1,18 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { SessionProvider } from "@/contexts/SessionContext";
 import RecipeDisplay from "./RecipeDisplay";
 
 jest.mock("streamdown", () => ({
   Streamdown: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="streamdown">{children}</div>
   ),
+}));
+
+jest.mock("@/hooks/useSession", () => () => ({
+  userId: "user-123",
+  isLoading: false,
+  isAuthenticated: true,
+  user: { id: "user-123", name: "Test User", email: "test@example.com", image: null },
 }));
 
 const baseRecipe = {
@@ -23,7 +31,11 @@ const baseRecipe = {
 };
 
 const renderRecipe = (overrides: Partial<typeof baseRecipe> = {}) =>
-  render(<RecipeDisplay recipe={{ ...baseRecipe, ...overrides } as never} onBack={jest.fn()} />);
+  render(
+    <SessionProvider>
+      <RecipeDisplay recipe={{ ...baseRecipe, ...overrides } as never} onBack={jest.fn()} />
+    </SessionProvider>,
+  );
 
 describe("RecipeDisplay", () => {
   describe("Basic Rendering", () => {
@@ -118,11 +130,13 @@ describe("RecipeDisplay", () => {
     it("calls onStartCooking when provided and does not render CookingMode internally", () => {
       const onStartCooking = jest.fn();
       render(
-        <RecipeDisplay
-          recipe={recipeWithSteps}
-          onBack={jest.fn()}
-          onStartCooking={onStartCooking}
-        />,
+        <SessionProvider>
+          <RecipeDisplay
+            recipe={recipeWithSteps}
+            onBack={jest.fn()}
+            onStartCooking={onStartCooking}
+          />
+        </SessionProvider>,
       );
       fireEvent.click(screen.getByLabelText(/Start cooking/));
       expect(onStartCooking).toHaveBeenCalledTimes(1);
@@ -131,7 +145,11 @@ describe("RecipeDisplay", () => {
     });
 
     it("falls back to internal cooking mode when onStartCooking is not provided", () => {
-      render(<RecipeDisplay recipe={recipeWithSteps} onBack={jest.fn()} />);
+      render(
+        <SessionProvider>
+          <RecipeDisplay recipe={recipeWithSteps} onBack={jest.fn()} />
+        </SessionProvider>,
+      );
       fireEvent.click(screen.getByLabelText(/Start cooking/));
       expect(screen.getByText(/Exit cooking mode/i)).toBeInTheDocument();
     });

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -679,7 +679,7 @@ export default function RecipeDisplay({
   const originalRecipeRef = useRef<RecipeWithId>(recipe);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const steps = (recipe.steps ?? []) as RecipeStep[];
+  const steps = (tweakedRecipe.steps ?? []) as RecipeStep[];
   const canCook = steps.length > 0;
 
   // Compute changed fields (memoised — only recalculates when the recipes change)
@@ -690,6 +690,15 @@ export default function RecipeDisplay({
   );
 
   // ── Handlers ───────────────────────────────────────────────────────────────
+
+  // Reset tweak state when the recipe changes (e.g. navigating to a different recipe)
+  useEffect(() => {
+    setTweakedRecipe(recipe);
+    originalRecipeRef.current = recipe;
+    setTweakState("resting");
+    setIsSaving(false);
+    setInstruction("");
+  }, [recipe.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Focus the input whenever the tweak bar opens
   useEffect(() => {
@@ -730,6 +739,7 @@ export default function RecipeDisplay({
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
         let accumulated = "";
+        let parsedAtLeastOnce = false;
 
         try {
           while (true) {
@@ -754,6 +764,7 @@ export default function RecipeDisplay({
                 instructions: originalRecipeRef.current.instructions,
               };
               setTweakedRecipe(updatedRecipe);
+              parsedAtLeastOnce = true;
             } catch {
               // JSON not yet complete — keep accumulating
             }
@@ -762,7 +773,13 @@ export default function RecipeDisplay({
           reader.cancel().catch(() => {});
         }
 
-        setTweakState("preview");
+        if (parsedAtLeastOnce) {
+          setTweakState("preview");
+        } else {
+          // AI responded with non-JSON (e.g. refused the request) — surface an error
+          toast.error("Ah Mah couldn't tweak this one. Try a different instruction?");
+          setTweakState("open");
+        }
       } catch (err) {
         console.error("[RecipeDisplay] tweak stream error:", err);
         toast.error("Aiyah, something went wrong. Try again?");

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -1,8 +1,14 @@
+"use client";
+
 import { CookingMode } from "@/features/Recipe";
+import { useSessionContext } from "@/contexts/SessionContext";
 import { RecipeIngredient, RecipeStep, RecipeWithId } from "@/lib/recipes/schemas";
 import Image from "next/image";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Streamdown } from "streamdown";
+import { toast } from "sonner";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
 
 const formatAmount = (n: number) => {
   if (Number.isInteger(n)) return String(n);
@@ -24,7 +30,80 @@ const formatTime = (minutes: number): string => {
   return m > 0 ? `${h} h ${m} m` : `${h} h`;
 };
 
-function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
+// ─── Tweak state machine ─────────────────────────────────────────────────────
+
+type TweakState = "resting" | "open" | "streaming" | "preview" | "saved";
+
+const QUICK_TWEAKS = [
+  "Use what's in my pantry",
+  "Swap for pantry staples",
+  "Less spicy",
+  "Make it quicker",
+];
+
+// ─── Changed-field tracking ──────────────────────────────────────────────────
+
+function diffRecipes(
+  original: RecipeWithId,
+  tweaked: RecipeWithId,
+): { ingredients: Set<number>; steps: Set<number> } {
+  const changedIngredients = new Set<number>();
+  const changedSteps = new Set<number>();
+
+  const origIngs = (original.ingredients || []) as RecipeIngredient[];
+  const tweakIngs = (tweaked.ingredients || []) as RecipeIngredient[];
+
+  tweakIngs.forEach((ing, i) => {
+    const orig = origIngs[i];
+    if (
+      !orig ||
+      orig.name !== ing.name ||
+      orig.amount !== ing.amount ||
+      orig.unit !== ing.unit
+    ) {
+      changedIngredients.add(i);
+    }
+  });
+  // Also mark newly inserted rows
+  if (tweakIngs.length > origIngs.length) {
+    for (let i = origIngs.length; i < tweakIngs.length; i++) {
+      changedIngredients.add(i);
+    }
+  }
+
+  const origSteps = (original.steps || []) as RecipeStep[];
+  const tweakSteps = (tweaked.steps || []) as RecipeStep[];
+
+  tweakSteps.forEach((step, i) => {
+    const orig = origSteps[i];
+    if (!orig || orig.body !== step.body || orig.title !== step.title) {
+      changedSteps.add(i);
+    }
+  });
+
+  return { ingredients: changedIngredients, steps: changedSteps };
+}
+
+// ─── RecipeBody ──────────────────────────────────────────────────────────────
+
+interface RecipeBodyProps {
+  selectedRecipe: RecipeWithId;
+  /** Fields that changed compared to original (highlight them) */
+  changedIngredients?: Set<number>;
+  changedSteps?: Set<number>;
+  tweakState: TweakState;
+  onTweakClick: () => void;
+  onTweakAgain: () => void;
+}
+
+function RecipeBody({
+  selectedRecipe,
+  changedIngredients = new Set(),
+  changedSteps = new Set(),
+  tweakState,
+  onTweakClick,
+  onTweakAgain,
+}: RecipeBodyProps) {
   const [servings, setServings] = useState<number>(selectedRecipe.baseServings ?? 2);
   const baseServings = selectedRecipe.baseServings || 2;
   const ingredients = (selectedRecipe.ingredients || []) as RecipeIngredient[];
@@ -32,12 +111,18 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
   const steps = (selectedRecipe.steps || []) as RecipeStep[];
   const scale = servings / baseServings;
 
+  const showHighlights = tweakState === "streaming" || tweakState === "preview" || tweakState === "saved";
+
   return (
     <>
       {/* Hero strip */}
       <div
         className="relative h-[180px] sm:h-[260px] border-b border-border flex items-end overflow-hidden"
-        style={!selectedRecipe.imageUrl ? { background: "linear-gradient(135deg, oklch(0.55 0.13 35) 0%, oklch(0.42 0.10 30) 100%)" } : undefined}
+        style={
+          !selectedRecipe.imageUrl
+            ? { background: "linear-gradient(135deg, oklch(0.55 0.13 35) 0%, oklch(0.42 0.10 30) 100%)" }
+            : undefined
+        }
       >
         {selectedRecipe.imageUrl ? (
           <Image
@@ -50,7 +135,10 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
         ) : (
           <div
             className="absolute inset-0"
-            style={{ backgroundImage: "repeating-linear-gradient(135deg, oklch(1 0 0 / 0.04) 0 12px, transparent 12px 24px)" }}
+            style={{
+              backgroundImage:
+                "repeating-linear-gradient(135deg, oklch(1 0 0 / 0.04) 0 12px, transparent 12px 24px)",
+            }}
           />
         )}
         <div
@@ -76,17 +164,19 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
             {selectedRecipe.name}
           </h1>
         </div>
-        {selectedRecipe.imageUrl && selectedRecipe.photographerName && selectedRecipe.photographerUrl && (
-          <a
-            href={selectedRecipe.photographerUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="absolute bottom-2 right-3 font-sans text-[10px] text-white/70 hover:text-white transition-colors leading-none"
-            style={{ textShadow: "0 1px 2px rgba(0,0,0,0.6)" }}
-          >
-            Photo by {selectedRecipe.photographerName}
-          </a>
-        )}
+        {selectedRecipe.imageUrl &&
+          selectedRecipe.photographerName &&
+          selectedRecipe.photographerUrl && (
+            <a
+              href={selectedRecipe.photographerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute bottom-2 right-3 font-sans text-[10px] text-white/70 hover:text-white transition-colors leading-none"
+              style={{ textShadow: "0 1px 2px rgba(0,0,0,0.6)" }}
+            >
+              Photo by {selectedRecipe.photographerName}
+            </a>
+          )}
       </div>
 
       {/* Body */}
@@ -97,13 +187,55 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
             <div className="relative w-10 h-10 shrink-0">
               <Image src="/granny-icon.png" alt="" fill className="object-contain" />
             </div>
-            <div>
-              <div className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint mb-1">
+            <div className="flex-1 min-w-0">
+              <div className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint mb-1 flex items-center gap-2">
                 From Ah Mah
+                {tweakState === "saved" && (
+                  <span className="text-emerald-600 tracking-[0.14em]">· tweaked just now</span>
+                )}
               </div>
               <div className="font-display italic text-[15px] sm:text-base text-foreground leading-[1.5] max-w-prose">
                 {selectedRecipe.description}
               </div>
+
+              {/* State 1 — inline tweak button (resting) */}
+              {tweakState === "resting" && (
+                <button
+                  onClick={onTweakClick}
+                  className="mt-3 inline-flex items-center gap-2 px-3.5 py-1.5 text-[12.5px] font-semibold text-primary bg-primary/5 border border-dashed border-primary/60 rounded-full cursor-pointer hover:bg-primary/10 transition-colors"
+                >
+                  <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+                    <path
+                      d="M3 10.5 L8.5 5 L11 7.5 L5.5 13 H3 V10.5 Z M8.5 5 L10 3.5 L12.5 6 L11 7.5"
+                      stroke="currentColor"
+                      strokeWidth="1.4"
+                      strokeLinejoin="round"
+                      fill="none"
+                    />
+                  </svg>
+                  Want Ah Mah to tweak this?
+                  <span className="text-ink-faint ml-0.5">→</span>
+                </button>
+              )}
+
+              {/* State 5 — tweak again (saved) */}
+              {tweakState === "saved" && (
+                <button
+                  onClick={onTweakAgain}
+                  className="mt-3 inline-flex items-center gap-2 px-3.5 py-1.5 text-[12.5px] font-semibold text-primary bg-primary/5 border border-dashed border-primary/60 rounded-lg cursor-pointer hover:bg-primary/10 transition-colors"
+                >
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                    <path
+                      d="M3 10.5 L8.5 5 L11 7.5 L5.5 13 H3 V10.5 Z M8.5 5 L10 3.5 L12.5 6 L11 7.5"
+                      stroke="currentColor"
+                      strokeWidth="1.4"
+                      strokeLinejoin="round"
+                      fill="none"
+                    />
+                  </svg>
+                  Tweak again
+                </button>
+              )}
             </div>
           </div>
         )}
@@ -154,10 +286,13 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
             <ul className="list-none p-0 mt-2 border-t border-border">
               {ingredients.map((ing, i) => {
                 const scaled = ing.amount != null ? ing.amount * scale : undefined;
+                const isChanged = showHighlights && changedIngredients.has(i);
                 return (
                   <li
                     key={i}
-                    className="flex items-baseline gap-3 py-2.5 border-b border-dashed border-border"
+                    className={`flex items-baseline gap-3 py-2.5 border-b border-dashed border-border transition-colors ${
+                      isChanged ? "bg-amber-50 dark:bg-amber-950/20 -mx-1 px-1 rounded" : ""
+                    }`}
                   >
                     <span
                       className={`basis-20 sm:basis-24 shrink-0 text-[13px] text-foreground text-right ${
@@ -211,28 +346,34 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
           </h2>
           {steps.length > 0 ? (
             <ol className="list-none p-0 flex flex-col gap-5">
-              {steps.map((step, i) => (
-                <li key={i} className="flex gap-4">
-                  <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums pt-0.5 shrink-0 w-5 text-right">
-                    {i + 1}.
-                  </span>
-                  <div className="flex-1">
-                    {step.title && (
-                      <div className="font-display font-semibold text-[15px] text-foreground mb-0.5">
-                        {step.title}
+              {steps.map((step, i) => {
+                const isChanged = showHighlights && changedSteps.has(i);
+                return (
+                  <li
+                    key={i}
+                    className={`flex gap-4 transition-colors ${
+                      isChanged ? "bg-amber-50 dark:bg-amber-950/20 -mx-1 px-1 rounded-lg py-1" : ""
+                    }`}
+                  >
+                    <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums pt-0.5 shrink-0 w-5 text-right">
+                      {i + 1}.
+                    </span>
+                    <div className="flex-1">
+                      {step.title && (
+                        <div className="font-display font-semibold text-[15px] text-foreground mb-0.5">
+                          {step.title}
+                        </div>
+                      )}
+                      <div className="font-sans text-[14px] text-foreground leading-[1.6]">
+                        {step.body}
                       </div>
-                    )}
-                    <div className="font-sans text-[14px] text-foreground leading-[1.6]">
-                      {step.body}
+                      {step.tip && (
+                        <div className="mt-1.5 text-[12.5px] text-ink-faint italic">{step.tip}</div>
+                      )}
                     </div>
-                    {step.tip && (
-                      <div className="mt-1.5 text-[12.5px] text-ink-faint italic">
-                        {step.tip}
-                      </div>
-                    )}
-                  </div>
-                </li>
-              ))}
+                  </li>
+                );
+              })}
             </ol>
           ) : (
             <div className="recipe-prose">
@@ -245,6 +386,206 @@ function RecipeBody({ selectedRecipe }: { selectedRecipe: RecipeWithId }) {
   );
 }
 
+// ─── Bottom bar ──────────────────────────────────────────────────────────────
+
+interface TweakBarProps {
+  tweakState: TweakState;
+  instruction: string;
+  onInstructionChange: (v: string) => void;
+  onSend: (prompt?: string) => void;
+  onDismiss: () => void;
+  onSave: () => void;
+  onTryAgain: () => void;
+  onDiscard: () => void;
+  isSaving: boolean;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+}
+
+function TweakBar({
+  tweakState,
+  instruction,
+  onInstructionChange,
+  onSend,
+  onDismiss,
+  onSave,
+  onTryAgain,
+  onDiscard,
+  isSaving,
+  inputRef,
+}: TweakBarProps) {
+  if (tweakState !== "open" && tweakState !== "streaming" && tweakState !== "preview") {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-50 bg-background border-t border-border/60 shadow-[0_-4px_24px_oklch(0_0_0/0.08)]"
+      style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+    >
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-3.5">
+        {/* State 2 — open input */}
+        {tweakState === "open" && (
+          <div className="flex gap-3">
+            <div className="relative w-8 h-8 shrink-0 mt-1">
+              <Image
+                src="/granny-avatar.png"
+                alt="Ah Mah"
+                fill
+                className="object-cover rounded-full border border-border"
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center justify-between mb-2">
+                <p className="font-display italic text-[13.5px] text-muted-foreground leading-snug">
+                  What should I change, ah? Tell me anything — taste, ingredients, time.
+                </p>
+                <button
+                  onClick={onDismiss}
+                  aria-label="Dismiss"
+                  className="ml-3 shrink-0 w-6 h-6 inline-flex items-center justify-center border border-border rounded-full text-[11px] text-muted-foreground hover:bg-muted/60 cursor-pointer transition-colors"
+                >
+                  ✕
+                </button>
+              </div>
+              {/* Quick-tweak chips */}
+              <div className="flex flex-wrap gap-1.5 mb-2.5">
+                {QUICK_TWEAKS.map((chip) => (
+                  <button
+                    key={chip}
+                    onClick={() => onSend(chip)}
+                    className="px-2.5 py-1 text-[11px] font-medium text-muted-foreground bg-card border border-border/70 rounded-full cursor-pointer hover:bg-muted/60 transition-colors"
+                  >
+                    {chip}
+                  </button>
+                ))}
+              </div>
+              {/* Input row */}
+              <div className="flex items-center gap-2.5 px-4 py-2 bg-card border border-border rounded-full shadow-[0_1px_0_var(--color-border-soft),0_8px_24px_-16px_oklch(0_0_0/0.2)]">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  className="shrink-0 text-primary"
+                >
+                  <path
+                    d="M3 10.5 L8.5 5 L11 7.5 L5.5 13 H3 V10.5 Z M8.5 5 L10 3.5 L12.5 6 L11 7.5"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                    strokeLinejoin="round"
+                    fill="none"
+                  />
+                </svg>
+                <input
+                  ref={inputRef}
+                  value={instruction}
+                  onChange={(e) => onInstructionChange(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") onSend();
+                  }}
+                  placeholder="Tell Ah Mah what to change…"
+                  className="flex-1 bg-transparent border-none outline-none text-[13.5px] text-foreground placeholder:text-muted-foreground font-sans"
+                />
+                <button
+                  onClick={() => onSend()}
+                  disabled={!instruction.trim()}
+                  aria-label="Send"
+                  className={`w-8 h-8 rounded-full inline-flex items-center justify-center shrink-0 transition-colors cursor-pointer ${
+                    instruction.trim()
+                      ? "bg-primary border border-primary/80 text-primary-foreground shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90"
+                      : "bg-muted border border-border text-muted-foreground cursor-not-allowed"
+                  }`}
+                >
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
+                    <path d="M3 12 L21 4 L13 21 L11 13 Z" fill="currentColor" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* State 3 — streaming */}
+        {tweakState === "streaming" && (
+          <div className="flex gap-3">
+            <div className="relative w-8 h-8 shrink-0 mt-1">
+              <Image
+                src="/granny-avatar.png"
+                alt="Ah Mah"
+                fill
+                className="object-cover rounded-full border border-border"
+              />
+            </div>
+            <div className="flex-1">
+              <div className="inline-flex items-center gap-2 px-3.5 py-2 bg-card border border-border rounded-xl text-[13px] text-foreground">
+                <span className="text-muted-foreground">You said:</span>
+                <span className="font-display italic text-[14px]">&ldquo;{instruction}&rdquo;</span>
+              </div>
+              <div className="mt-2 flex items-center gap-2 text-[11.5px] text-muted-foreground">
+                <span className="inline-flex gap-1">
+                  {[0, 1, 2].map((i) => (
+                    <span
+                      key={i}
+                      className="w-1.5 h-1.5 rounded-full bg-primary"
+                      style={{ animation: `tweakDot 1.2s ease-in-out ${i * 0.15}s infinite` }}
+                    />
+                  ))}
+                </span>
+                Ah Mah is rewriting above…
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* State 4 — preview ready */}
+        {tweakState === "preview" && (
+          <div className="flex gap-3 items-start">
+            <div className="relative w-8 h-8 shrink-0 mt-1">
+              <Image
+                src="/granny-avatar.png"
+                alt="Ah Mah"
+                fill
+                className="object-cover rounded-full border border-border"
+              />
+            </div>
+            <div className="flex-1">
+              <p className="font-display italic text-[14px] text-foreground mb-1">
+                How does this look? Save it to your cookbook, or tell me what&rsquo;s still off.
+              </p>
+              <p className="text-[11px] text-muted-foreground mb-3">
+                &ldquo;{instruction}&rdquo;
+              </p>
+              <div className="flex items-center gap-2.5 flex-wrap">
+                <button
+                  onClick={onSave}
+                  disabled={isSaving}
+                  className="px-3.5 py-2 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-60"
+                >
+                  {isSaving ? "Saving…" : "Save changes"}
+                </button>
+                <button
+                  onClick={onTryAgain}
+                  className="px-3 py-2 text-[12.5px] font-semibold text-foreground bg-card border border-border rounded-lg cursor-pointer hover:bg-muted/60 transition-colors"
+                >
+                  Try a different tweak
+                </button>
+                <button
+                  onClick={onDiscard}
+                  className="px-1.5 py-2 text-[11.5px] font-semibold tracking-[0.14em] uppercase text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── RecipeDisplay ───────────────────────────────────────────────────────────
+
 interface RecipeDisplayProps {
   recipe: RecipeWithId;
   onBack: () => void;
@@ -252,11 +593,162 @@ interface RecipeDisplayProps {
   hideBackButton?: boolean;
 }
 
-export default function RecipeDisplay({ recipe, onBack, onStartCooking, hideBackButton }: RecipeDisplayProps) {
+export default function RecipeDisplay({
+  recipe,
+  onBack,
+  onStartCooking,
+  hideBackButton,
+}: RecipeDisplayProps) {
+  const { userId } = useSessionContext();
   const [cooking, setCooking] = useState(false);
+
+  // ── Tweak state ────────────────────────────────────────────────────────────
+  const [tweakState, setTweakState] = useState<TweakState>("resting");
+  const [instruction, setInstruction] = useState("");
+  const [tweakedRecipe, setTweakedRecipe] = useState<RecipeWithId>(recipe);
+  const [isSaving, setIsSaving] = useState(false);
+  const originalRecipeRef = useRef<RecipeWithId>(recipe);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   const steps = (recipe.steps ?? []) as RecipeStep[];
   const canCook = steps.length > 0;
+
+  // Compute changed fields
+  const { ingredients: changedIngredients, steps: changedSteps } = diffRecipes(
+    originalRecipeRef.current,
+    tweakedRecipe,
+  );
+
+  // ── Handlers ───────────────────────────────────────────────────────────────
+
+  const openTweak = useCallback(() => {
+    setTweakState("open");
+    setTimeout(() => inputRef.current?.focus(), 80);
+  }, []);
+
+  const dismissTweak = useCallback(() => {
+    setTweakState("resting");
+    setInstruction("");
+    setTweakedRecipe(originalRecipeRef.current);
+  }, []);
+
+  const sendTweak = useCallback(
+    async (prompt?: string) => {
+      const p = (prompt ?? instruction).trim();
+      if (!p) return;
+
+      const finalInstruction = prompt ?? instruction;
+      setInstruction(finalInstruction);
+      setTweakState("streaming");
+
+      try {
+        const res = await fetch(`/api/recipe/${recipe.id}/tweak`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userId, instruction: p, recipe: tweakedRecipe }),
+        });
+
+        if (!res.ok || !res.body) {
+          throw new Error("Tweak request failed");
+        }
+
+        // Read the stream and accumulate
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulated = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          accumulated += decoder.decode(value, { stream: true });
+
+          // Try to parse accumulated text as JSON progressively
+          try {
+            const parsed = JSON.parse(accumulated);
+            // Map RecipeBlock → RecipeWithId (carry over the id and image fields)
+            const updatedRecipe: RecipeWithId = {
+              ...originalRecipeRef.current,
+              name: parsed.title ?? originalRecipeRef.current.name,
+              description: parsed.description ?? originalRecipeRef.current.description,
+              totalTimeMinutes: parsed.totalTimeMinutes ?? originalRecipeRef.current.totalTimeMinutes,
+              baseServings: parsed.baseServings ?? originalRecipeRef.current.baseServings,
+              ingredients: parsed.ingredients ?? originalRecipeRef.current.ingredients,
+              prep: parsed.prep ?? originalRecipeRef.current.prep,
+              steps: parsed.steps ?? originalRecipeRef.current.steps,
+              tags: parsed.tags ?? originalRecipeRef.current.tags,
+              instructions: originalRecipeRef.current.instructions,
+            };
+            setTweakedRecipe(updatedRecipe);
+          } catch {
+            // JSON not yet complete — keep accumulating
+          }
+        }
+
+        setTweakState("preview");
+      } catch (err) {
+        console.error("[RecipeDisplay] tweak stream error:", err);
+        toast.error("Aiyah, something went wrong. Try again?");
+        setTweakState("open");
+      }
+    },
+    [instruction, recipe.id, userId, tweakedRecipe],
+  );
+
+  const tryAgain = useCallback(() => {
+    setTweakedRecipe(originalRecipeRef.current);
+    setInstruction("");
+    setTweakState("open");
+    setTimeout(() => inputRef.current?.focus(), 80);
+  }, []);
+
+  const saveChanges = useCallback(async () => {
+    if (!userId) return;
+    setIsSaving(true);
+    try {
+      const recipeBlock = {
+        title: tweakedRecipe.name,
+        description: tweakedRecipe.description,
+        totalTimeMinutes: tweakedRecipe.totalTimeMinutes,
+        baseServings: tweakedRecipe.baseServings,
+        ingredients: tweakedRecipe.ingredients,
+        prep: tweakedRecipe.prep,
+        steps: tweakedRecipe.steps,
+        tags: tweakedRecipe.tags,
+      };
+
+      const res = await fetch(`/api/recipe/${recipe.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, recipe: recipeBlock }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Save failed");
+      }
+
+      // Update the original reference so future tweaks start from the saved version
+      originalRecipeRef.current = tweakedRecipe;
+      setTweakState("saved");
+      toast.success("Recipe saved!");
+    } catch (err) {
+      console.error("[RecipeDisplay] save error:", err);
+      toast.error("Couldn't save. Try again?");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [recipe.id, tweakedRecipe, userId]);
+
+  const discardChanges = useCallback(() => {
+    setTweakedRecipe(originalRecipeRef.current);
+    setInstruction("");
+    setTweakState("resting");
+  }, []);
+
+  const tweakAgain = useCallback(() => {
+    setInstruction("");
+    setTweakState("open");
+    setTimeout(() => inputRef.current?.focus(), 80);
+  }, []);
 
   const handleStartCooking = () => {
     if (onStartCooking) {
@@ -265,6 +757,10 @@ export default function RecipeDisplay({ recipe, onBack, onStartCooking, hideBack
       setCooking(true);
     }
   };
+
+  // Keep tweakState bottom bar above iOS home indicator
+  const hasBottomBar =
+    tweakState === "open" || tweakState === "streaming" || tweakState === "preview";
 
   if (cooking) {
     return (
@@ -278,37 +774,67 @@ export default function RecipeDisplay({ recipe, onBack, onStartCooking, hideBack
   }
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-3xl px-4 sm:px-6 pt-4 sm:pt-5 pb-8">
-          <div className="flex items-center justify-between mb-3 sm:mb-4">
-            {!hideBackButton && (
-              <button
-                onClick={onBack}
-                className="font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
-                aria-label="Back to cookbook"
-              >
-                ← Back to cookbook
-              </button>
-            )}
-            {canCook && (
-              <button
-                onClick={handleStartCooking}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12.5px] font-semibold text-primary-foreground bg-primary border border-primary rounded-md cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
-                aria-label="Start cooking — step-by-step view with screen stay-on"
-              >
-                <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
-                  <path d="M5 3l8 5-8 5V3z" fill="currentColor" />
-                </svg>
-                Start cooking
-              </button>
-            )}
-          </div>
-          <div className="rounded-xl border border-border bg-card overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
-            <RecipeBody selectedRecipe={recipe} />
+    <>
+      {/* Dot animation keyframes injected as a style tag */}
+      <style>{`
+        @keyframes tweakDot {
+          0%, 80%, 100% { opacity: 0.2; transform: scale(0.85); }
+          40% { opacity: 1; transform: scale(1); }
+        }
+      `}</style>
+
+      <div className="flex flex-col h-full">
+        <div className={`flex-1 overflow-y-auto ${hasBottomBar ? "pb-36" : ""}`}>
+          <div className="mx-auto max-w-3xl px-4 sm:px-6 pt-4 sm:pt-5 pb-8">
+            <div className="flex items-center justify-between mb-3 sm:mb-4">
+              {!hideBackButton && (
+                <button
+                  onClick={onBack}
+                  className="font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
+                  aria-label="Back to cookbook"
+                >
+                  ← Back to cookbook
+                </button>
+              )}
+              {canCook && (
+                <button
+                  onClick={handleStartCooking}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12.5px] font-semibold text-primary-foreground bg-primary border border-primary rounded-md cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
+                  aria-label="Start cooking — step-by-step view with screen stay-on"
+                >
+                  <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+                    <path d="M5 3l8 5-8 5V3z" fill="currentColor" />
+                  </svg>
+                  Start cooking
+                </button>
+              )}
+            </div>
+            <div className="rounded-xl border border-border bg-card overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
+              <RecipeBody
+                selectedRecipe={tweakedRecipe}
+                changedIngredients={changedIngredients}
+                changedSteps={changedSteps}
+                tweakState={tweakState}
+                onTweakClick={openTweak}
+                onTweakAgain={tweakAgain}
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+
+      <TweakBar
+        tweakState={tweakState}
+        instruction={instruction}
+        onInstructionChange={setInstruction}
+        onSend={sendTweak}
+        onDismiss={dismissTweak}
+        onSave={saveChanges}
+        onTryAgain={tryAgain}
+        onDiscard={discardChanges}
+        isSaving={isSaving}
+        inputRef={inputRef}
+      />
+    </>
   );
 }

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -4,7 +4,7 @@ import { CookingMode } from "@/features/Recipe";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { RecipeIngredient, RecipeStep, RecipeWithId } from "@/lib/recipes/schemas";
 import Image from "next/image";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Streamdown } from "streamdown";
 import { toast } from "sonner";
 
@@ -46,16 +46,23 @@ const QUICK_TWEAKS = [
 function diffRecipes(
   original: RecipeWithId,
   tweaked: RecipeWithId,
-): { ingredients: Set<number>; steps: Set<number> } {
+): { ingredients: Set<number>; steps: Set<number>; deletedIngredients: Set<number>; deletedSteps: Set<number> } {
   const changedIngredients = new Set<number>();
   const changedSteps = new Set<number>();
+  const deletedIngredients = new Set<number>();
+  const deletedSteps = new Set<number>();
 
   const origIngs = (original.ingredients || []) as RecipeIngredient[];
   const tweakIngs = (tweaked.ingredients || []) as RecipeIngredient[];
 
-  tweakIngs.forEach((ing, i) => {
+  const ingLen = Math.max(origIngs.length, tweakIngs.length);
+  for (let i = 0; i < ingLen; i++) {
     const orig = origIngs[i];
-    if (
+    const ing = tweakIngs[i];
+    if (!ing) {
+      // Row deleted by AI — mark the original index as deleted
+      deletedIngredients.add(i);
+    } else if (
       !orig ||
       orig.name !== ing.name ||
       orig.amount !== ing.amount ||
@@ -63,25 +70,23 @@ function diffRecipes(
     ) {
       changedIngredients.add(i);
     }
-  });
-  // Also mark newly inserted rows
-  if (tweakIngs.length > origIngs.length) {
-    for (let i = origIngs.length; i < tweakIngs.length; i++) {
-      changedIngredients.add(i);
-    }
   }
 
   const origSteps = (original.steps || []) as RecipeStep[];
   const tweakSteps = (tweaked.steps || []) as RecipeStep[];
 
-  tweakSteps.forEach((step, i) => {
+  const stepsLen = Math.max(origSteps.length, tweakSteps.length);
+  for (let i = 0; i < stepsLen; i++) {
     const orig = origSteps[i];
-    if (!orig || orig.body !== step.body || orig.title !== step.title) {
+    const step = tweakSteps[i];
+    if (!step) {
+      deletedSteps.add(i);
+    } else if (!orig || orig.body !== step.body || orig.title !== step.title) {
       changedSteps.add(i);
     }
-  });
+  }
 
-  return { ingredients: changedIngredients, steps: changedSteps };
+  return { ingredients: changedIngredients, steps: changedSteps, deletedIngredients, deletedSteps };
 }
 
 // ─── RecipeBody ──────────────────────────────────────────────────────────────
@@ -91,6 +96,11 @@ interface RecipeBodyProps {
   /** Fields that changed compared to original (highlight them) */
   changedIngredients?: Set<number>;
   changedSteps?: Set<number>;
+  /** Rows present in original but removed by AI tweak */
+  deletedIngredients?: Set<number>;
+  deletedSteps?: Set<number>;
+  /** Original recipe — needed to render deleted rows */
+  originalRecipe?: RecipeWithId;
   tweakState: TweakState;
   onTweakClick: () => void;
   onTweakAgain: () => void;
@@ -100,6 +110,9 @@ function RecipeBody({
   selectedRecipe,
   changedIngredients = new Set(),
   changedSteps = new Set(),
+  deletedIngredients = new Set(),
+  deletedSteps = new Set(),
+  originalRecipe,
   tweakState,
   onTweakClick,
   onTweakAgain,
@@ -107,6 +120,8 @@ function RecipeBody({
   const [servings, setServings] = useState<number>(selectedRecipe.baseServings ?? 2);
   const baseServings = selectedRecipe.baseServings || 2;
   const ingredients = (selectedRecipe.ingredients || []) as RecipeIngredient[];
+  const origIngredients = (originalRecipe?.ingredients || []) as RecipeIngredient[];
+  const origSteps = (originalRecipe?.steps || []) as RecipeStep[];
   const prep = (selectedRecipe.prep ?? []) as string[];
   const steps = (selectedRecipe.steps || []) as RecipeStep[];
   const scale = servings / baseServings;
@@ -311,6 +326,34 @@ function RecipeBody({
                   </li>
                 );
               })}
+              {/* Deleted ingredients — shown with strikethrough when tweaking */}
+              {showHighlights &&
+                Array.from(deletedIngredients).map((i) => {
+                  const ing = origIngredients[i];
+                  if (!ing) return null;
+                  const scaled = ing.amount != null ? ing.amount * scale : undefined;
+                  return (
+                    <li
+                      key={`deleted-ing-${i}`}
+                      className="flex items-baseline gap-3 py-2.5 border-b border-dashed border-border transition-colors line-through opacity-50"
+                    >
+                      <span
+                        className={`basis-20 sm:basis-24 shrink-0 text-[13px] text-foreground text-right ${
+                          scaled != null
+                            ? "font-mono font-semibold tabular-nums"
+                            : "font-display italic text-muted-foreground"
+                        }`}
+                      >
+                        {scaled != null
+                          ? `${formatAmount(scaled)}${ing.unit ? ` ${ing.unit}` : ""}`
+                          : "to taste"}
+                      </span>
+                      <span className="flex-1 font-display text-[15px] text-foreground leading-[1.4]">
+                        {ing.name}
+                      </span>
+                    </li>
+                  );
+                })}
             </ul>
           </section>
         )}
@@ -374,6 +417,32 @@ function RecipeBody({
                   </li>
                 );
               })}
+              {/* Deleted steps — shown with strikethrough when tweaking */}
+              {showHighlights &&
+                Array.from(deletedSteps).map((i) => {
+                  const step = origSteps[i];
+                  if (!step) return null;
+                  return (
+                    <li
+                      key={`deleted-step-${i}`}
+                      className="flex gap-4 transition-colors line-through opacity-50"
+                    >
+                      <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums pt-0.5 shrink-0 w-5 text-right">
+                        {i + 1}.
+                      </span>
+                      <div className="flex-1">
+                        {step.title && (
+                          <div className="font-display font-semibold text-[15px] text-foreground mb-0.5">
+                            {step.title}
+                          </div>
+                        )}
+                        <div className="font-sans text-[14px] text-foreground leading-[1.6]">
+                          {step.body}
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
             </ol>
           ) : (
             <div className="recipe-prose">
@@ -613,17 +682,22 @@ export default function RecipeDisplay({
   const steps = (recipe.steps ?? []) as RecipeStep[];
   const canCook = steps.length > 0;
 
-  // Compute changed fields
-  const { ingredients: changedIngredients, steps: changedSteps } = diffRecipes(
-    originalRecipeRef.current,
-    tweakedRecipe,
+  // Compute changed fields (memoised — only recalculates when the recipes change)
+  const { ingredients: changedIngredients, steps: changedSteps, deletedIngredients, deletedSteps } = useMemo(
+    () => diffRecipes(originalRecipeRef.current, tweakedRecipe),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [tweakedRecipe],
   );
 
   // ── Handlers ───────────────────────────────────────────────────────────────
 
+  // Focus the input whenever the tweak bar opens
+  useEffect(() => {
+    if (tweakState === "open") inputRef.current?.focus();
+  }, [tweakState]);
+
   const openTweak = useCallback(() => {
     setTweakState("open");
-    setTimeout(() => inputRef.current?.focus(), 80);
   }, []);
 
   const dismissTweak = useCallback(() => {
@@ -645,7 +719,7 @@ export default function RecipeDisplay({
         const res = await fetch(`/api/recipe/${recipe.id}/tweak`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ userId, instruction: p, recipe: tweakedRecipe }),
+          body: JSON.stringify({ userId, instruction: p, recipe: originalRecipeRef.current }),
         });
 
         if (!res.ok || !res.body) {
@@ -657,31 +731,35 @@ export default function RecipeDisplay({
         const decoder = new TextDecoder();
         let accumulated = "";
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          accumulated += decoder.decode(value, { stream: true });
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            accumulated += decoder.decode(value, { stream: true });
 
-          // Try to parse accumulated text as JSON progressively
-          try {
-            const parsed = JSON.parse(accumulated);
-            // Map RecipeBlock → RecipeWithId (carry over the id and image fields)
-            const updatedRecipe: RecipeWithId = {
-              ...originalRecipeRef.current,
-              name: parsed.title ?? originalRecipeRef.current.name,
-              description: parsed.description ?? originalRecipeRef.current.description,
-              totalTimeMinutes: parsed.totalTimeMinutes ?? originalRecipeRef.current.totalTimeMinutes,
-              baseServings: parsed.baseServings ?? originalRecipeRef.current.baseServings,
-              ingredients: parsed.ingredients ?? originalRecipeRef.current.ingredients,
-              prep: parsed.prep ?? originalRecipeRef.current.prep,
-              steps: parsed.steps ?? originalRecipeRef.current.steps,
-              tags: parsed.tags ?? originalRecipeRef.current.tags,
-              instructions: originalRecipeRef.current.instructions,
-            };
-            setTweakedRecipe(updatedRecipe);
-          } catch {
-            // JSON not yet complete — keep accumulating
+            // Try to parse accumulated text as JSON progressively
+            try {
+              const parsed = JSON.parse(accumulated);
+              // Map RecipeBlock → RecipeWithId (carry over the id and image fields)
+              const updatedRecipe: RecipeWithId = {
+                ...originalRecipeRef.current,
+                name: parsed.title ?? originalRecipeRef.current.name,
+                description: parsed.description ?? originalRecipeRef.current.description,
+                totalTimeMinutes: parsed.totalTimeMinutes ?? originalRecipeRef.current.totalTimeMinutes,
+                baseServings: parsed.baseServings ?? originalRecipeRef.current.baseServings,
+                ingredients: parsed.ingredients ?? originalRecipeRef.current.ingredients,
+                prep: parsed.prep ?? originalRecipeRef.current.prep,
+                steps: parsed.steps ?? originalRecipeRef.current.steps,
+                tags: parsed.tags ?? originalRecipeRef.current.tags,
+                instructions: originalRecipeRef.current.instructions,
+              };
+              setTweakedRecipe(updatedRecipe);
+            } catch {
+              // JSON not yet complete — keep accumulating
+            }
           }
+        } finally {
+          reader.cancel().catch(() => {});
         }
 
         setTweakState("preview");
@@ -691,14 +769,13 @@ export default function RecipeDisplay({
         setTweakState("open");
       }
     },
-    [instruction, recipe.id, userId, tweakedRecipe],
+    [instruction, recipe.id, userId],
   );
 
   const tryAgain = useCallback(() => {
     setTweakedRecipe(originalRecipeRef.current);
     setInstruction("");
     setTweakState("open");
-    setTimeout(() => inputRef.current?.focus(), 80);
   }, []);
 
   const saveChanges = useCallback(async () => {
@@ -747,7 +824,6 @@ export default function RecipeDisplay({
   const tweakAgain = useCallback(() => {
     setInstruction("");
     setTweakState("open");
-    setTimeout(() => inputRef.current?.focus(), 80);
   }, []);
 
   const handleStartCooking = () => {
@@ -814,6 +890,9 @@ export default function RecipeDisplay({
                 selectedRecipe={tweakedRecipe}
                 changedIngredients={changedIngredients}
                 changedSteps={changedSteps}
+                deletedIngredients={deletedIngredients}
+                deletedSteps={deletedSteps}
+                originalRecipe={originalRecipeRef.current}
                 tweakState={tweakState}
                 onTweakClick={openTweak}
                 onTweakAgain={tweakAgain}

--- a/src/features/RecipeList/RecipeList.test.tsx
+++ b/src/features/RecipeList/RecipeList.test.tsx
@@ -1,6 +1,9 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { mutate } from "swr";
 import RecipeList from "./RecipeList";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({ useRouter: () => ({ push: mockPush }) }));
 
 jest.mock("streamdown", () => ({
   Streamdown: ({ children }: { children: React.ReactNode }) => (
@@ -72,31 +75,17 @@ describe("RecipeList — delete recipe", () => {
   });
 });
 
-describe("RecipeList — start cooking flow", () => {
-  it("closes the recipe modal and surfaces CookingMode when Start cooking is clicked", () => {
-    render(<RecipeList />);
-
-    // Open the recipe modal
-    fireEvent.click(screen.getByText("Test Recipe"));
-    const dialog = screen.getByRole("dialog");
-    expect(within(dialog).getByLabelText(/Start cooking/)).toBeInTheDocument();
-
-    // Click Start cooking
-    fireEvent.click(within(dialog).getByLabelText(/Start cooking/));
-
-    // Dialog should be gone, CookingMode should be visible
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    expect(screen.getByText(/Exit cooking mode/i)).toBeInTheDocument();
-    expect(screen.getByText("Step one")).toBeInTheDocument();
+describe("RecipeList — card navigation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
   });
 
-  it("advances to the next step when Next step is clicked from CookingMode", () => {
+  it("navigates to recipe page when card is clicked", () => {
     render(<RecipeList />);
-    fireEvent.click(screen.getByText("Test Recipe"));
-    fireEvent.click(within(screen.getByRole("dialog")).getByLabelText(/Start cooking/));
 
-    expect(screen.getByText("Step one")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Next step/i }));
-    expect(screen.getByText("Step two")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Test Recipe"));
+
+    expect(mockPush).toHaveBeenCalledWith("/recipe/r1");
   });
 });

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { useSessionContext } from "@/contexts/SessionContext";
-import { CookingMode } from "@/features/Recipe";
-import RecipeDisplay from "@/features/RecipeDisplay/RecipeDisplay";
-import { RecipeStep, RecipeWithId } from "@/lib/recipes/schemas";
+import { RecipeWithId } from "@/lib/recipes/schemas";
 import { fetcher } from "@/lib/utils";
-import { VisuallyHidden } from "radix-ui";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
@@ -22,10 +19,9 @@ interface RecipeListProps {
 
 export default function RecipeList({ onChatClick }: RecipeListProps) {
   const { userId } = useSessionContext();
+  const router = useRouter();
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [openRecipe, setOpenRecipe] = useState<RecipeWithId | null>(null);
-  const [cookingRecipe, setCookingRecipe] = useState<RecipeWithId | null>(null);
   const [showAdd, setShowAdd] = useState(false);
 
   const { data: recipes, isLoading } = useSWR<RecipeWithId[]>(
@@ -176,7 +172,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
               <RecipeCard
                 key={recipe.id}
                 recipe={recipe}
-                onSelect={(r) => setOpenRecipe(r)}
+                onSelect={(r) => router.push(`/recipe/${r.id}`)}
                 onDelete={deleteRecipe}
               />
             ))}
@@ -185,39 +181,6 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
       </div>
 
       <AddRecipeModal open={showAdd} onOpenChange={setShowAdd} />
-
-      <Dialog
-        open={!!openRecipe && !cookingRecipe}
-        onOpenChange={(o) => !o && setOpenRecipe(null)}
-      >
-        <DialogContent
-          showCloseButton={false}
-          className="max-w-3xl w-[95vw] sm:w-[92vw] h-[92vh] p-0 overflow-hidden bg-background"
-        >
-          <VisuallyHidden.Root>
-            <DialogTitle>{openRecipe?.name ?? "Recipe"}</DialogTitle>
-          </VisuallyHidden.Root>
-          {openRecipe && (
-            <RecipeDisplay
-              recipe={openRecipe}
-              onBack={() => setOpenRecipe(null)}
-              onStartCooking={() => {
-                setCookingRecipe(openRecipe);
-                setOpenRecipe(null);
-              }}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
-      {cookingRecipe && (
-        <CookingMode
-          title={cookingRecipe.name}
-          steps={(cookingRecipe.steps ?? []) as RecipeStep[]}
-          prep={(cookingRecipe.prep ?? []) as string[]}
-          onExit={() => setCookingRecipe(null)}
-        />
-      )}
     </div>
   );
 }

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -44,12 +44,8 @@ export async function deleteRecipeForUser(recipeId: string, userId: string) {
 }
 
 export async function updateRecipeForUser(id: string, userId: string, block: RecipeBlock) {
-  const existing = await prisma.recipe.findUnique({ where: { id } });
-  if (!existing || existing.userId !== userId) {
-    throw new Error("not found");
-  }
-  return await prisma.recipe.update({
-    where: { id },
+  const result = await prisma.recipe.updateMany({
+    where: { id, userId },
     data: {
       name: block.title,
       tags: normalizeTags(block.tags ?? []),
@@ -73,6 +69,10 @@ export async function updateRecipeForUser(id: string, userId: string, block: Rec
       instructions: block.description ?? "",
     },
   });
+  if (result.count === 0) {
+    throw new Error("not found");
+  }
+  return await prisma.recipe.findUnique({ where: { id } });
 }
 
 export async function saveRecipeFromBlock(block: RecipeBlock, userId: string, recipeId?: string) {

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -43,6 +43,34 @@ export async function deleteRecipeForUser(recipeId: string, userId: string) {
   }
 }
 
+export async function updateRecipe(id: string, block: RecipeBlock) {
+  return await prisma.recipe.update({
+    where: { id },
+    data: {
+      name: block.title,
+      tags: normalizeTags(block.tags ?? []),
+      baseServings: block.baseServings,
+      ingredients: block.ingredients.map((ing: RecipeIngredientModel) => ({
+        name: ing.name,
+        category: ing.category ?? "Misc",
+        amount:
+          ing.amount !== undefined
+            ? Number.isNaN(parseFloat(ing.amount))
+              ? undefined
+              : parseFloat(ing.amount)
+            : undefined,
+        unit: ing.unit,
+        note: ing.note,
+      })),
+      prep: block.prep ?? [],
+      steps: block.steps ?? [],
+      description: block.description,
+      totalTimeMinutes: block.totalTimeMinutes,
+      instructions: JSON.stringify(block),
+    },
+  });
+}
+
 export async function saveRecipeFromBlock(block: RecipeBlock, userId: string, recipeId?: string) {
   const tags = normalizeTags(block.tags ?? []);
   const photo = await fetchRecipePhoto(block.title, tags);

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -43,7 +43,11 @@ export async function deleteRecipeForUser(recipeId: string, userId: string) {
   }
 }
 
-export async function updateRecipe(id: string, block: RecipeBlock) {
+export async function updateRecipeForUser(id: string, userId: string, block: RecipeBlock) {
+  const existing = await prisma.recipe.findUnique({ where: { id } });
+  if (!existing || existing.userId !== userId) {
+    throw new Error("not found");
+  }
   return await prisma.recipe.update({
     where: { id },
     data: {
@@ -66,7 +70,7 @@ export async function updateRecipe(id: string, block: RecipeBlock) {
       steps: block.steps ?? [],
       description: block.description,
       totalTimeMinutes: block.totalTimeMinutes,
-      instructions: JSON.stringify(block),
+      instructions: block.description ?? "",
     },
   });
 }


### PR DESCRIPTION
## Summary

- **Modal → page**: Recipe cards in the Cookbook now navigate to `/recipe/[id]` (full page) instead of opening an in-page Dialog
- **`PATCH /api/recipe/[id]`**: New update endpoint — replaces an existing recipe in-place, scoped by `userId`, validated with `RecipeBlockSchema`
- **`POST /api/recipe/[id]/tweak`**: Dedicated single-turn AI route (separate from `/api/chat`) — streams a modified `RecipeBlock` back; system prompt constrains the model to targeted recipe modifications only
- **Recipe Tweak UI** (Direction C): 5-state interactive flow on the recipe page — inline "Want Ah Mah to tweak this?" button → pinned bottom bar → streaming in-place preview with diff highlighting → Save / Try again / Discard

## Architecture decisions

- ADR-0004: tweak route is separate from `/api/chat` (no conversation persistence, no inventory tools)
- Save replaces the existing recipe — no duplicate saved; preview-before-commit is the safety gate
- Quick-tweak chips: "Use what's in my pantry", "Swap for pantry staples", "Less spicy", "Make it quicker"

## Test Plan

- [ ] Click a recipe card in the Cookbook — navigates to `/recipe/[id]`, not a modal
- [ ] "Back to cookbook" on the recipe page returns to the cookbook tab
- [ ] Start Cooking still works from the recipe page
- [ ] "Want Ah Mah to tweak this?" button appears below the Ah Mah note
- [ ] Clicking it opens the pinned bottom bar with chips and input
- [ ] ✕ dismisses the bar and returns to resting state
- [ ] Submitting a tweak streams the updated recipe in-place; changed fields highlight in amber
- [ ] Deleted ingredients/steps appear with strikethrough
- [ ] "Save changes" replaces the recipe; "tweaked just now" label appears
- [ ] "Discard" resets to the original recipe
- [ ] "Try a different tweak" re-opens the input with focus
- [ ] Off-topic instruction (e.g. "give me chicken rice") gets a polite refusal from the model
- [ ] Mobile: bottom bar doesn't obscure the input when keyboard is open

## Closes

Closes #214, #215, #216, #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recipe tweak functionality enabling AI-powered recipe modifications with streaming preview
  * Visual highlighting of changed, added, and deleted ingredients and steps
  * Interactive preview screen with Save, Try Again, and Discard controls
  * Improved recipe navigation using routing instead of in-page dialogs

* **Documentation**
  * Added recipe tweak glossary and architectural decision documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->