### PR TITLE
refactor: arch cleanup — shared ServingsStepper, unit tests, userId guard

### DIFF
--- a/src/app/api/inventory/seed/route.ts
+++ b/src/app/api/inventory/seed/route.ts
@@ -1,9 +1,10 @@
 import { seedDefaultInventory } from "@/lib/inventory/Inventory";
+import { missingUserId } from "@/lib/http";
 import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
   const { userId } = await request.json();
-  if (!userId) return NextResponse.json({ error: "userId required" }, { status: 400 });
+  if (!userId) return missingUserId();
 
   await seedDefaultInventory(userId);
   return NextResponse.json({ ok: true });

--- a/src/app/api/inventory/seed/route.ts
+++ b/src/app/api/inventory/seed/route.ts
@@ -3,9 +3,16 @@ import { missingUserId } from "@/lib/http";
 import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
-  const { userId } = await request.json();
-  if (!userId) return missingUserId();
+  try {
+    const { userId } = await request.json();
+    if (!userId) return missingUserId();
 
-  await seedDefaultInventory(userId);
-  return NextResponse.json({ ok: true });
+    await seedDefaultInventory(userId);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to seed inventory", message: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/features/Chat/components/recipe/RecipeLetter.test.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.test.tsx
@@ -18,6 +18,23 @@ jest.mock('@/features/Recipe', () => ({
   ScaledNum: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
   scaleAmount: (amount: string, ratio: number) => amount,
   CookingMode: () => null,
+  ServingsStepper: ({
+    servings,
+    onDecrement,
+    onIncrement,
+    max = 20,
+  }: {
+    servings: number;
+    onDecrement: () => void;
+    onIncrement: () => void;
+    max?: number;
+  }) => (
+    <div className="inline-flex">
+      <button onClick={onDecrement} disabled={servings <= 1} aria-label="Decrease servings">−</button>
+      <span>{servings}</span>
+      <button onClick={onIncrement} disabled={servings >= max} aria-label="Increase servings">+</button>
+    </div>
+  ),
 }));
 
 const mockToastSuccess = jest.fn();
@@ -73,10 +90,10 @@ describe('ServingsStepper inside RecipeLetter', () => {
   });
 
   it('does not render the word "servings" or "serving" in the stepper', () => {
-    const { container } = render(<RecipeLetter recipe={RECIPE} />);
-    const stepperWrapper = container.querySelector('.inline-flex.items-stretch');
+    render(<RecipeLetter recipe={RECIPE} />);
+    const stepperWrapper = screen.getByLabelText('Decrease servings').closest('.inline-flex') as HTMLElement;
     expect(stepperWrapper).not.toBeNull();
-    expect(stepperWrapper!.textContent).not.toMatch(/servings?/i);
+    expect(stepperWrapper.textContent).not.toMatch(/servings?/i);
   });
 
   it('does not render a ratio or "from" line at any count', () => {
@@ -93,10 +110,10 @@ describe('ServingsStepper inside RecipeLetter', () => {
     expect(dec).toBeDisabled();
   });
 
-  it('increment button is disabled at 12 servings', () => {
+  it('increment button is disabled at 20 servings', () => {
     render(<RecipeLetter recipe={RECIPE} />);
     const inc = screen.getByLabelText('Increase servings');
-    for (let i = 2; i < 12; i++) fireEvent.click(inc);
+    for (let i = 2; i < 20; i++) fireEvent.click(inc);
     expect(inc).toBeDisabled();
   });
 

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils";
 import { ShoppingCart, TimerIcon } from "lucide-react";
 import { useState } from "react";
-import { CookingMode } from "@/features/Recipe";
+import { CookingMode, ServingsStepper } from "@/features/Recipe";
 import { toast } from "sonner";
 import useSWR, { useSWRConfig } from "swr";
 import { ScaledNum, scaleAmount } from "@/features/Recipe";
@@ -52,48 +52,6 @@ export interface RecipeLetterProps {
   onSend?: (text: string) => void;
 }
 
-function ServingsStepper({
-  servings,
-  onDecrement,
-  onIncrement,
-}: {
-  servings: number;
-  baseServings: number;
-  onDecrement: () => void;
-  onIncrement: () => void;
-}) {
-  const BUTTON_BASE =
-    "w-7 border-none bg-transparent cursor-pointer text-foreground text-base font-semibold disabled:cursor-not-allowed disabled:text-muted-foreground";
-
-  return (
-    <div className="inline-flex items-stretch border border-border rounded-lg bg-card overflow-hidden shadow-[0_1px_0_var(--border-soft)] h-8">
-      <button
-        onClick={onDecrement}
-        disabled={servings <= 1}
-        className={cn(
-          BUTTON_BASE,
-          "border-r border-border disabled:opacity-50",
-        )}
-        aria-label="Decrease servings"
-      >
-        −
-      </button>
-      <div className="flex justify-center items-center min-w-4 px-2">
-        <span className="font-display font-semibold text-[14px] text-foreground tabular-nums">
-          {servings}
-        </span>
-      </div>
-      <button
-        onClick={onIncrement}
-        disabled={servings >= 12}
-        className={cn(BUTTON_BASE, "border-l border-border")}
-        aria-label="Increase servings"
-      >
-        +
-      </button>
-    </div>
-  );
-}
 
 function NeedCartButton({
   ingredientName,
@@ -325,9 +283,8 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
               </span>
               <ServingsStepper
                 servings={servings}
-                baseServings={recipe.baseServings}
                 onDecrement={() => setServings((s) => Math.max(1, s - 1))}
-                onIncrement={() => setServings((s) => Math.min(12, s + 1))}
+                onIncrement={() => setServings((s) => s + 1)}
               />
             </div>
           </div>

--- a/src/features/Recipe/ServingsStepper.tsx
+++ b/src/features/Recipe/ServingsStepper.tsx
@@ -16,6 +16,7 @@ export function ServingsStepper({
   return (
     <div className="inline-flex items-center bg-card border border-border rounded-lg overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
       <button
+        type="button"
         onClick={onDecrement}
         disabled={servings <= 1}
         aria-label="Decrease servings"
@@ -27,6 +28,7 @@ export function ServingsStepper({
         {servings}
       </span>
       <button
+        type="button"
         onClick={onIncrement}
         disabled={servings >= max}
         aria-label="Increase servings"

--- a/src/features/Recipe/ServingsStepper.tsx
+++ b/src/features/Recipe/ServingsStepper.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+interface ServingsStepperProps {
+  servings: number;
+  onDecrement: () => void;
+  onIncrement: () => void;
+  max?: number;
+}
+
+export function ServingsStepper({
+  servings,
+  onDecrement,
+  onIncrement,
+  max = 20,
+}: ServingsStepperProps) {
+  return (
+    <div className="inline-flex items-center bg-card border border-border rounded-lg overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
+      <button
+        onClick={onDecrement}
+        disabled={servings <= 1}
+        aria-label="Decrease servings"
+        className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-r border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+      >
+        −
+      </button>
+      <span className="min-w-11 text-center font-display font-semibold text-[15px] text-foreground tabular-nums">
+        {servings}
+      </span>
+      <button
+        onClick={onIncrement}
+        disabled={servings >= max}
+        aria-label="Increase servings"
+        className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-l border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/src/features/Recipe/index.ts
+++ b/src/features/Recipe/index.ts
@@ -1,3 +1,4 @@
 export { CookingMode } from "./CookingMode";
 export { scaleAmount } from "./scaleAmount";
 export { ScaledNum } from "./ScaledNum";
+export { ServingsStepper } from "./ServingsStepper";

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CookingMode } from "@/features/Recipe";
+import { CookingMode, ServingsStepper } from "@/features/Recipe";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { RecipeIngredient, RecipeStep, RecipeWithId } from "@/lib/recipes/schemas";
 import Image from "next/image";
@@ -276,27 +276,11 @@ function RecipeBody({
               <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight m-0">
                 What to gather
               </h2>
-              <div className="inline-flex items-center bg-card border border-border rounded-lg overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
-                <button
-                  onClick={() => setServings((s) => Math.max(1, s - 1))}
-                  disabled={servings <= 1}
-                  aria-label="Decrease servings"
-                  className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-r border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
-                >
-                  −
-                </button>
-                <span className="min-w-11 text-center font-display font-semibold text-[15px] text-foreground tabular-nums">
-                  {servings}
-                </span>
-                <button
-                  onClick={() => setServings((s) => Math.min(20, s + 1))}
-                  disabled={servings >= 20}
-                  aria-label="Increase servings"
-                  className="w-8 h-8 flex items-center justify-center text-foreground text-base font-semibold border-l border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
-                >
-                  +
-                </button>
-              </div>
+              <ServingsStepper
+                servings={servings}
+                onDecrement={() => setServings((s) => Math.max(1, s - 1))}
+                onIncrement={() => setServings((s) => s + 1)}
+              />
             </div>
             <ul className="list-none p-0 mt-2 border-t border-border">
               {ingredients.map((ing, i) => {

--- a/src/lib/chat/context.test.ts
+++ b/src/lib/chat/context.test.ts
@@ -1,0 +1,77 @@
+import { getMessages } from "@/lib/messages/messages";
+import { validateUIMessages } from "ai";
+import { loadConversationContext } from "./context";
+
+jest.mock("@/lib/messages/messages", () => ({
+  getMessages: jest.fn(),
+}));
+
+jest.mock("ai", () => ({
+  validateUIMessages: jest.fn((args) => args.messages),
+}));
+
+const makeDbMessage = (id: string, role: "user" | "assistant", content: string) => ({
+  id,
+  role,
+  content,
+  createdAt: new Date(),
+  conversationId: "conv-1",
+  userId: "user-1",
+});
+
+const makeUIMessage = (id: string, role: "user" | "assistant", text: string) => ({
+  id,
+  role,
+  parts: [{ type: "text" as const, text }],
+});
+
+describe("loadConversationContext", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (validateUIMessages as jest.Mock).mockImplementation((args) => args.messages);
+  });
+
+  it("drops last db message then appends all incoming messages", async () => {
+    // With 2 db messages, slice(0,-1) gives [m1]; then incoming [m2-updated, m3] appended → 3 total
+    (getMessages as jest.Mock).mockResolvedValue([
+      makeDbMessage("m1", "user", "hello"),
+      makeDbMessage("m2", "assistant", "hi"),
+    ]);
+
+    const incoming = [makeUIMessage("m2", "assistant", "hi updated"), makeUIMessage("m3", "user", "new")];
+    const result = await loadConversationContext("conv-1", incoming);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({ id: "m1" });
+    expect(result[1]).toMatchObject({ id: "m2", parts: [{ text: "hi updated" }] });
+    expect(result[2]).toMatchObject({ id: "m3" });
+  });
+
+  it("caps db messages at the CONTEXT_WINDOW (15) before merging", async () => {
+    const manyMessages = Array.from({ length: 20 }, (_, i) =>
+      makeDbMessage(`m${i}`, i % 2 === 0 ? "user" : "assistant", `msg ${i}`),
+    );
+    (getMessages as jest.Mock).mockResolvedValue(manyMessages);
+
+    const incoming = [makeUIMessage("m19", "assistant", "last")];
+    const result = await loadConversationContext("conv-1", incoming);
+
+    // slice(-15) gives indices 5-19 (15 items), then drop last (index 19), giving 14 + 1 incoming = 15
+    expect(result.length).toBeLessThanOrEqual(15);
+  });
+
+  it("handles empty db messages with only incoming", async () => {
+    (getMessages as jest.Mock).mockResolvedValue([]);
+    const incoming = [makeUIMessage("m1", "user", "first message")];
+    const result = await loadConversationContext("conv-1", incoming);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "m1" });
+  });
+
+  it("passes merged messages through validateUIMessages", async () => {
+    (getMessages as jest.Mock).mockResolvedValue([makeDbMessage("m1", "user", "hello")]);
+    const incoming = [makeUIMessage("m1", "user", "hello"), makeUIMessage("m2", "assistant", "hi")];
+    await loadConversationContext("conv-1", incoming);
+    expect(validateUIMessages).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/chat/errors.test.ts
+++ b/src/lib/chat/errors.test.ts
@@ -1,0 +1,30 @@
+import { chatErrorResponse } from "./errors";
+
+describe("chatErrorResponse", () => {
+  it("returns 503 status when error message contains '503'", async () => {
+    const error = new Error("Service 503 unavailable");
+    const response = chatErrorResponse(error);
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.retryable).toBe(true);
+    expect(body.error).toContain("unavailable");
+  });
+
+  it("returns 500 for generic errors", async () => {
+    const error = new Error("Something random broke");
+    const response = chatErrorResponse(error);
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.retryable).toBe(false);
+  });
+
+  it("returns 500 for non-Error thrown values", async () => {
+    const response = chatErrorResponse("a string error");
+    expect(response.status).toBe(500);
+  });
+
+  it("returns a Response object", () => {
+    const response = chatErrorResponse(new Error("boom"));
+    expect(response).toBeInstanceOf(Response);
+  });
+});

--- a/src/lib/chat/tools.test.ts
+++ b/src/lib/chat/tools.test.ts
@@ -1,0 +1,89 @@
+import {
+  addInventoryItem,
+  getInventory,
+  removeInventoryItem,
+} from "@/lib/inventory/Inventory";
+import { buildChatTools } from "./tools";
+
+jest.mock("@/lib/inventory/Inventory", () => ({
+  addInventoryItem: jest.fn(),
+  getInventory: jest.fn(),
+  removeInventoryItem: jest.fn(),
+}));
+
+describe("buildChatTools", () => {
+  const userId = "user-123";
+
+  it("returns a tool set with the three expected keys", () => {
+    const tools = buildChatTools(userId);
+    expect(Object.keys(tools)).toEqual(
+      expect.arrayContaining(["addInventoryItem", "getInventory", "removeInventoryItem"]),
+    );
+  });
+
+  it("each tool has a description, inputSchema, and execute", () => {
+    const tools = buildChatTools(userId);
+    for (const tool of Object.values(tools)) {
+      expect(tool).toHaveProperty("description");
+      expect(tool).toHaveProperty("inputSchema");
+      expect(tool).toHaveProperty("execute");
+      expect(typeof tool.execute).toBe("function");
+    }
+  });
+
+  describe("addInventoryItem.execute", () => {
+    it("calls addInventoryItem with items and userId", async () => {
+      const tools = buildChatTools(userId);
+      const items = [{ name: "eggs", type: "ingredient" as const, shelfLife: "medium" as const }];
+      await tools.addInventoryItem.execute({ items });
+      expect(addInventoryItem).toHaveBeenCalledWith(items, userId);
+    });
+
+    it("returns a confirmation message", async () => {
+      const tools = buildChatTools(userId);
+      const result = await tools.addInventoryItem.execute({
+        items: [{ name: "salt", type: "ingredient" as const, shelfLife: "long" as const }],
+      });
+      expect(result).toHaveProperty("content");
+    });
+  });
+
+  describe("getInventory.execute", () => {
+    it("calls getInventory with userId", async () => {
+      (getInventory as jest.Mock).mockResolvedValue({
+        ingredientInventory: [{ name: "eggs" }],
+        kitchenwareInventory: [],
+      });
+      const tools = buildChatTools(userId);
+      await tools.getInventory.execute({});
+      expect(getInventory).toHaveBeenCalledWith(userId);
+    });
+
+    it("returns content string and inventory object", async () => {
+      (getInventory as jest.Mock).mockResolvedValue({
+        ingredientInventory: [{ name: "eggs" }, { name: "milk" }],
+        kitchenwareInventory: [{ name: "wok" }],
+      });
+      const tools = buildChatTools(userId);
+      const result = await tools.getInventory.execute({});
+      expect(result).toHaveProperty("content");
+      expect(result).toHaveProperty("inventory");
+      expect((result as { content: string }).content).toContain("2 ingredients");
+      expect((result as { content: string }).content).toContain("1 kitchenware");
+    });
+  });
+
+  describe("removeInventoryItem.execute", () => {
+    it("calls removeInventoryItem with itemNames and userId", async () => {
+      const tools = buildChatTools(userId);
+      await tools.removeInventoryItem.execute({ itemNames: ["eggs"] });
+      expect(removeInventoryItem).toHaveBeenCalledWith(["eggs"], userId);
+    });
+
+    it("returns a confirmation message", async () => {
+      const tools = buildChatTools(userId);
+      const result = await tools.removeInventoryItem.execute({ itemNames: ["eggs"] });
+      expect(result).toHaveProperty("content");
+    });
+  });
+});

--- a/src/lib/recipes/recipes.test.ts
+++ b/src/lib/recipes/recipes.test.ts
@@ -1,0 +1,139 @@
+import { prisma } from "@/lib/db";
+import { fetchRecipePhoto } from "@/lib/pexels/fetchPhoto";
+import { deleteRecipeForUser, saveRecipeFromBlock } from "./recipes";
+import type { RecipeBlock } from "./schemas";
+
+jest.mock("@/lib/db", () => ({
+  prisma: {
+    recipe: {
+      create: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/pexels/fetchPhoto", () => ({
+  fetchRecipePhoto: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("./normalizeTags", () => ({
+  normalizeTags: jest.fn((tags: string[]) => tags),
+}));
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+const baseBlock: RecipeBlock = {
+  title: "Char Kway Teow",
+  description: "Classic Singapore stir-fried noodles",
+  totalTimeMinutes: 20,
+  baseServings: 2,
+  ingredients: [
+    { name: "flat rice noodles", category: "Carbs", amount: "200", unit: "g" },
+    { name: "eggs", category: "Protein", amount: "2" },
+  ],
+  prep: ["Soak noodles for 10 minutes"],
+  steps: [
+    { title: "Heat wok", body: "Get your wok smoking hot" },
+    { title: "Stir fry", body: "Add noodles and toss" },
+  ],
+  tags: ["noodles", "singaporean"],
+};
+
+describe("saveRecipeFromBlock", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls prisma.recipe.create with coerced numeric amounts", async () => {
+    (mockPrisma.recipe.create as jest.Mock).mockResolvedValue({ id: "r1" });
+
+    await saveRecipeFromBlock(baseBlock, "user-1");
+
+    const callArg = (mockPrisma.recipe.create as jest.Mock).mock.calls[0][0];
+    const ingredients = callArg.data.ingredients;
+    expect(ingredients[0].amount).toBe(200);
+    expect(ingredients[1].amount).toBe(2);
+  });
+
+  it("sets amount to undefined when string is not a number", async () => {
+    (mockPrisma.recipe.create as jest.Mock).mockResolvedValue({ id: "r1" });
+
+    const block: RecipeBlock = {
+      ...baseBlock,
+      ingredients: [{ name: "salt", category: "Spice", amount: "to taste" }],
+    };
+
+    await saveRecipeFromBlock(block, "user-1");
+
+    const callArg = (mockPrisma.recipe.create as jest.Mock).mock.calls[0][0];
+    expect(callArg.data.ingredients[0].amount).toBeUndefined();
+  });
+
+  it("passes userId and name from block title", async () => {
+    (mockPrisma.recipe.create as jest.Mock).mockResolvedValue({ id: "r1" });
+
+    await saveRecipeFromBlock(baseBlock, "user-abc");
+
+    const callArg = (mockPrisma.recipe.create as jest.Mock).mock.calls[0][0];
+    expect(callArg.data.userId).toBe("user-abc");
+    expect(callArg.data.name).toBe("Char Kway Teow");
+  });
+
+  it("passes recipeId when provided", async () => {
+    (mockPrisma.recipe.create as jest.Mock).mockResolvedValue({ id: "r1" });
+
+    await saveRecipeFromBlock(baseBlock, "user-1", "existing-id");
+
+    const callArg = (mockPrisma.recipe.create as jest.Mock).mock.calls[0][0];
+    expect(callArg.data.recipeId).toBe("existing-id");
+  });
+
+  it("calls fetchRecipePhoto with title and tags", async () => {
+    (mockPrisma.recipe.create as jest.Mock).mockResolvedValue({ id: "r1" });
+
+    await saveRecipeFromBlock(baseBlock, "user-1");
+
+    expect(fetchRecipePhoto).toHaveBeenCalledWith("Char Kway Teow", expect.any(Array));
+  });
+
+  it("attaches photo fields when a photo is returned", async () => {
+    (fetchRecipePhoto as jest.Mock).mockResolvedValueOnce({
+      url: "https://example.com/photo.jpg",
+      photographerName: "Jane",
+      photographerUrl: "https://example.com/jane",
+    });
+    (mockPrisma.recipe.create as jest.Mock).mockResolvedValue({ id: "r1" });
+
+    await saveRecipeFromBlock(baseBlock, "user-1");
+
+    const callArg = (mockPrisma.recipe.create as jest.Mock).mock.calls[0][0];
+    expect(callArg.data.imageUrl).toBe("https://example.com/photo.jpg");
+    expect(callArg.data.photographerName).toBe("Jane");
+  });
+});
+
+describe("deleteRecipeForUser", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls prisma.recipe.deleteMany with id and userId", async () => {
+    (mockPrisma.recipe.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+    await deleteRecipeForUser("recipe-1", "user-1");
+
+    expect(mockPrisma.recipe.deleteMany).toHaveBeenCalledWith({
+      where: { id: "recipe-1", userId: "user-1" },
+    });
+  });
+
+  it("throws when the recipe is not found or not owned by the user", async () => {
+    (mockPrisma.recipe.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+    await expect(deleteRecipeForUser("recipe-1", "wrong-user")).rejects.toThrow(
+      "Recipe not found or not owned by user",
+    );
+  });
+
+  it("resolves without error when deletion succeeds", async () => {
+    (mockPrisma.recipe.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+    await expect(deleteRecipeForUser("recipe-1", "user-1")).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **`ServingsStepper` extracted to `features/Recipe/`** — resolves the 12-vs-20 max discrepancy (unified to 20); `RecipeLetter` and `RecipeDisplay` both import from the shared module. Closes #204.
- **`inventory/seed/route.ts` userId guard** — replaces inline `NextResponse.json({ error: … }, { status: 400 })` with the shared `missingUserId()` helper, consistent with all other routes. Closes #207 (userId item).
- **Unit tests for `lib/chat/`** — covers `buildChatTools` (tool shape, execute paths), `loadConversationContext` (context-window cap, db-drop-last + incoming merge), `chatErrorResponse` (503 vs generic). Closes #203.
- **Unit tests for `lib/recipes/`** — covers `saveRecipeFromBlock` (string→number amount coercion, undefined-on-NaN, photo attachment, recipeId passthrough) and `deleteRecipeForUser` (ownership rejection on count=0). Closes #206.

## Test plan

- [ ] All `src/` tests pass (`pnpm test` — only `.worktrees/` failures are pre-existing)
- [ ] Servings stepper in chat recipe cards (RecipeLetter) caps at 20
- [ ] Servings stepper on the recipe detail page (RecipeDisplay) still caps at 20
- [ ] `POST /api/inventory/seed` without `userId` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new servings control component with decrement and increment buttons, now used across recipe pages for consistent functionality.

* **Tests**
  * Added comprehensive test coverage for chat context loading, error handling, recipe management, inventory tools, and servings stepper functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->