### PR TITLE
refactor(prompts): single source of truth for domain rules via PROMPT_FRAGMENTS

### DIFF
--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -1,3 +1,5 @@
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
+
 export const CHAT_SYSTEM_PROMPT = `You are Ah Mah, a warm Singaporean grandmother who teaches home cooking. You speak warmly and casually, with the occasional "lah", "ah", or "aiyah" landing naturally — not performatively.
 
 **Off-topic policy.** You only know cooking. For anything else — science, history, news, politics, weather, math, sports, anything not food/cooking/kitchen — DO NOT attempt an answer. No explanations, no half-explanations, no "but since you ask…" pivots into facts. A granny doesn't lecture on Rayleigh scattering. Reply short and warm, in character, then offer a cooking turn. Examples:
@@ -12,18 +14,11 @@ When you explain technique, lean on the science of why it works — Maillard rea
 
 - \`getInventory\` — call this before suggesting recipes or answering "what can I cook". If empty, ask the user what they have rather than guess blind. Do NOT call it for general cooking knowledge questions (e.g., "what's the difference between baking soda and baking powder"). When the inventory includes equipment (wok, pressure cooker, air fryer, slow cooker, etc.), always adapt the recipe method to that equipment — adjust timing, technique, and instructions accordingly without waiting to be asked.
 - \`addInventoryItem\` — when the user mentions buying or having something, add it. If the user just says "I have X" or "bought X" with no recipe request, call this and acknowledge briefly — do NOT pivot to suggestions. Always set \`shelfLife\` for every item:
-  - "short" — leafy greens, herbs, seafood, dairy, cooked leftovers, mushrooms
-  - "medium" — most meat, most fresh produce, eggs, tofu, bread
-  - "long" — oils, dry goods (rice, pasta, flour), spices, sauces, canned/bottled goods, kitchenware
-  - "frozen" — anything stored in the freezer (frozen vegetables, frozen meat, frozen dumplings, ice cream, sukiyaki/shabu slices sold frozen). If the user later thaws it, update shelfLife back to the underlying value ("short" for seafood/meat, etc.).
+${PROMPT_FRAGMENTS.shelfLifeRules}
+  If the user later thaws a frozen item, update shelfLife back to the underlying value ("short" for seafood/meat, etc.).
   Only set \`quantity\`/\`unit\` when the user explicitly states an amount (e.g., "200g chicken", "2 eggs"). Otherwise leave them unset — unset means "they have it, amount unlimited".
   Always set \`category\` for ingredients (omit for kitchenware):
-  - "Protein" — meat, poultry, seafood, eggs, tofu, tempeh, legumes
-  - "Carbs" — rice, noodles, pasta, bread, flour, potatoes, starches
-  - "Vegetable" — all produce, herbs, mushrooms (incl. dried), leafy greens, aromatics (garlic, ginger, spring onion)
-  - "Condiments" — sauces, oils, vinegars, pastes, sugar, salt
-  - "Spice" — dry spices and spice blends (pepper, cumin, paprika, chili flakes, garam masala)
-  - "Misc" — fruit, dairy, snacks, anything that doesn't clearly fit above
+${PROMPT_FRAGMENTS.categoryRules}
 - \`removeInventoryItem\` — when the user says they've finished or thrown out something.
 
 When choosing units in the ingredient list, prefer the units the user already has in inventory. If their inventory says "200g chicken breast", write grams in the recipe — not pounds — so the app can compute shortfalls accurately.
@@ -97,17 +92,12 @@ Emit:
 
 Rules:
 - \`amount\` is always a string (handles "1 1/2", "½", "500", etc.)
-- Every ingredient MUST include \`category\` and it must be one of: "Protein", "Carbs", "Vegetable", "Condiments", "Spice", "Misc".
+- Every ingredient MUST include \`category\` and it must be one of: ${PROMPT_FRAGMENTS.categoryList}.
 - \`description\` is ≤140 chars — the soul of the dish in one sentence.
 - \`prep\` 0–8 short imperative strings covering ALL knife work (dice, mince, chop, slice), marinating, beating, soaking, scoring — anything BEFORE heat. If a step says "the diced X" or "the marinated Y", that prep MUST be in this array. Omit \`prep\` (or use \`[]\`) for assemble-only recipes with no real prep.
 - \`tip\` on a step is optional — only add when the why/trick is non-obvious.
 - \`tags\` 3–6 tags. EVERY tag MUST come from one of these exact lists. If you cannot find a match in these lists, DO NOT emit the tag:
-  - cuisine: italian, chinese, japanese, mexican, indian, thai, french, mediterranean, american, korean, vietnamese, middle-eastern, greek, spanish, moroccan, malaysian, singaporean, filipino, asian, western, african, latin-american
-  - main: chicken, beef, pork, fish, seafood, eggs, tofu, beans, lentils, rice, noodle, pasta, bread, dumpling, pancake
-  - method: baked, fried, grilled, steamed, boiled, roasted, sauteed, stir-fried, braised, slow-cooked, pressure-cooked, air-fried, no-cook, raw, marinated, fermented, pickled, stew, blended
-  - meal: breakfast, lunch, dinner, snack, appetizer, dessert, side-dish, main-course, soup, salad, beverage, condiment
-  - effort: easy, quick (under 30 min), one-pot, make-ahead, oven-free
-  - style: crispy, creamy, spicy, sweet, savory, tangy, hearty, light, refreshing, warming, comfort, numbing
+${PROMPT_FRAGMENTS.tagCatalog}
   Do NOT invent variants (e.g. "minced-beef" → use "beef"; "tortilla" or "wrap" → use "bread"; "one-pan" → use "one-pot"). Do NOT use ingredient names as tags (no "onion", "garlic", etc.).
 - A brief warm sentence BEFORE the block is fine (e.g. "Here it is — the way I make it:").
 

--- a/src/app/api/inventory/parse/route.ts
+++ b/src/app/api/inventory/parse/route.ts
@@ -1,6 +1,7 @@
 import { addInventoryItem } from "@/lib/inventory/Inventory";
 import { AddInventoryItemSchema } from "@/lib/inventory/schemas";
 import { missingUserId } from "@/lib/http";
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { NextRequest, NextResponse } from "next/server";
@@ -29,18 +30,10 @@ RULES:
 - Each item gets: name, type ("ingredient" | "kitchenware"), shelfLife ("short" | "medium" | "long" | "frozen"), and OPTIONAL quantity + unit.
 - ONLY set quantity/unit when the user explicitly states an amount (e.g., "200g chicken" → quantity=200, unit="g"; "2 chicken breasts" → quantity=2, unit="pieces"). If they say "some bok choy" or just "eggs", LEAVE quantity AND unit UNSET — unset means "they have it, amount unlimited".
 - shelfLife rules:
-  - "short" — leafy greens, herbs, seafood, dairy, cooked leftovers, fresh fish, mushrooms
-  - "medium" — most meat, most fresh produce, eggs, tofu, bread
-  - "long" — oils, dry goods (rice, pasta, flour), spices, sauces, canned/bottled goods, ALL kitchenware
-  - "frozen" — anything explicitly stored in the freezer (frozen vegetables, frozen meat, frozen dumplings, ice cream, sukiyaki/shabu slices sold frozen)
+${PROMPT_FRAGMENTS.shelfLifeRules}
 - type rules: kitchenware = pots, pans, utensils, appliances. Everything edible = ingredient.
 - category rules (REQUIRED for type=ingredient, OMIT for type=kitchenware):
-  - "Protein" — meat, poultry, seafood, eggs, tofu, tempeh, legumes
-  - "Carbs" — rice, noodles, pasta, bread, flour, potatoes, starches
-  - "Vegetable" — all produce, herbs, mushrooms (incl. dried), leafy greens, aromatics (garlic, ginger, spring onion)
-  - "Condiments" — sauces, oils, vinegars, pastes, sugar, salt
-  - "Spice" — dry spices and spice blends (pepper, cumin, paprika, chili flakes, garam masala)
-  - "Misc" — fruit, dairy, snacks, anything that doesn't clearly fit above
+${PROMPT_FRAGMENTS.categoryRules}
 - Normalize names to singular, title case where natural ("chicken breasts" → "Chicken breast", "bok choy" → "Bok choy").
 - unit MUST come from this allowlist if used: g, kg, oz, lb, ml, l, cup, tbsp, tsp, piece, pieces, clove, cloves, bottle, bottles, can, cans, pack, packs, bunch, bunches, pinch, dash, slice, slices.
 

--- a/src/lib/prompts/fragments.ts
+++ b/src/lib/prompts/fragments.ts
@@ -1,0 +1,51 @@
+import { CategorySchema, ShelfLifeSchema } from "@/lib/inventory/schemas";
+import { TAG_SETS } from "@/lib/recipes/tagColors";
+
+const CATEGORY_EXAMPLES: Record<string, string> = {
+  Protein: "meat, poultry, seafood, eggs, tofu, tempeh, legumes",
+  Carbs: "rice, noodles, pasta, bread, flour, potatoes, starches",
+  Vegetable:
+    "all produce, herbs, mushrooms (incl. dried), leafy greens, aromatics (garlic, ginger, spring onion)",
+  Condiments: "sauces, oils, vinegars, pastes, sugar, salt",
+  Spice:
+    "dry spices and spice blends (pepper, cumin, paprika, chili flakes, garam masala)",
+  Misc: "fruit, dairy, snacks, anything that doesn't clearly fit above",
+};
+
+const SHELF_LIFE_EXAMPLES: Record<string, string> = {
+  short:
+    "leafy greens, herbs, seafood, dairy, cooked leftovers, fresh fish, mushrooms",
+  medium: "most meat, most fresh produce, eggs, tofu, bread",
+  long: "oils, dry goods (rice, pasta, flour), spices, sauces, canned/bottled goods, ALL kitchenware",
+  frozen:
+    "anything explicitly stored in the freezer (frozen vegetables, frozen meat, frozen dumplings, ice cream, sukiyaki/shabu slices sold frozen)",
+};
+
+function buildCategoryRules(): string {
+  return CategorySchema.options
+    .map((cat) => `  - "${cat}" — ${CATEGORY_EXAMPLES[cat] ?? cat.toLowerCase()}`)
+    .join("\n");
+}
+
+function buildShelfLifeRules(): string {
+  return ShelfLifeSchema.options
+    .map((v) => `  - "${v}" — ${SHELF_LIFE_EXAMPLES[v] ?? v}`)
+    .join("\n");
+}
+
+function buildTagCatalog(): string {
+  return Object.entries(TAG_SETS)
+    .map(([cat, tags]) => `${cat.toUpperCase()}: ${(tags as readonly string[]).join(", ")}`)
+    .join("\n");
+}
+
+export const PROMPT_FRAGMENTS = {
+  /** Full "value — examples" block for ingredient category rules. */
+  categoryRules: buildCategoryRules(),
+  /** Comma-separated list of valid category values for brief inline references. */
+  categoryList: CategorySchema.options.join(", "),
+  /** Full "value — examples" block for shelfLife rules. */
+  shelfLifeRules: buildShelfLifeRules(),
+  /** Tag catalog string for recipe tag selection prompts. */
+  tagCatalog: buildTagCatalog(),
+} as const;

--- a/src/lib/recipes/parseRecipeText.ts
+++ b/src/lib/recipes/parseRecipeText.ts
@@ -1,12 +1,8 @@
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { RecipeBlockSchema, type RecipeBlock } from "./schemas";
-import { TAG_SETS } from "./tagColors";
 import { normalizeTags } from "./normalizeTags";
-
-const TAG_CATEGORIES = Object.entries(TAG_SETS)
-  .map(([cat, tags]) => `${cat.toUpperCase()}: ${tags.join(", ")}`)
-  .join("\n");
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 
 export async function parseRecipeText(text: string): Promise<RecipeBlock> {
   const result = await generateObject({
@@ -21,7 +17,7 @@ FIELDS:
 - baseServings: number of servings as written; infer 2–4 if unstated
 - totalTimeMinutes: total time in minutes if stated; omit if not mentioned
 - ingredients: array of { name, category, amount, unit, note }
-  - category must be one of: Protein, Carbs, Vegetable, Condiments, Spice, Misc
+  - category must be one of: ${PROMPT_FRAGMENTS.categoryList}
   - amount is a string (e.g. "1 1/2", "200") — omit for "to taste" items
   - unit is the normalised unit string after applying the UNIT NORMALIZATION rules below
 - prep: array of short imperative strings for knife work and prep done BEFORE heat (e.g. "Dice 1 onion", "Mince 3 cloves garlic"). Empty array if no real prep.
@@ -75,7 +71,7 @@ Temperatures in step bodies — convert °F to °C (formula: (F−32)×5/9, roun
 Fallback — if you are not confident about a conversion, keep the source unit and add a brief note explaining the original value.
 
 TAG CATEGORIES:
-${TAG_CATEGORIES}
+${PROMPT_FRAGMENTS.tagCatalog}
 
 RECIPE TEXT:
 ${text}`,

--- a/src/lib/recipes/recipeProcessor.ts
+++ b/src/lib/recipes/recipeProcessor.ts
@@ -1,9 +1,9 @@
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { z } from "zod";
-import { TAG_SETS } from "./tagColors";
 import { normalizeTags } from "./normalizeTags";
 import { CategorySchema } from "@/lib/inventory/schemas";
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 
 // Extract metadata from a recipe. We don't ask the model to re-emit the
 // recipe text — passing raw instructions through is more reliable and the
@@ -73,10 +73,6 @@ const RecipeMetadataSchema = z.object({
 
 export type RecipeMetadata = z.infer<typeof RecipeMetadataSchema>;
 
-const TAG_CATEGORIES = Object.entries(TAG_SETS)
-  .map(([cat, tags]) => `${cat.toUpperCase()}: ${tags.join(", ")}`)
-  .join("\n");
-
 export async function processRecipe(
   recipeName: string,
   recipeInstructions: string,
@@ -87,7 +83,7 @@ TASKS:
 1. Choose 3-8 tags. ONLY use exact tag names from the list below — do not invent new tags, do not use ingredient names (e.g. "onion", "garlic") as tags. If unsure, prefer fewer correct tags over more guesses.
 2. Identify baseServings — how many servings the recipe makes (infer 2 or 4 if unstated).
 3. Extract ingredients as { name, category, amount?, unit? }.
-   - category must be one of: Protein, Carbs, Vegetable, Condiments, Spice, Misc.
+   - category must be one of: ${PROMPT_FRAGMENTS.categoryList}.
    - Use the exact unit strings the recipe uses.
    - Omit amount/unit for non-quantified items like "salt to taste".
 4. Write a description: one evocative sentence ≤140 chars. Capture the soul of the dish — not a step list. e.g. "Sunday lunch staple — rice poached in chicken stock, finished with ginger-scallion oil."
@@ -95,7 +91,7 @@ TASKS:
 6. Extract prep — all knife work, marinating, beating, soaking that happens BEFORE heat. Each item is a short imperative ("Dice 1 bell pepper"). If a step references "the diced X" or "the marinated Y", that prep MUST appear here. Empty array if there's no real prep.
 
 TAG CATEGORIES:
-${TAG_CATEGORIES}
+${PROMPT_FRAGMENTS.tagCatalog}
 
 RECIPE NAME: ${recipeName}
 


### PR DESCRIPTION
## Summary

- Creates `src/lib/prompts/fragments.ts` exporting `PROMPT_FRAGMENTS` — a single object with `categoryRules`, `categoryList`, `shelfLifeRules`, and `tagCatalog` strings, each built programmatically from the Zod schemas (`CategorySchema`, `ShelfLifeSchema`) and `TAG_SETS`
- The same domain rules (ingredient categories, shelf-life enums, tag taxonomy) no longer live as prose repeated across 4 LLM prompts — every prompt now imports and interpolates from `PROMPT_FRAGMENTS`
- Adding a new Zod enum value (e.g. a new ingredient category) automatically flows into every prompt with zero manual copy

**Files updated:**
| File | Fragments consumed |
|---|---|
| `src/app/api/chat/constants.ts` | `shelfLifeRules`, `categoryRules`, `categoryList`, `tagCatalog` |
| `src/app/api/inventory/parse/route.ts` | `shelfLifeRules`, `categoryRules` |
| `src/lib/recipes/recipeProcessor.ts` | `categoryList`, `tagCatalog` (removes local `TAG_CATEGORIES`) |
| `src/lib/recipes/parseRecipeText.ts` | `categoryList`, `tagCatalog` (removes local `TAG_CATEGORIES`) |

## Test plan

- [ ] `pnpm tsc --noEmit` — no new errors in modified files
- [ ] All `src/` tests pass
- [ ] Spot-check: parse a freeform inventory entry via the UI — categories and shelf-life still classify correctly
- [ ] Spot-check: request a recipe — tags still come from the known taxonomy only

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated prompt template configurations into a centralized fragments module to improve code maintainability. Updated API endpoints and recipe-processing modules to reference shared prompt rules, category configurations, and tag catalogs, reducing duplication across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->