### PR TITLE
test(conversation): fix tests to match deferred-creation behavior from #210

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,3 +55,13 @@ Related: [ADR-0001](docs/adr/0001-butter-is-where-you-are.md), [ADR-0003](docs/a
 The visual token reserved for "you, here, now" — the thing the user is currently reading or acting on. Applied to the active conversation row and the user's own message bubbles. Never applied to navigation items (those use `bg-card`).
 
 See [ADR-0001](docs/adr/0001-butter-is-where-you-are.md) for the full rationale.
+
+---
+
+## Recipe Tweak
+
+A single-turn AI modification of an existing saved recipe, initiated from the recipe page. The user types a refinement instruction (e.g. "add green chilli") and the AI streams an updated version of the same recipe in-place. A Recipe Tweak is not a full recipe prompt — it cannot generate a new, unrelated dish.
+
+The tweaked version is shown as a preview before the user confirms. On confirmation, the existing recipe is replaced (not duplicated). The AI call goes through a dedicated route (`POST /api/recipe/[id]/tweak`), separate from the chat pipeline.
+
+Related: [ADR-0004](docs/adr/0004-recipe-tweak-uses-dedicated-route.md)

--- a/docs/adr/0004-recipe-tweak-uses-dedicated-route.md
+++ b/docs/adr/0004-recipe-tweak-uses-dedicated-route.md
@@ -1,0 +1,25 @@
+# ADR-0004 — Recipe Tweak uses a dedicated API route
+
+**Status:** Accepted
+
+## Context
+
+The Recipe Tweak feature lets users refine a saved recipe via a short AI instruction (e.g. "add green chilli"). We needed to decide where the AI call should go: reuse the existing `/api/chat` route, or create a new dedicated route.
+
+## Decision
+
+Recipe Tweak uses `POST /api/recipe/[id]/tweak` — a separate, lean `streamText` call — rather than routing through `/api/chat`.
+
+## Reasons
+
+`/api/chat` carries infrastructure that a tweak does not need:
+- Conversation and message persistence
+- Inventory tool bindings (`addInventoryItem`, `getInventory`, `removeInventoryItem`)
+- Context window loading (`getMessages`, `CONTEXT_WINDOW = 15`)
+- `validateUIMessages` and multi-step logic (`stepCountIs(5)`)
+
+A Recipe Tweak is a single-turn call: "here is the recipe, here is the instruction, return an updated recipe block." Routing through chat would mean working around all of the above.
+
+## Trade-offs
+
+Using a dedicated route means a second AI entry point to maintain. The upside is that the tweak route stays small and purpose-built, and the chat route stays uncluttered.

--- a/src/app/api/conversation/route.test.ts
+++ b/src/app/api/conversation/route.test.ts
@@ -1,6 +1,5 @@
 import { GET, POST } from "./route";
 import {
-  getOrCreateActiveConversation,
   getOrCreateEmptyConversation,
   listConversations,
 } from "@/lib/conversations";
@@ -20,12 +19,10 @@ jest.mock("next/server", () => ({
 
 jest.mock("@/lib/conversations", () => ({
   listConversations: jest.fn(),
-  getOrCreateActiveConversation: jest.fn(),
   getOrCreateEmptyConversation: jest.fn(),
 }));
 
 const mockedListConversations = jest.mocked(listConversations);
-const mockedGetOrCreateActiveConversation = jest.mocked(getOrCreateActiveConversation);
 const mockedGetOrCreateEmptyConversation = jest.mocked(getOrCreateEmptyConversation);
 
 const createMockRequest = (url: string, options: RequestInit = {}) => {
@@ -67,24 +64,6 @@ function makeConversation(overrides: Partial<{
 describe("Conversation API Routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  describe("GET ?active=true", () => {
-    it("should return the active conversation for a user", async () => {
-      const conv = makeConversation({ id: "conv-active", userId: "test-user-123" });
-      mockedGetOrCreateActiveConversation.mockResolvedValue(conv);
-
-      const request = createMockRequest(
-        "http://localhost:3000/api/conversation?active=true&userId=test-user-123"
-      );
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data).toEqual({ conversation: conv });
-      expect(mockedGetOrCreateActiveConversation).toHaveBeenCalledWith("test-user-123");
-      expect(mockedListConversations).not.toHaveBeenCalled();
-    });
   });
 
   describe("GET /api/conversation", () => {

--- a/src/contexts/ConversationContext.test.tsx
+++ b/src/contexts/ConversationContext.test.tsx
@@ -101,21 +101,14 @@ describe("ConversationContext", () => {
     consoleSpy.mockRestore();
   });
 
-  it("sets activeConversationId from the active-conversation endpoint when localStorage is empty", async () => {
-    const conversation = makeConversation("conv-from-api");
-    swrData.set(
-      `/api/conversation?active=true&userId=${mockUserId}`,
-      { conversation }
-    );
+  it("starts in staging state (null) when localStorage is empty", () => {
     swrData.set(`/api/conversation?userId=${mockUserId}`, {
-      conversations: [conversation],
+      conversations: [makeConversation("conv-from-api")],
     });
 
     const { result } = renderHook(() => useConversationContext(), { wrapper });
 
-    await waitFor(() => {
-      expect(result.current.activeConversationId).toBe("conv-from-api");
-    });
+    expect(result.current.activeConversationId).toBe(null);
   });
 
   it("uses the localStorage value instead of fetching an active conversation", () => {
@@ -129,33 +122,24 @@ describe("ConversationContext", () => {
     expect(result.current.activeConversationId).toBe("conv-from-storage");
   });
 
-  it("startNewConversation reuses the server-returned empty conversation", async () => {
+  it("startNewConversation clears active id and enters staging state without a fetch", () => {
     const current = makeConversation("conv-current", {
       title: "Dinner",
       _count: { messages: 2 },
     });
-    const empty = makeConversation("conv-empty");
     localStorageMock.getItem.mockReturnValueOnce("conv-current");
     swrData.set(`/api/conversation?userId=${mockUserId}`, {
-      conversations: [current, empty],
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ conversation: empty }),
+      conversations: [current],
     });
 
     const { result } = renderHook(() => useConversationContext(), { wrapper });
 
-    await act(async () => {
-      await result.current.startNewConversation();
+    act(() => {
+      result.current.startNewConversation();
     });
 
-    expect(mockFetch).toHaveBeenCalledWith("/api/conversation", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userId: mockUserId }),
-    });
-    expect(result.current.activeConversationId).toBe("conv-empty");
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.activeConversationId).toBe(null);
   });
 
   it("renameConversation PATCHes the given id", async () => {
@@ -232,7 +216,9 @@ describe("ConversationContext", () => {
       await result.current.deleteConversation("conv-delete");
     });
 
-    expect(result.current.activeConversationId).toBe("conv-delete");
+    await waitFor(() => {
+      expect(result.current.activeConversationId).toBe("conv-delete");
+    });
     expect(toast.error).toHaveBeenCalledWith(
       "Could not delete conversation. Try again."
     );
@@ -240,25 +226,18 @@ describe("ConversationContext", () => {
 
   it("deleteConversation rolls back to original active id when no fallback exists and DELETE fails", async () => {
     const { toast } = await import("sonner");
-    // Only one conversation with messages — no fallback will be found, so startNewConversation runs
+    // Only one conversation with messages — enters staging state, then rolls back on failure
     const active = makeConversation("conv-only", {
       title: "Solo Chat",
       _count: { messages: 2 },
     });
-    const newConv = makeConversation("conv-new");
     localStorageMock.getItem.mockReturnValueOnce("conv-only");
     swrData.set(`/api/conversation?userId=${mockUserId}`, {
       conversations: [active],
     });
 
-    // First fetch: POST to create new conversation (startNewConversation)
-    // Second fetch: DELETE that fails
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ conversation: newConv }),
-      })
-      .mockResolvedValueOnce({ ok: false });
+    // DELETE fails
+    mockFetch.mockResolvedValueOnce({ ok: false });
 
     const { result } = renderHook(() => useConversationContext(), { wrapper });
 
@@ -267,7 +246,9 @@ describe("ConversationContext", () => {
     });
 
     // After DELETE failure the original active id must be restored
-    expect(result.current.activeConversationId).toBe("conv-only");
+    await waitFor(() => {
+      expect(result.current.activeConversationId).toBe("conv-only");
+    });
     // SWR cache rolled back — globalMutate called with previousConversations (the original list)
     expect(mockMutate).toHaveBeenCalledWith(
       `/api/conversation?userId=${mockUserId}`,


### PR DESCRIPTION
## Summary
- Removes the stale `GET ?active=true` test from `route.test.ts` — this route branch was deleted in #210
- Updates `ConversationContext.test.tsx` to reflect that `activeConversationId` starts `null` (staging state) when localStorage is empty
- Updates `startNewConversation` test to call synchronously with no fetch expected (no longer async or API-driven)
- Adds `waitFor` to two `deleteConversation` rollback tests to handle React 18 batched state flush
- Removes stale `mockFetch` setup that was consuming the DELETE mock slot in the no-fallback rollback test

## Test plan
- [ ] `pnpm test` passes — all 316 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)