### PR TITLE
feat(recipe): Tweak Bench — multi-turn recipe refinement with structural diff

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,10 +58,20 @@ See [ADR-0001](docs/adr/0001-butter-is-where-you-are.md) for the full rationale.
 
 ---
 
+## Tweak Bench
+
+The interactive right-side panel that hosts a multi-turn recipe refinement session. A user opens the Tweak Bench from a recipe page and sends one or more instructions; each instruction is a **Recipe Tweak**. State is ephemeral — the turn log and working draft live only in memory while the bench is open. Saving commits the working draft to the cookbook; Discarding or closing collapses the bench and the draft evaporates.
+
+The bench displays a "What changed" checklist (decorative, read-only) alongside an inline diff overlay on the recipe (NEW chips, "was X" strikethrough, highlighted rows). Both views are driven by the structured change list returned by the model — they cannot disagree.
+
+Related: [ADR-0005](docs/adr/0005-tweak-bench-multi-turn.md)
+
+---
+
 ## Recipe Tweak
 
-A single-turn AI modification of an existing saved recipe, initiated from the recipe page. The user types a refinement instruction (e.g. "add green chilli") and the AI streams an updated version of the same recipe in-place. A Recipe Tweak is not a full recipe prompt — it cannot generate a new, unrelated dish.
+A single turn within a **Tweak Bench** session. The user types one refinement instruction (e.g. "use chicken instead of tofu") and the AI streams an updated recipe block plus a structured change list. A Recipe Tweak cannot generate a wholly unrelated dish — the model refuses in plain text and leaves the working draft unchanged.
 
-The tweaked version is shown as a preview before the user confirms. On confirmation, the existing recipe is replaced (not duplicated). The AI call goes through a dedicated route (`POST /api/recipe/[id]/tweak`), separate from the chat pipeline.
+The AI call goes through a dedicated route (`POST /api/recipe/[id]/tweak`), separate from the chat pipeline.
 
-Related: [ADR-0004](docs/adr/0004-recipe-tweak-uses-dedicated-route.md)
+Related: [ADR-0005](docs/adr/0005-tweak-bench-multi-turn.md)

--- a/docs/adr/0004-recipe-tweak-uses-dedicated-route.md
+++ b/docs/adr/0004-recipe-tweak-uses-dedicated-route.md
@@ -1,6 +1,6 @@
 # ADR-0004 — Recipe Tweak uses a dedicated API route
 
-**Status:** Accepted
+**Status:** Superseded by [ADR-0005](0005-tweak-bench-multi-turn.md)
 
 ## Context
 

--- a/docs/adr/0005-tweak-bench-multi-turn.md
+++ b/docs/adr/0005-tweak-bench-multi-turn.md
@@ -1,0 +1,43 @@
+# ADR-0005 — Tweak Bench is multi-turn with a structured change list
+
+**Status:** Accepted  
+**Supersedes:** [ADR-0004](0004-recipe-tweak-uses-dedicated-route.md)
+
+## Context
+
+ADR-0004 established that Recipe Tweak uses a dedicated route (`POST /api/recipe/[id]/tweak`) rather than the chat pipeline. That part stands.
+
+What changed: the original design was single-turn (one instruction → one preview → save or discard). The new design replaces the bottom input bar with a **Tweak Bench** — a right-side panel supporting multiple turns of iterative refinement, paired with an inline structural diff on the recipe.
+
+Two decisions needed to be made:
+
+1. **Multi-turn vs. single-turn.** The bench layout implies iteration ("anything still off?"). But ADR-0004 explicitly chose single-turn.
+2. **How to drive the inline diff.** The mockup shows per-row annotations (NEW chips, "was X" strikethrough, step highlights) alongside a narrative "What changed" panel. These two views must stay in sync.
+
+## Decisions
+
+### Multi-turn within an ephemeral session
+
+The Tweak Bench supports multiple turns within one open session. The turn log and working draft are in-memory only — no DB persistence, no localStorage. Saving commits the working draft; Discarding or closing collapses the bench and the draft evaporates. "Try a different tweak" resets the log and draft to the original without closing the bench.
+
+### Model returns recipe + structured change list
+
+Each turn the model returns a JSON object with:
+- `recipe` — the full updated `RecipeBlock`
+- `changes` — an array of `{ kind, ref, label }` entries
+
+`ref` is a structural anchor (ingredient name or step index) that drives the inline diff overlay. `label` is narrative text rendered in the "What changed" panel. Because both views read from the same source, they cannot disagree.
+
+The change list is **cumulative against the original saved recipe** — not against the previous turn's draft. The route receives both `originalRecipe` and `workingDraft`; the model applies the instruction to `workingDraft` but writes the change list against `originalRecipe`. This means the diff overlay always answers "what am I about to commit to my cookbook."
+
+### Checkmarks are decorative
+
+The "What changed" entries are read-only. Users correct unwanted changes by typing a new instruction. This keeps the model as the single source of truth for the draft and prevents client-side mutation from creating inconsistencies.
+
+## Why not alternatives
+
+**Keeping single-turn:** "Try a different tweak" already implied a reset path; making each turn an explicit commit-and-restart forced users to re-type context they'd already established. Multi-turn with an ephemeral session avoids a new DB entity while still supporting iteration.
+
+**Client-side diff only (no model change list):** Would require structural diffing of two `RecipeBlock` objects. Ingredient and step matching is ambiguous (no stable IDs). The narrative labels ("to velvet the chicken") cannot be derived from a structural diff — they require the model's reasoning. Hybrid is the only way to guarantee coherence between the panel and the inline overlay.
+
+**Interactive toggles on the change list:** Each "undo" toggle would produce an inconsistent draft (e.g., chicken in ingredients, step still says "marinate the chicken"). The multi-turn path already handles this more expressively. Decorative checkmarks kept the model authoritative.

--- a/docs/adr/0005-tweak-bench-multi-turn.md
+++ b/docs/adr/0005-tweak-bench-multi-turn.md
@@ -26,7 +26,7 @@ Each turn the model returns a JSON object with:
 - `recipe` — the full updated `RecipeBlock`
 - `changes` — an array of `{ kind, ref, label }` entries
 
-`ref` is a structural anchor (ingredient name or step index) that drives the inline diff overlay. `label` is narrative text rendered in the "What changed" panel. Because both views read from the same source, they cannot disagree.
+`ref` is an optional structural locator object (`type`, `index`, `basis`) that drives the inline diff overlay for ingredient and step rows. It uses `workingDraft` indices for visible added/changed rows and `original` indices for removed rows. `label` is narrative text rendered in the "What changed" panel. Because both views read from the same source, they cannot disagree.
 
 The change list is **cumulative against the original saved recipe** — not against the previous turn's draft. The route receives both `originalRecipe` and `workingDraft`; the model applies the instruction to `workingDraft` but writes the change list against `originalRecipe`. This means the diff overlay always answers "what am I about to commit to my cookbook."
 

--- a/src/app/api/recipe/[id]/tweak/route.ts
+++ b/src/app/api/recipe/[id]/tweak/route.ts
@@ -39,14 +39,21 @@ Return ONLY a valid JSON object matching this schema — no markdown fences, no 
 {
   "recipe": { ${RECIPE_FIELDS} },
   "changes": [
-    { "kind": "<one of: ${CHANGE_KINDS}>", "ref": "<ingredient name or step index>", "label": "<narrative label>" }
+    {
+      "kind": "<one of: ${CHANGE_KINDS}>",
+      "ref": { "type": "ingredient|step", "index": 0, "basis": "original|workingDraft" },
+      "label": "<narrative label>"
+    }
   ]
 }
 \`\`\`
 
 The \`changes\` array must list **every structural delta against the original recipe** (not against the working draft). Each entry needs:
 - \`kind\`: the type of change
-- \`ref\`: for ingredient changes, the ingredient name; for step changes, the step index (0-based number); omit for recipe-level changes (title, description, tags, servings, time)
+- \`ref\`: omit for recipe-level changes (title, description, tags, servings, time). For row changes, use a structural locator with:
+  - \`type\`: "ingredient" or "step"
+  - \`index\`: a 0-based row index
+  - \`basis\`: "workingDraft" for rows visible in the returned recipe (\`ingredient_added\`, \`ingredient_changed\`, \`step_added\`, \`step_replaced\`); "original" for removed rows (\`ingredient_removed\`, \`step_removed\`)
 - \`label\`: a short narrative label in Ah Mah's voice (e.g. "Added cornstarch to velvet the chicken")`;
 }
 
@@ -94,11 +101,20 @@ export async function POST(
       return NextResponse.json({ error: "recipe id mismatch" }, { status: 400 });
     }
 
-    // workingDraft defaults to originalRecipe on the first turn
-    const parsedDraft = workingDraftRaw
-      ? RecipeBlockWithIdSchema.safeParse(workingDraftRaw)
-      : parsedOriginal;
-    const workingDraft = parsedDraft.success ? parsedDraft.data : parsedOriginal.data;
+    let workingDraft = parsedOriginal.data;
+    if (workingDraftRaw !== undefined) {
+      const parsedDraft = RecipeBlockWithIdSchema.safeParse(workingDraftRaw);
+      if (!parsedDraft.success) {
+        return NextResponse.json(
+          { error: "Invalid workingDraft payload", details: parsedDraft.error.flatten() },
+          { status: 400 }
+        );
+      }
+      if (parsedDraft.data.id !== id) {
+        return NextResponse.json({ error: "workingDraft id mismatch" }, { status: 400 });
+      }
+      workingDraft = parsedDraft.data;
+    }
 
     const result = streamText({
       model: openai("gpt-4.1-mini"),

--- a/src/app/api/recipe/[id]/tweak/route.ts
+++ b/src/app/api/recipe/[id]/tweak/route.ts
@@ -1,30 +1,53 @@
 import { missingUserId } from "@/lib/http";
-import { RecipeBlockSchema } from "@/lib/recipes/schemas";
-import type { RecipeWithId } from "@/lib/recipes/schemas";
+import { RecipeBlockSchema, TweakResponseSchema } from "@/lib/recipes/schemas";
 import { openai } from "@ai-sdk/openai";
 import { streamText } from "ai";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
-const RecipeWithIdSchema = RecipeBlockSchema.extend({ id: z.string() });
+// The client sends blocks (recipeWithIdToBlock already applied) — validate directly
+const RecipeBlockWithIdSchema = RecipeBlockSchema.extend({ id: z.string() });
+type RecipeBlockWithId = z.infer<typeof RecipeBlockWithIdSchema>;
 
 const MAX_INSTRUCTION_LENGTH = 500;
 
+const CHANGE_KINDS = TweakResponseSchema.shape.changes.element.shape.kind.options.join(", ");
 const RECIPE_FIELDS = Object.keys(RecipeBlockSchema.shape).join(", ");
 
-function buildSystemPrompt(recipe: RecipeWithId): string {
-  return `You are a recipe editor. Your task is to apply a targeted modification to the following recipe.
+function buildSystemPrompt(originalRecipe: RecipeBlockWithId, workingDraft: RecipeBlockWithId): string {
+  return `You are a recipe editor. Apply the user's instruction to the working draft, then return a JSON object describing the result.
 
-## Current recipe
+## Original recipe (the saved cookbook version — change list anchors against this)
 \`\`\`json
-${JSON.stringify(recipe, null, 2)}
+${JSON.stringify(originalRecipe, null, 2)}
+\`\`\`
+
+## Working draft (apply the instruction to this)
+\`\`\`json
+${JSON.stringify(workingDraft, null, 2)}
 \`\`\`
 
 ## Instructions
-- Apply the user's instruction as a precise, minimal change — keep all unaffected fields exactly as they are.
-- Return ONLY a valid JSON object matching the RecipeBlock schema. Do not wrap it in markdown fences or add any surrounding text.
-- RecipeBlock fields: ${RECIPE_FIELDS}
-- If the user's request would produce a wholly different dish unrelated to the current recipe, politely refuse in plain text (not JSON) and explain why.`;
+- Apply the user's instruction as a precise, minimal change to the working draft.
+- Keep all unaffected fields exactly as they are in the working draft.
+- Update the \`description\` ("Ah Mah's note") if the dish character meaningfully changes (e.g. protein swap, cuisine shift). Include a \`description_updated\` change entry when you do.
+- If the request would produce a wholly different dish unrelated to the current recipe, politely refuse in plain text (not JSON) and explain why.
+
+## Response format
+Return ONLY a valid JSON object matching this schema — no markdown fences, no surrounding text:
+\`\`\`
+{
+  "recipe": { ${RECIPE_FIELDS} },
+  "changes": [
+    { "kind": "<one of: ${CHANGE_KINDS}>", "ref": "<ingredient name or step index>", "label": "<narrative label>" }
+  ]
+}
+\`\`\`
+
+The \`changes\` array must list **every structural delta against the original recipe** (not against the working draft). Each entry needs:
+- \`kind\`: the type of change
+- \`ref\`: for ingredient changes, the ingredient name; for step changes, the step index (0-based number); omit for recipe-level changes (title, description, tags, servings, time)
+- \`label\`: a short narrative label in Ah Mah's voice (e.g. "Added cornstarch to velvet the chicken")`;
 }
 
 export async function POST(
@@ -34,10 +57,14 @@ export async function POST(
   const { id } = await params;
 
   try {
-    const body: { userId?: string; instruction?: string; recipe?: RecipeWithId } =
-      await req.json();
+    const body: {
+      userId?: string;
+      instruction?: string;
+      originalRecipe?: unknown;
+      workingDraft?: unknown;
+    } = await req.json();
 
-    const { userId, recipe } = body;
+    const { userId, originalRecipe: originalRecipeRaw, workingDraft: workingDraftRaw } = body;
     let { instruction } = body;
 
     if (!userId) return missingUserId();
@@ -50,24 +77,34 @@ export async function POST(
       return NextResponse.json({ error: "instruction is required" }, { status: 400 });
     }
 
-    if (!recipe) {
-      return NextResponse.json({ error: "recipe is required" }, { status: 400 });
+    if (!originalRecipeRaw) {
+      return NextResponse.json({ error: "originalRecipe is required" }, { status: 400 });
     }
 
-    const parsedRecipe = RecipeWithIdSchema.safeParse(recipe);
-    if (!parsedRecipe.success) {
-      return NextResponse.json({ error: "Invalid recipe payload", details: parsedRecipe.error.flatten() }, { status: 400 });
+    // Client sends block format (recipeWithIdToBlock already applied) — validate directly
+    const parsedOriginal = RecipeBlockWithIdSchema.safeParse(originalRecipeRaw);
+    if (!parsedOriginal.success) {
+      return NextResponse.json(
+        { error: "Invalid originalRecipe payload", details: parsedOriginal.error.flatten() },
+        { status: 400 }
+      );
     }
 
-    if (parsedRecipe.data.id !== id) {
+    if (parsedOriginal.data.id !== id) {
       return NextResponse.json({ error: "recipe id mismatch" }, { status: 400 });
     }
 
+    // workingDraft defaults to originalRecipe on the first turn
+    const parsedDraft = workingDraftRaw
+      ? RecipeBlockWithIdSchema.safeParse(workingDraftRaw)
+      : parsedOriginal;
+    const workingDraft = parsedDraft.success ? parsedDraft.data : parsedOriginal.data;
+
     const result = streamText({
       model: openai("gpt-4.1-mini"),
-      system: buildSystemPrompt(recipe),
+      system: buildSystemPrompt(parsedOriginal.data, workingDraft),
       messages: [{ role: "user", content: instruction }],
-      maxOutputTokens: 1500,
+      maxOutputTokens: 2000,
     });
 
     return result.toTextStreamResponse();

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -51,37 +51,49 @@ function changesToDiff(
 
   if (!changes.length) return { changedIngredients, deletedIngredients, changedSteps, deletedSteps };
 
-  const addedOrChangedNames = new Set(
-    changes
-      .filter((c) => c.kind === "ingredient_added" || c.kind === "ingredient_changed")
-      .map((c) => String(c.ref)),
-  );
-  workingDraft.ingredients.forEach((ing, i) => {
-    if (addedOrChangedNames.has(ing.name)) changedIngredients.add(i);
+  changes.forEach((change) => {
+    const ref = change.ref;
+    if (!ref) return;
+
+    if (
+      ref.type === "ingredient" &&
+      ref.basis === "workingDraft" &&
+      ref.index < workingDraft.ingredients.length &&
+      (change.kind === "ingredient_added" || change.kind === "ingredient_changed")
+    ) {
+      changedIngredients.add(ref.index);
+      return;
+    }
+
+    if (
+      ref.type === "ingredient" &&
+      ref.basis === "original" &&
+      ref.index < original.ingredients.length &&
+      change.kind === "ingredient_removed"
+    ) {
+      deletedIngredients.add(ref.index);
+      return;
+    }
+
+    if (
+      ref.type === "step" &&
+      ref.basis === "workingDraft" &&
+      ref.index < (workingDraft.steps?.length ?? 0) &&
+      (change.kind === "step_added" || change.kind === "step_replaced")
+    ) {
+      changedSteps.add(ref.index);
+      return;
+    }
+
+    if (
+      ref.type === "step" &&
+      ref.basis === "original" &&
+      ref.index < (original.steps?.length ?? 0) &&
+      change.kind === "step_removed"
+    ) {
+      deletedSteps.add(ref.index);
+    }
   });
-
-  const removedNames = new Set(
-    changes
-      .filter((c) => c.kind === "ingredient_removed")
-      .map((c) => String(c.ref)),
-  );
-  original.ingredients.forEach((ing, i) => {
-    if (removedNames.has(ing.name)) deletedIngredients.add(i);
-  });
-
-  changes
-    .filter((c) => c.kind === "step_replaced" || c.kind === "step_added")
-    .forEach((c) => {
-      const idx = Number(c.ref);
-      if (!isNaN(idx)) changedSteps.add(idx);
-    });
-
-  changes
-    .filter((c) => c.kind === "step_removed")
-    .forEach((c) => {
-      const idx = Number(c.ref);
-      if (!isNaN(idx)) deletedSteps.add(idx);
-    });
 
   return { changedIngredients, deletedIngredients, changedSteps, deletedSteps };
 }

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -3,14 +3,17 @@
 import { useSessionContext } from "@/contexts/SessionContext";
 import { CookingMode, ServingsStepper } from "@/features/Recipe";
 import {
-  RecipeIngredient,
-  RecipeStep,
-  RecipeWithId,
+  type ChangeEntry,
+  type RecipeIngredient,
+  type RecipeStep,
+  type RecipeWithId,
+  recipeWithIdToBlock,
 } from "@/lib/recipes/schemas";
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Streamdown } from "streamdown";
+import { TweakBench } from "./TweakBench";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -34,88 +37,65 @@ const formatTime = (minutes: number): string => {
   return m > 0 ? `${h} h ${m} m` : `${h} h`;
 };
 
-// ─── Tweak state machine ─────────────────────────────────────────────────────
+// ─── Diff overlay (derived from model change list) ───────────────────────────
 
-type TweakState = "resting" | "open" | "streaming" | "preview" | "saved";
-
-const QUICK_TWEAKS = [
-  "Use what's in my pantry",
-  "Swap for pantry staples",
-  "Less spicy",
-  "Make it quicker",
-];
-
-// ─── Changed-field tracking ──────────────────────────────────────────────────
-
-function diffRecipes(
+function changesToDiff(
+  changes: ChangeEntry[],
+  workingDraft: RecipeWithId,
   original: RecipeWithId,
-  tweaked: RecipeWithId,
-): {
-  ingredients: Set<number>;
-  steps: Set<number>;
-  deletedIngredients: Set<number>;
-  deletedSteps: Set<number>;
-} {
+) {
   const changedIngredients = new Set<number>();
-  const changedSteps = new Set<number>();
   const deletedIngredients = new Set<number>();
+  const changedSteps = new Set<number>();
   const deletedSteps = new Set<number>();
 
-  const origIngs = (original.ingredients || []) as RecipeIngredient[];
-  const tweakIngs = (tweaked.ingredients || []) as RecipeIngredient[];
+  if (!changes.length) return { changedIngredients, deletedIngredients, changedSteps, deletedSteps };
 
-  const ingLen = Math.max(origIngs.length, tweakIngs.length);
-  for (let i = 0; i < ingLen; i++) {
-    const orig = origIngs[i];
-    const ing = tweakIngs[i];
-    if (!ing) {
-      // Row deleted by AI — mark the original index as deleted
-      deletedIngredients.add(i);
-    } else if (
-      !orig ||
-      orig.name !== ing.name ||
-      orig.amount !== ing.amount ||
-      orig.unit !== ing.unit
-    ) {
-      changedIngredients.add(i);
-    }
-  }
+  const addedOrChangedNames = new Set(
+    changes
+      .filter((c) => c.kind === "ingredient_added" || c.kind === "ingredient_changed")
+      .map((c) => String(c.ref)),
+  );
+  workingDraft.ingredients.forEach((ing, i) => {
+    if (addedOrChangedNames.has(ing.name)) changedIngredients.add(i);
+  });
 
-  const origSteps = (original.steps || []) as RecipeStep[];
-  const tweakSteps = (tweaked.steps || []) as RecipeStep[];
+  const removedNames = new Set(
+    changes
+      .filter((c) => c.kind === "ingredient_removed")
+      .map((c) => String(c.ref)),
+  );
+  original.ingredients.forEach((ing, i) => {
+    if (removedNames.has(ing.name)) deletedIngredients.add(i);
+  });
 
-  const stepsLen = Math.max(origSteps.length, tweakSteps.length);
-  for (let i = 0; i < stepsLen; i++) {
-    const orig = origSteps[i];
-    const step = tweakSteps[i];
-    if (!step) {
-      deletedSteps.add(i);
-    } else if (!orig || orig.body !== step.body || orig.title !== step.title) {
-      changedSteps.add(i);
-    }
-  }
+  changes
+    .filter((c) => c.kind === "step_replaced" || c.kind === "step_added")
+    .forEach((c) => {
+      const idx = Number(c.ref);
+      if (!isNaN(idx)) changedSteps.add(idx);
+    });
 
-  return {
-    ingredients: changedIngredients,
-    steps: changedSteps,
-    deletedIngredients,
-    deletedSteps,
-  };
+  changes
+    .filter((c) => c.kind === "step_removed")
+    .forEach((c) => {
+      const idx = Number(c.ref);
+      if (!isNaN(idx)) deletedSteps.add(idx);
+    });
+
+  return { changedIngredients, deletedIngredients, changedSteps, deletedSteps };
 }
 
 // ─── RecipeBody ──────────────────────────────────────────────────────────────
 
 interface RecipeBodyProps {
   selectedRecipe: RecipeWithId;
-  /** Fields that changed compared to original (highlight them) */
   changedIngredients?: Set<number>;
   changedSteps?: Set<number>;
-  /** Rows present in original but removed by AI tweak */
   deletedIngredients?: Set<number>;
   deletedSteps?: Set<number>;
-  /** Original recipe — needed to render deleted rows */
   originalRecipe?: RecipeWithId;
-  tweakState: TweakState;
+  showHighlights?: boolean;
 }
 
 function RecipeBody({
@@ -125,24 +105,18 @@ function RecipeBody({
   deletedIngredients = new Set(),
   deletedSteps = new Set(),
   originalRecipe,
-  tweakState,
+  showHighlights = false,
 }: RecipeBodyProps) {
   const [servings, setServings] = useState<number>(
     selectedRecipe.baseServings ?? 2,
   );
   const baseServings = selectedRecipe.baseServings || 2;
   const ingredients = (selectedRecipe.ingredients || []) as RecipeIngredient[];
-  const origIngredients = (originalRecipe?.ingredients ||
-    []) as RecipeIngredient[];
+  const origIngredients = (originalRecipe?.ingredients || []) as RecipeIngredient[];
   const origSteps = (originalRecipe?.steps || []) as RecipeStep[];
   const prep = (selectedRecipe.prep ?? []) as string[];
   const steps = (selectedRecipe.steps || []) as RecipeStep[];
   const scale = servings / baseServings;
-
-  const showHighlights =
-    tweakState === "streaming" ||
-    tweakState === "preview" ||
-    tweakState === "saved";
 
   return (
     <>
@@ -230,13 +204,8 @@ function RecipeBody({
               />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint mb-1 flex items-center gap-2">
+              <div className="font-sans text-[10.5px] font-bold tracking-[0.16em] uppercase text-ink-faint mb-1">
                 From Ah Mah
-                {tweakState === "saved" && (
-                  <span className="text-emerald-600 tracking-[0.14em]">
-                    · tweaked just now
-                  </span>
-                )}
               </div>
               <div className="font-display italic text-[15px] sm:text-base text-foreground leading-[1.5] max-w-prose">
                 {selectedRecipe.description}
@@ -259,7 +228,7 @@ function RecipeBody({
           </div>
         )}
 
-        {/* Ingredients — header inline with servings stepper */}
+        {/* Ingredients */}
         {ingredients.length > 0 && (
           <section className="mb-9">
             <div className="flex items-center justify-between mb-1 gap-3">
@@ -303,7 +272,7 @@ function RecipeBody({
                   </li>
                 );
               })}
-              {/* Deleted ingredients — shown with strikethrough when tweaking */}
+              {/* Deleted ingredients */}
               {showHighlights &&
                 Array.from(deletedIngredients).map((i) => {
                   const ing = origIngredients[i];
@@ -399,7 +368,7 @@ function RecipeBody({
                   </li>
                 );
               })}
-              {/* Deleted steps — shown with strikethrough when tweaking */}
+              {/* Deleted steps */}
               {showHighlights &&
                 Array.from(deletedSteps).map((i) => {
                   const step = origSteps[i];
@@ -439,206 +408,6 @@ function RecipeBody({
   );
 }
 
-// ─── Workshop card (Direction B — floating, not sticky) ──────────────────────
-
-const TweakIcon = () => (
-  <svg
-    width="13"
-    height="13"
-    viewBox="0 0 16 16"
-    fill="none"
-    className="shrink-0"
-  >
-    <path
-      d="M3 10.5 L8.5 5 L11 7.5 L5.5 13 H3 V10.5 Z M8.5 5 L10 3.5 L12.5 6 L11 7.5"
-      stroke="currentColor"
-      strokeWidth="1.4"
-      strokeLinejoin="round"
-      fill="none"
-    />
-  </svg>
-);
-
-interface WorkshopCardProps {
-  tweakState: TweakState;
-  instruction: string;
-  totalChanges: number;
-  onInstructionChange: (v: string) => void;
-  onSend: (prompt?: string) => void;
-  onDismiss: () => void;
-  onSave: () => void;
-  onTryAgain: () => void;
-  onDiscard: () => void;
-  isSaving: boolean;
-  inputRef: React.RefObject<HTMLInputElement | null>;
-}
-
-function WorkshopCard({
-  tweakState,
-  instruction,
-  totalChanges,
-  onInstructionChange,
-  onSend,
-  onDismiss,
-  onSave,
-  onTryAgain,
-  onDiscard,
-  isSaving,
-  inputRef,
-}: WorkshopCardProps) {
-  if (
-    tweakState !== "open" &&
-    tweakState !== "streaming" &&
-    tweakState !== "preview"
-  ) {
-    return null;
-  }
-
-  return (
-    <div
-      className="absolute inset-x-4 sm:inset-x-6 bottom-4 sm:bottom-5 max-w-3xl mx-auto bg-card border border-border rounded-2xl shadow-[0_24px_48px_-20px_oklch(0_0_0/0.35),0_1px_0_var(--color-border-soft)] z-40 overflow-hidden"
-      style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
-    >
-      <div className="p-3.5 sm:p-4">
-        {/* State 2 — open */}
-        {tweakState === "open" && (
-          <div>
-            <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-2.5">
-                <div className="w-6 h-6 rounded-[7px] bg-primary/8 border border-primary/40 text-primary inline-flex items-center justify-center">
-                  <TweakIcon />
-                </div>
-                <div>
-                  <div className="font-display italic font-semibold text-[15px] text-foreground tracking-tight leading-none">
-                    Tweak workshop
-                  </div>
-                  <div className="font-sans text-[11px] text-ink-faint mt-0.5">
-                    Describe a change. Ah Mah will rewrite the recipe.
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={onDismiss}
-                aria-label="Dismiss"
-                className="w-7 h-7 inline-flex items-center justify-center border border-border rounded-full text-[11px] text-muted-foreground hover:bg-muted/60 transition-colors cursor-pointer shrink-0"
-              >
-                ✕
-              </button>
-            </div>
-            {/* Quick-tweak chips */}
-            <div className="flex flex-wrap gap-1.5 mb-3">
-              {QUICK_TWEAKS.map((chip) => (
-                <button
-                  key={chip}
-                  onClick={() => onSend(chip)}
-                  className="px-2.5 py-1 text-[11px] font-medium text-muted-foreground bg-background border border-border/70 rounded-full cursor-pointer hover:bg-muted/60 transition-colors"
-                >
-                  {chip}
-                </button>
-              ))}
-            </div>
-            {/* Input row */}
-            <div className="flex items-center gap-2.5 px-4 py-2 bg-background border border-border rounded-full shadow-[0_1px_0_var(--color-border-soft),0_8px_24px_-16px_oklch(0_0_0/0.15)]">
-              <TweakIcon />
-              <input
-                ref={inputRef}
-                value={instruction}
-                onChange={(e) => onInstructionChange(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") onSend();
-                }}
-                placeholder="e.g. less spicy, add cucumber for crunch…"
-                className="flex-1 bg-transparent border-none outline-none text-[13.5px] text-foreground placeholder:text-muted-foreground font-sans"
-              />
-              <button
-                onClick={() => onSend()}
-                disabled={!instruction.trim()}
-                aria-label="Send"
-                className={`w-8 h-8 rounded-full inline-flex items-center justify-center shrink-0 transition-colors cursor-pointer ${
-                  instruction.trim()
-                    ? "bg-primary border border-primary/80 text-primary-foreground shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90"
-                    : "bg-muted border border-border text-muted-foreground cursor-not-allowed"
-                }`}
-              >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
-                  <path d="M3 12 L21 4 L13 21 L11 13 Z" fill="currentColor" />
-                </svg>
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* State 3 — streaming */}
-        {tweakState === "streaming" && (
-          <div>
-            <div className="flex items-center justify-between mb-2.5">
-              <div className="inline-flex items-center gap-2 font-sans text-[12px] font-semibold text-primary">
-                <span className="inline-flex gap-[3px]">
-                  {[0, 1, 2].map((i) => (
-                    <span
-                      key={i}
-                      className="w-[5px] h-[5px] rounded-full bg-primary"
-                      style={{
-                        animation: `tweakDot 1.2s ease-in-out ${i * 0.15}s infinite`,
-                      }}
-                    />
-                  ))}
-                </span>
-                Ah Mah is rewriting…
-              </div>
-            </div>
-            <div className="px-3 py-2 bg-primary/5 border border-dashed border-primary/40 rounded-lg font-display italic text-[13px] text-primary">
-              &ldquo;{instruction}&rdquo;
-            </div>
-          </div>
-        )}
-
-        {/* State 4 — preview ready */}
-        {tweakState === "preview" && (
-          <div>
-            <div className="flex items-center justify-between mb-3">
-              <div>
-                <div className="font-display italic font-semibold text-[15px] text-foreground tracking-tight leading-none">
-                  Preview ready
-                  {totalChanges > 0 && (
-                    <span className="font-sans not-italic font-normal text-[12px] text-ink-faint ml-2">
-                      — {totalChanges} change{totalChanges !== 1 ? "s" : ""}
-                    </span>
-                  )}
-                </div>
-                <div className="font-sans text-[11px] text-ink-faint mt-1">
-                  &ldquo;{instruction}&rdquo;
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center justify-end gap-2.5 flex-wrap">
-              <button
-                onClick={onDiscard}
-                className="px-3 py-2 text-[12px] font-semibold tracking-[0.14em] uppercase text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
-              >
-                Discard
-              </button>
-              <button
-                onClick={onTryAgain}
-                className="px-3.5 py-2 text-[12.5px] font-semibold text-foreground bg-background border border-border rounded-lg cursor-pointer hover:bg-muted/60 transition-colors"
-              >
-                Tweak again
-              </button>
-              <button
-                onClick={onSave}
-                disabled={isSaving}
-                className="px-4 py-2 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-60"
-              >
-                {isSaving ? "Saving…" : "Save changes"}
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
 // ─── RecipeDisplay ───────────────────────────────────────────────────────────
 
 interface RecipeDisplayProps {
@@ -657,180 +426,68 @@ export default function RecipeDisplay({
   const { userId } = useSessionContext();
   const [cooking, setCooking] = useState(false);
 
-  // ── Tweak state ────────────────────────────────────────────────────────────
-  const [tweakState, setTweakState] = useState<TweakState>("resting");
-  const [instruction, setInstruction] = useState("");
-  const [tweakedRecipe, setTweakedRecipe] = useState<RecipeWithId>(recipe);
+  // ── Bench state ────────────────────────────────────────────────────────────
+  const [benchOpen, setBenchOpen] = useState(false);
+  const [workingDraft, setWorkingDraft] = useState<RecipeWithId>(recipe);
+  const [changes, setChanges] = useState<ChangeEntry[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const originalRecipeRef = useRef<RecipeWithId>(recipe);
-  const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const steps = (tweakedRecipe.steps ?? []) as RecipeStep[];
+  const steps = (workingDraft.steps ?? []) as RecipeStep[];
   const canCook = steps.length > 0;
 
-  // Compute changed fields (memoised — only recalculates when the recipes change)
-  const {
-    ingredients: changedIngredients,
-    steps: changedSteps,
-    deletedIngredients,
-    deletedSteps,
-  } = useMemo(
-    () => diffRecipes(originalRecipeRef.current, tweakedRecipe),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [tweakedRecipe],
-  );
+  // Derive diff overlay sets from the model's change list
+  const { changedIngredients, deletedIngredients, changedSteps, deletedSteps } =
+    useMemo(
+      () => changesToDiff(changes, workingDraft, originalRecipeRef.current),
+      [changes, workingDraft],
+    );
 
-  const totalChanges =
-    changedIngredients.size +
-    changedSteps.size +
-    deletedIngredients.size +
-    deletedSteps.size;
+  const showHighlights = changes.length > 0;
+
+  // Reset when navigating to a different recipe
+  useEffect(() => {
+    originalRecipeRef.current = recipe;
+    setWorkingDraft(recipe);
+    setChanges([]);
+    setBenchOpen(false);
+    setIsSaving(false);
+  }, [recipe.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Handlers ───────────────────────────────────────────────────────────────
 
-  // Reset tweak state when the recipe changes (e.g. navigating to a different recipe)
-  useEffect(() => {
-    setTweakedRecipe(recipe);
-    originalRecipeRef.current = recipe;
-    setTweakState("resting");
-    setIsSaving(false);
-    setInstruction("");
-  }, [recipe.id]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Focus the input whenever the tweak bar opens
-  useEffect(() => {
-    if (tweakState === "open") inputRef.current?.focus();
-  }, [tweakState]);
-
-  const openTweak = useCallback(() => {
-    setTweakState("open");
-  }, []);
-
-  const dismissTweak = useCallback(() => {
-    setTweakState("resting");
-    setInstruction("");
-    setTweakedRecipe(originalRecipeRef.current);
-  }, []);
-
-  const sendTweak = useCallback(
-    async (prompt?: string) => {
-      const p = (prompt ?? instruction).trim();
-      if (!p) return;
-
-      const finalInstruction = prompt ?? instruction;
-      setInstruction(finalInstruction);
-      setTweakState("streaming");
-
-      try {
-        const res = await fetch(`/api/recipe/${recipe.id}/tweak`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            userId,
-            instruction: p,
-            recipe: originalRecipeRef.current,
-          }),
-        });
-
-        if (!res.ok || !res.body) {
-          throw new Error("Tweak request failed");
-        }
-
-        // Read the stream and accumulate
-        const reader = res.body.getReader();
-        const decoder = new TextDecoder();
-        let accumulated = "";
-        let parsedAtLeastOnce = false;
-
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            accumulated += decoder.decode(value, { stream: true });
-
-            // Try to parse accumulated text as JSON progressively
-            try {
-              const parsed = JSON.parse(accumulated);
-              // Map RecipeBlock → RecipeWithId (carry over the id and image fields)
-              const updatedRecipe: RecipeWithId = {
-                ...originalRecipeRef.current,
-                name: parsed.title ?? originalRecipeRef.current.name,
-                description:
-                  parsed.description ?? originalRecipeRef.current.description,
-                totalTimeMinutes:
-                  parsed.totalTimeMinutes ??
-                  originalRecipeRef.current.totalTimeMinutes,
-                baseServings:
-                  parsed.baseServings ?? originalRecipeRef.current.baseServings,
-                ingredients:
-                  parsed.ingredients ?? originalRecipeRef.current.ingredients,
-                prep: parsed.prep ?? originalRecipeRef.current.prep,
-                steps: parsed.steps ?? originalRecipeRef.current.steps,
-                tags: parsed.tags ?? originalRecipeRef.current.tags,
-                instructions: originalRecipeRef.current.instructions,
-              };
-              setTweakedRecipe(updatedRecipe);
-              parsedAtLeastOnce = true;
-            } catch {
-              // JSON not yet complete — keep accumulating
-            }
-          }
-        } finally {
-          reader.cancel().catch(() => {});
-        }
-
-        if (parsedAtLeastOnce) {
-          setTweakState("preview");
-        } else {
-          // AI responded with non-JSON (e.g. refused the request) — surface an error
-          toast.error(
-            "Ah Mah couldn't tweak this one. Try a different instruction?",
-          );
-          setTweakState("open");
-        }
-      } catch (err) {
-        console.error("[RecipeDisplay] tweak stream error:", err);
-        toast.error("Aiyah, something went wrong. Try again?");
-        setTweakState("open");
-      }
+  const handleWorkingDraftChange = useCallback(
+    (draft: RecipeWithId, newChanges: ChangeEntry[]) => {
+      setWorkingDraft(draft);
+      setChanges(newChanges);
     },
-    [instruction, recipe.id, userId],
+    [],
   );
 
-  const tryAgain = useCallback(() => {
-    setTweakedRecipe(originalRecipeRef.current);
-    setInstruction("");
-    setTweakState("open");
+  const handleBenchClose = useCallback(() => {
+    setBenchOpen(false);
+    setWorkingDraft(originalRecipeRef.current);
+    setChanges([]);
   }, []);
 
-  const saveChanges = useCallback(async () => {
+  const handleSave = useCallback(async () => {
     if (!userId) return;
     setIsSaving(true);
     try {
-      const recipeBlock = {
-        title: tweakedRecipe.name,
-        description: tweakedRecipe.description,
-        totalTimeMinutes: tweakedRecipe.totalTimeMinutes,
-        baseServings: tweakedRecipe.baseServings,
-        ingredients: tweakedRecipe.ingredients,
-        prep: tweakedRecipe.prep,
-        steps: tweakedRecipe.steps,
-        tags: tweakedRecipe.tags,
-      };
-
       const res = await fetch(`/api/recipe/${recipe.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId, recipe: recipeBlock }),
+        body: JSON.stringify({
+          userId,
+          recipe: recipeWithIdToBlock(workingDraft),
+        }),
       });
 
-      if (!res.ok) {
-        throw new Error("Save failed");
-      }
+      if (!res.ok) throw new Error("Save failed");
 
-      // Update the original reference so future tweaks start from the saved version
-      originalRecipeRef.current = tweakedRecipe;
-      setTweakState("saved");
+      originalRecipeRef.current = workingDraft;
+      setBenchOpen(false);
+      setChanges([]);
       toast.success("Recipe saved!");
     } catch (err) {
       console.error("[RecipeDisplay] save error:", err);
@@ -838,18 +495,7 @@ export default function RecipeDisplay({
     } finally {
       setIsSaving(false);
     }
-  }, [recipe.id, tweakedRecipe, userId]);
-
-  const discardChanges = useCallback(() => {
-    setTweakedRecipe(originalRecipeRef.current);
-    setInstruction("");
-    setTweakState("resting");
-  }, []);
-
-  const tweakAgain = useCallback(() => {
-    setInstruction("");
-    setTweakState("open");
-  }, []);
+  }, [recipe.id, userId, workingDraft]);
 
   const handleStartCooking = () => {
     if (onStartCooking) {
@@ -858,11 +504,6 @@ export default function RecipeDisplay({
       setCooking(true);
     }
   };
-
-  const hasWorkshopCard =
-    tweakState === "open" ||
-    tweakState === "streaming" ||
-    tweakState === "preview";
 
   if (cooking) {
     return (
@@ -877,7 +518,7 @@ export default function RecipeDisplay({
 
   return (
     <>
-      {/* Dot animation keyframes */}
+      {/* Dot animation for streaming indicator */}
       <style>{`
         @keyframes tweakDot {
           0%, 80%, 100% { opacity: 0.2; transform: scale(0.85); }
@@ -885,75 +526,98 @@ export default function RecipeDisplay({
         }
       `}</style>
 
-      <div className="flex flex-col h-full relative">
-        <div
-          className={`flex-1 overflow-y-auto ${hasWorkshopCard ? "pb-52" : "pb-24"}`}
-        >
-          <div className="mx-auto max-w-4xl px-4 sm:px-6 pt-4 sm:pt-5 pb-8">
-            <div className="flex items-center justify-between mb-3 sm:mb-4">
-              {!hideBackButton && (
-                <button
-                  onClick={onBack}
-                  className="min-h-11 inline-flex items-center font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
-                  aria-label="Back to cookbook"
-                >
-                  ← Back to cookbook
-                </button>
-              )}
-              {canCook && (
-                <button
-                  onClick={handleStartCooking}
-                  className="inline-flex items-center gap-1.5 min-h-11 px-3 py-1.5 text-[12.5px] font-semibold text-primary-foreground bg-primary border border-primary rounded-md cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
-                  aria-label="Start cooking — step-by-step view with screen stay-on"
-                >
-                  <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
-                    <path d="M5 3l8 5-8 5V3z" fill="currentColor" />
-                  </svg>
-                  Start cooking
-                </button>
-              )}
-            </div>
-            <div className="rounded-xl border border-border bg-card overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
-              <RecipeBody
-                selectedRecipe={tweakedRecipe}
-                changedIngredients={changedIngredients}
-                changedSteps={changedSteps}
-                deletedIngredients={deletedIngredients}
-                deletedSteps={deletedSteps}
-                originalRecipe={originalRecipeRef.current}
-                tweakState={tweakState}
-              />
+      <div className="flex h-full overflow-hidden">
+        {/* Recipe panel */}
+        <div className="flex flex-col flex-1 min-w-0 relative h-full">
+          <div className="flex-1 overflow-y-auto pb-24">
+            <div className="mx-auto max-w-4xl px-4 sm:px-6 pt-4 sm:pt-5 pb-8">
+              {/* Nav bar */}
+              <div className="flex items-center justify-between mb-3 sm:mb-4">
+                {!hideBackButton && (
+                  <button
+                    onClick={onBack}
+                    className="min-h-11 inline-flex items-center font-sans text-[11.5px] font-semibold tracking-[0.14em] uppercase text-ink-faint hover:text-foreground transition-colors cursor-pointer"
+                    aria-label="Back to cookbook"
+                  >
+                    ← Back to cookbook
+                  </button>
+                )}
+                <div className="flex items-center gap-2 ml-auto">
+                  {!benchOpen && (
+                    <button
+                      onClick={() => setBenchOpen(true)}
+                      className="inline-flex items-center gap-1.5 min-h-11 px-3 py-1.5 text-[12.5px] font-semibold text-primary bg-card border border-border rounded-md cursor-pointer hover:bg-muted/60 transition-colors"
+                      aria-label="Tweak this recipe"
+                    >
+                      <TweakIcon />
+                      Tweak this recipe
+                    </button>
+                  )}
+                  {canCook && (
+                    <button
+                      onClick={handleStartCooking}
+                      className="inline-flex items-center gap-1.5 min-h-11 px-3 py-1.5 text-[12.5px] font-semibold text-primary-foreground bg-primary border border-primary rounded-md cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity"
+                      aria-label="Start cooking — step-by-step view with screen stay-on"
+                    >
+                      <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+                        <path d="M5 3l8 5-8 5V3z" fill="currentColor" />
+                      </svg>
+                      Start cooking
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {/* Recipe card */}
+              <div className="rounded-xl border border-border bg-card overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
+                <RecipeBody
+                  selectedRecipe={workingDraft}
+                  changedIngredients={changedIngredients}
+                  changedSteps={changedSteps}
+                  deletedIngredients={deletedIngredients}
+                  deletedSteps={deletedSteps}
+                  originalRecipe={originalRecipeRef.current}
+                  showHighlights={showHighlights}
+                />
+              </div>
             </div>
           </div>
         </div>
 
-        {/* Direction B — floating pill (resting / saved) */}
-        {(tweakState === "resting" || tweakState === "saved") && (
-          <button
-            onClick={openTweak}
-            className="absolute right-5 bottom-5 inline-flex items-center gap-2 px-[18px] py-[11px] font-sans text-[13px] font-semibold text-primary-foreground bg-primary border border-primary/80 rounded-full cursor-pointer shadow-[0_12px_32px_-10px_oklch(0_0_0/0.35),0_1px_0_oklch(0.46_0.135_35),inset_0_1px_0_oklch(0.65_0.13_38)] hover:opacity-90 transition-opacity z-40"
-            style={{ bottom: "max(20px, env(safe-area-inset-bottom, 20px))" }}
-          >
-            <TweakIcon />
-            Tweak this recipe
-          </button>
+        {/* Tweak Bench — right panel */}
+        {benchOpen && userId && (
+          <TweakBench
+            recipe={originalRecipeRef.current}
+            userId={userId}
+            onWorkingDraftChange={handleWorkingDraftChange}
+            onClose={handleBenchClose}
+            onSave={handleSave}
+            isSaving={isSaving}
+          />
         )}
-
-        {/* Direction B — floating workshop card (open / streaming / preview) */}
-        <WorkshopCard
-          tweakState={tweakState}
-          instruction={instruction}
-          totalChanges={totalChanges}
-          onInstructionChange={setInstruction}
-          onSend={sendTweak}
-          onDismiss={dismissTweak}
-          onSave={saveChanges}
-          onTryAgain={tryAgain}
-          onDiscard={discardChanges}
-          isSaving={isSaving}
-          inputRef={inputRef}
-        />
       </div>
     </>
+  );
+}
+
+// ─── TweakIcon (shared with TweakBench header) ───────────────────────────────
+
+function TweakIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      className="shrink-0"
+    >
+      <path
+        d="M3 10.5 L8.5 5 L11 7.5 L5.5 13 H3 V10.5 Z M8.5 5 L10 3.5 L12.5 6 L11 7.5"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
   );
 }

--- a/src/features/RecipeDisplay/TweakBench.tsx
+++ b/src/features/RecipeDisplay/TweakBench.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import type { ChangeEntry, RecipeWithId } from "@/lib/recipes/schemas";
+import { recipeWithIdToBlock } from "@/lib/recipes/schemas";
+import Image from "next/image";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type TurnEntry =
+  | { kind: "user"; text: string }
+  | { kind: "assistant"; changes: ChangeEntry[] }
+  | { kind: "refusal"; text: string };
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+interface TweakBenchProps {
+  recipe: RecipeWithId;
+  userId: string;
+  onWorkingDraftChange: (draft: RecipeWithId, changes: ChangeEntry[]) => void;
+  onClose: () => void;
+  onSave: () => Promise<void>;
+  isSaving: boolean;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const QUICK_TWEAKS = ["Less spicy", "Make it quicker", "More servings", "Swap for pantry staples"];
+
+// ─── TweakBench ──────────────────────────────────────────────────────────────
+
+export function TweakBench({
+  recipe,
+  userId,
+  onWorkingDraftChange,
+  onClose,
+  onSave,
+  isSaving,
+}: TweakBenchProps) {
+  const [turns, setTurns] = useState<TurnEntry[]>([]);
+  const [instruction, setInstruction] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  // Working draft accumulates across turns — used as the model input for each new turn
+  const workingDraftRef = useRef<RecipeWithId>(recipe);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const logEndRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset bench when the recipe changes (different recipe page)
+  useEffect(() => {
+    workingDraftRef.current = recipe;
+    setTurns([]);
+    setInstruction("");
+    setIsStreaming(false);
+    onWorkingDraftChange(recipe, []);
+  }, [recipe.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-scroll turn log to bottom
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [turns, isStreaming]);
+
+  // Focus input on open
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const successfulTurns = turns.filter((t) => t.kind === "assistant").length;
+
+  const sendTweak = useCallback(
+    async (prompt?: string) => {
+      const text = (prompt ?? instruction).trim();
+      if (!text || isStreaming) return;
+
+      setInstruction("");
+      setIsStreaming(true);
+      setTurns((prev) => [...prev, { kind: "user", text }]);
+
+      const currentDraft = workingDraftRef.current;
+
+      try {
+        const res = await fetch(`/api/recipe/${recipe.id}/tweak`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            userId,
+            instruction: text,
+            originalRecipe: recipeWithIdToBlock(recipe),
+            workingDraft: recipeWithIdToBlock(currentDraft),
+          }),
+        });
+
+        if (!res.ok || !res.body) throw new Error("Tweak request failed");
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulated = "";
+        let lastParsedDraft: RecipeWithId | null = null;
+        let lastParsedChanges: ChangeEntry[] = [];
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            accumulated += decoder.decode(value, { stream: true });
+
+            // Progressive parse — update recipe view during streaming
+            try {
+              const partial = JSON.parse(accumulated);
+              if (partial?.recipe) {
+                const r = partial.recipe as Record<string, unknown>;
+                const newDraft: RecipeWithId = {
+                  ...currentDraft,
+                  name: (r.title as string) ?? currentDraft.name,
+                  description: (r.description as string | undefined) ?? currentDraft.description,
+                  totalTimeMinutes: (r.totalTimeMinutes as number | undefined) ?? currentDraft.totalTimeMinutes,
+                  baseServings: (r.baseServings as number) ?? currentDraft.baseServings,
+                  ingredients: (r.ingredients as RecipeWithId["ingredients"]) ?? currentDraft.ingredients,
+                  prep: (r.prep as string[] | undefined) ?? currentDraft.prep,
+                  steps: (r.steps as RecipeWithId["steps"]) ?? currentDraft.steps,
+                  tags: (r.tags as string[] | undefined) ?? currentDraft.tags,
+                };
+                const newChanges: ChangeEntry[] = (partial.changes as ChangeEntry[]) ?? [];
+                lastParsedDraft = newDraft;
+                lastParsedChanges = newChanges;
+                onWorkingDraftChange(newDraft, newChanges);
+              }
+            } catch {
+              // Incomplete JSON — keep accumulating
+            }
+          }
+        } finally {
+          reader.cancel().catch(() => {});
+        }
+
+        if (lastParsedDraft) {
+          workingDraftRef.current = lastParsedDraft;
+          setTurns((prev) => [
+            ...prev,
+            { kind: "assistant", changes: lastParsedChanges },
+          ]);
+        } else {
+          // Non-JSON response = model refusal
+          const refusalText = accumulated.trim() || "Ah Mah couldn't do that one. Try a different instruction?";
+          setTurns((prev) => [...prev, { kind: "refusal", text: refusalText }]);
+        }
+      } catch (err) {
+        console.error("[TweakBench] stream error:", err);
+        setTurns((prev) => [
+          ...prev,
+          { kind: "refusal", text: "Aiyah, something went wrong. Try again?" },
+        ]);
+      } finally {
+        setIsStreaming(false);
+        setTimeout(() => inputRef.current?.focus(), 0);
+      }
+    },
+    [instruction, isStreaming, recipe, userId, onWorkingDraftChange],
+  );
+
+  const handleTryAgain = useCallback(() => {
+    workingDraftRef.current = recipe;
+    setTurns([]);
+    setInstruction("");
+    onWorkingDraftChange(recipe, []);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, [recipe, onWorkingDraftChange]);
+
+  return (
+    <div className="flex flex-col h-full border-l border-border bg-card w-[360px] sm:w-[380px] shrink-0">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3 px-4 pt-4 pb-3 border-b border-border shrink-0">
+        <div className="flex items-center gap-2.5">
+          <div className="w-7 h-7 rounded-[8px] bg-primary/8 border border-primary/40 text-primary inline-flex items-center justify-center shrink-0">
+            <PencilIcon />
+          </div>
+          <div>
+            <div className="font-display italic font-semibold text-[15px] text-foreground tracking-tight leading-none">
+              Tweak bench
+            </div>
+            <div className="font-sans text-[11px] text-ink-faint mt-0.5">
+              Ah Mah rewrites — you watch it happen
+            </div>
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close tweak bench"
+          className="w-7 h-7 inline-flex items-center justify-center border border-border rounded-full text-[11px] text-muted-foreground hover:bg-muted/60 transition-colors cursor-pointer shrink-0 mt-0.5"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Turn log */}
+      <div className="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-4 min-h-0">
+        <AssistantBubble text="What should I tweak?" />
+
+        {turns.map((turn, i) => {
+          if (turn.kind === "user") {
+            return (
+              <div key={i} className="flex justify-end">
+                <div className="max-w-[82%] px-3.5 py-2 bg-[oklch(0.86_0.10_88)] text-foreground rounded-2xl rounded-br-sm font-sans text-[13.5px] leading-[1.5]">
+                  {turn.text}
+                </div>
+              </div>
+            );
+          }
+
+          if (turn.kind === "assistant") {
+            const n = turn.changes.length;
+            return (
+              <div key={i} className="flex flex-col gap-3">
+                <AssistantBubble
+                  text={`Done! ${n} change${n !== 1 ? "s" : ""}. Have a look on the left — anything still off?`}
+                />
+                {n > 0 && (
+                  <div className="pl-[37px]">
+                    <div className="font-sans text-[9.5px] font-bold tracking-[0.16em] uppercase text-ink-faint mb-2">
+                      What changed
+                    </div>
+                    <ul className="flex flex-col gap-1.5">
+                      {turn.changes.map((c, j) => (
+                        <li key={j} className="flex items-start gap-2">
+                          <span className="text-emerald-600 shrink-0 mt-[1px]">
+                            <CheckIcon />
+                          </span>
+                          <span className="font-sans text-[12.5px] text-foreground leading-[1.45]">
+                            {c.label}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            );
+          }
+
+          if (turn.kind === "refusal") {
+            return <AssistantBubble key={i} text={turn.text} />;
+          }
+
+          return null;
+        })}
+
+        {/* Streaming indicator */}
+        {isStreaming && (
+          <div className="flex gap-2.5 items-center">
+            <div className="relative w-7 h-7 shrink-0">
+              <Image src="/granny-icon.png" alt="" fill className="object-contain" />
+            </div>
+            <div className="inline-flex gap-[4px] items-center">
+              {[0, 1, 2].map((i) => (
+                <span
+                  key={i}
+                  className="w-[5px] h-[5px] rounded-full bg-primary"
+                  style={{
+                    animation: `tweakDot 1.2s ease-in-out ${i * 0.15}s infinite`,
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div ref={logEndRef} />
+      </div>
+
+      {/* Input + footer */}
+      <div className="shrink-0 border-t border-border px-4 pt-3 pb-4">
+        {/* Quick chips — first turn only */}
+        {!isStreaming && turns.length === 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-2.5">
+            {QUICK_TWEAKS.map((chip) => (
+              <button
+                key={chip}
+                onClick={() => sendTweak(chip)}
+                className="px-2.5 py-1 text-[11px] font-medium text-muted-foreground bg-background border border-border/70 rounded-full cursor-pointer hover:bg-muted/60 transition-colors"
+              >
+                {chip}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Input row */}
+        {!isStreaming ? (
+          <div className="flex items-center gap-2.5 px-3.5 py-2 bg-background border border-border rounded-full shadow-[0_1px_0_var(--color-border-soft)]">
+            <input
+              ref={inputRef}
+              value={instruction}
+              onChange={(e) => setInstruction(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") sendTweak();
+              }}
+              placeholder="e.g. less spicy, add cucumber…"
+              className="flex-1 bg-transparent border-none outline-none text-[13px] text-foreground placeholder:text-muted-foreground font-sans"
+            />
+            <button
+              onClick={() => sendTweak()}
+              disabled={!instruction.trim()}
+              aria-label="Send"
+              className={`w-7 h-7 rounded-full inline-flex items-center justify-center shrink-0 transition-colors ${
+                instruction.trim()
+                  ? "bg-primary text-primary-foreground cursor-pointer hover:opacity-90"
+                  : "bg-muted text-muted-foreground cursor-not-allowed"
+              }`}
+            >
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none">
+                <path d="M3 12 L21 4 L13 21 L11 13 Z" fill="currentColor" />
+              </svg>
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 px-3.5 py-2 bg-background border border-border/60 rounded-full opacity-60">
+            <span className="font-sans text-[13px] text-muted-foreground italic">
+              Ah Mah is rewriting…
+            </span>
+          </div>
+        )}
+
+        {/* Footer actions — visible after a successful turn */}
+        {successfulTurns > 0 && !isStreaming && (
+          <div className="mt-3 flex flex-col gap-2">
+            <button
+              onClick={onSave}
+              disabled={isSaving}
+              className="w-full py-2.5 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary/80 rounded-lg cursor-pointer hover:opacity-90 transition-opacity disabled:opacity-60"
+            >
+              {isSaving ? "Saving…" : "Save to my cookbook"}
+            </button>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleTryAgain}
+                className="flex-1 py-2 text-[12px] font-semibold text-foreground bg-background border border-border rounded-lg cursor-pointer hover:bg-muted/60 transition-colors"
+              >
+                Try a different tweak
+              </button>
+              <button
+                onClick={onClose}
+                className="flex-1 py-2 text-[12px] font-semibold text-muted-foreground bg-background border border-border rounded-lg cursor-pointer hover:bg-muted/60 transition-colors"
+              >
+                ↩ Discard
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function AssistantBubble({ text }: { text: string }) {
+  return (
+    <div className="flex gap-2.5 items-start">
+      <div className="relative w-7 h-7 shrink-0">
+        <Image src="/granny-icon.png" alt="" fill className="object-contain" />
+      </div>
+      <div className="flex-1 font-display italic text-[13.5px] text-foreground leading-[1.5] pt-0.5">
+        {text}
+      </div>
+    </div>
+  );
+}
+
+function PencilIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      className="shrink-0"
+    >
+      <path
+        d="M3 10.5 L8.5 5 L11 7.5 L5.5 13 H3 V10.5 Z M8.5 5 L10 3.5 L12.5 6 L11 7.5"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+      <circle cx="8" cy="8" r="7" fill="currentColor" opacity="0.15" />
+      <path
+        d="M5 8.5L7 10.5L11 6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}

--- a/src/features/RecipeDisplay/TweakBench.tsx
+++ b/src/features/RecipeDisplay/TweakBench.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import type { ChangeEntry, RecipeWithId } from "@/lib/recipes/schemas";
-import { recipeWithIdToBlock } from "@/lib/recipes/schemas";
+import {
+  recipeBlockToRecipeWithId,
+  recipeWithIdToBlock,
+  TweakResponseSchema,
+} from "@/lib/recipes/schemas";
 import Image from "next/image";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -43,6 +47,9 @@ export function TweakBench({
 
   // Working draft accumulates across turns — used as the model input for each new turn
   const workingDraftRef = useRef<RecipeWithId>(recipe);
+  const abortRef = useRef<AbortController | null>(null);
+  const readerRef = useRef<ReadableStreamDefaultReader<Uint8Array> | null>(null);
+  const mountedRef = useRef(true);
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const logEndRef = useRef<HTMLDivElement | null>(null);
@@ -55,6 +62,14 @@ export function TweakBench({
     setIsStreaming(false);
     onWorkingDraftChange(recipe, []);
   }, [recipe.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      abortRef.current?.abort();
+      readerRef.current?.cancel().catch(() => {});
+    };
+  }, []);
 
   // Auto-scroll turn log to bottom
   useEffect(() => {
@@ -78,11 +93,16 @@ export function TweakBench({
       setTurns((prev) => [...prev, { kind: "user", text }]);
 
       const currentDraft = workingDraftRef.current;
+      const abortController = new AbortController();
+      abortRef.current?.abort();
+      abortRef.current = abortController;
+      let accumulated = "";
 
       try {
         const res = await fetch(`/api/recipe/${recipe.id}/tweak`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
+          signal: abortController.signal,
           body: JSON.stringify({
             userId,
             instruction: text,
@@ -94,66 +114,60 @@ export function TweakBench({
         if (!res.ok || !res.body) throw new Error("Tweak request failed");
 
         const reader = res.body.getReader();
+        readerRef.current = reader;
         const decoder = new TextDecoder();
-        let accumulated = "";
-        let lastParsedDraft: RecipeWithId | null = null;
-        let lastParsedChanges: ChangeEntry[] = [];
 
         try {
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
             accumulated += decoder.decode(value, { stream: true });
-
-            // Progressive parse — update recipe view during streaming
-            try {
-              const partial = JSON.parse(accumulated);
-              if (partial?.recipe) {
-                const r = partial.recipe as Record<string, unknown>;
-                const newDraft: RecipeWithId = {
-                  ...currentDraft,
-                  name: (r.title as string) ?? currentDraft.name,
-                  description: (r.description as string | undefined) ?? currentDraft.description,
-                  totalTimeMinutes: (r.totalTimeMinutes as number | undefined) ?? currentDraft.totalTimeMinutes,
-                  baseServings: (r.baseServings as number) ?? currentDraft.baseServings,
-                  ingredients: (r.ingredients as RecipeWithId["ingredients"]) ?? currentDraft.ingredients,
-                  prep: (r.prep as string[] | undefined) ?? currentDraft.prep,
-                  steps: (r.steps as RecipeWithId["steps"]) ?? currentDraft.steps,
-                  tags: (r.tags as string[] | undefined) ?? currentDraft.tags,
-                };
-                const newChanges: ChangeEntry[] = (partial.changes as ChangeEntry[]) ?? [];
-                lastParsedDraft = newDraft;
-                lastParsedChanges = newChanges;
-                onWorkingDraftChange(newDraft, newChanges);
-              }
-            } catch {
-              // Incomplete JSON — keep accumulating
-            }
           }
+          accumulated += decoder.decode();
         } finally {
+          readerRef.current = null;
           reader.cancel().catch(() => {});
         }
 
-        if (lastParsedDraft) {
-          workingDraftRef.current = lastParsedDraft;
+        if (abortController.signal.aborted) return;
+
+        const parsedJson = JSON.parse(accumulated);
+        const parsedResponse = TweakResponseSchema.safeParse(parsedJson);
+
+        if (parsedResponse.success) {
+          const newDraft = recipeBlockToRecipeWithId(parsedResponse.data.recipe, currentDraft);
+          const newChanges = parsedResponse.data.changes;
+          workingDraftRef.current = newDraft;
+          onWorkingDraftChange(newDraft, newChanges);
           setTurns((prev) => [
             ...prev,
-            { kind: "assistant", changes: lastParsedChanges },
+            { kind: "assistant", changes: newChanges },
           ]);
         } else {
-          // Non-JSON response = model refusal
-          const refusalText = accumulated.trim() || "Ah Mah couldn't do that one. Try a different instruction?";
-          setTurns((prev) => [...prev, { kind: "refusal", text: refusalText }]);
+          console.warn("[TweakBench] invalid tweak payload:", parsedResponse.error.flatten());
+          setTurns((prev) => [
+            ...prev,
+            { kind: "refusal", text: "Aiyah, that tweak came back muddled. Try again?" },
+          ]);
         }
       } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        if (err instanceof SyntaxError) {
+          const refusalText = accumulated.trim() || "Ah Mah couldn't do that one. Try a different instruction?";
+          setTurns((prev) => [...prev, { kind: "refusal", text: refusalText }]);
+          return;
+        }
         console.error("[TweakBench] stream error:", err);
         setTurns((prev) => [
           ...prev,
           { kind: "refusal", text: "Aiyah, something went wrong. Try again?" },
         ]);
       } finally {
-        setIsStreaming(false);
-        setTimeout(() => inputRef.current?.focus(), 0);
+        if (mountedRef.current && abortRef.current === abortController) {
+          abortRef.current = null;
+          setIsStreaming(false);
+          setTimeout(() => inputRef.current?.focus(), 0);
+        }
       }
     },
     [instruction, isStreaming, recipe, userId, onWorkingDraftChange],
@@ -180,7 +194,7 @@ export function TweakBench({
               Tweak bench
             </div>
             <div className="font-sans text-[11px] text-ink-faint mt-0.5">
-              Ah Mah rewrites — you watch it happen
+              Ah Mah drafts each tweak for review
             </div>
           </div>
         </div>

--- a/src/lib/recipes/schemas.ts
+++ b/src/lib/recipes/schemas.ts
@@ -90,3 +90,53 @@ export type RecipeWithId = Recipe & {
   photographerName?: string | null;
   photographerUrl?: string | null;
 };
+
+// Structured change list returned by the tweak model alongside the updated recipe
+export const ChangeKindSchema = z.enum([
+  "title_updated",
+  "description_updated",
+  "tags_updated",
+  "servings_updated",
+  "time_updated",
+  "ingredient_added",
+  "ingredient_removed",
+  "ingredient_changed",
+  "step_added",
+  "step_removed",
+  "step_replaced",
+  "prep_updated",
+]);
+export type ChangeKind = z.infer<typeof ChangeKindSchema>;
+
+export const ChangeEntrySchema = z.object({
+  kind: ChangeKindSchema,
+  ref: z.union([z.string(), z.number()]).optional(),
+  label: z.string(),
+});
+export type ChangeEntry = z.infer<typeof ChangeEntrySchema>;
+
+export const TweakResponseSchema = z.object({
+  recipe: RecipeBlockSchema,
+  changes: z.array(ChangeEntrySchema),
+});
+export type TweakResponse = z.infer<typeof TweakResponseSchema>;
+
+export function recipeWithIdToBlock(r: RecipeWithId) {
+  return {
+    id: r.id,
+    title: r.name,
+    description: r.description,
+    totalTimeMinutes: r.totalTimeMinutes,
+    baseServings: r.baseServings,
+    ingredients: r.ingredients.map((i) => ({
+      name: i.name,
+      category: i.category,
+      amount: i.amount != null ? String(i.amount) : undefined,
+      unit: i.unit,
+      note: i.note,
+    })),
+    prep: r.prep,
+    steps: r.steps ?? [],
+    tags: r.tags,
+  };
+}

--- a/src/lib/recipes/schemas.ts
+++ b/src/lib/recipes/schemas.ts
@@ -108,9 +108,16 @@ export const ChangeKindSchema = z.enum([
 ]);
 export type ChangeKind = z.infer<typeof ChangeKindSchema>;
 
+export const ChangeRefSchema = z.object({
+  type: z.enum(["ingredient", "step"]),
+  index: z.number().int().nonnegative(),
+  basis: z.enum(["original", "workingDraft"]),
+});
+export type ChangeRef = z.infer<typeof ChangeRefSchema>;
+
 export const ChangeEntrySchema = z.object({
   kind: ChangeKindSchema,
-  ref: z.union([z.string(), z.number()]).optional(),
+  ref: ChangeRefSchema.optional(),
   label: z.string(),
 });
 export type ChangeEntry = z.infer<typeof ChangeEntrySchema>;
@@ -120,6 +127,32 @@ export const TweakResponseSchema = z.object({
   changes: z.array(ChangeEntrySchema),
 });
 export type TweakResponse = z.infer<typeof TweakResponseSchema>;
+
+const parseIngredientAmount = (amount: string | undefined) => {
+  if (amount === undefined) return undefined;
+  const parsed = parseFloat(amount);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+export function recipeBlockToRecipeWithId(block: RecipeBlock, base: RecipeWithId): RecipeWithId {
+  return {
+    ...base,
+    name: block.title,
+    description: block.description,
+    totalTimeMinutes: block.totalTimeMinutes,
+    baseServings: block.baseServings,
+    ingredients: block.ingredients.map((i) => ({
+      name: i.name,
+      category: i.category ?? "Misc",
+      amount: parseIngredientAmount(i.amount),
+      unit: i.unit,
+      note: i.note,
+    })),
+    prep: block.prep,
+    steps: block.steps,
+    tags: block.tags,
+  };
+}
 
 export function recipeWithIdToBlock(r: RecipeWithId) {
   return {


### PR DESCRIPTION
## Summary

- Replaces the single-turn floating workshop card with a right-side **Tweak Bench** panel that supports iterative multi-turn refinement within an ephemeral session
- Each turn sends the working draft + original recipe to the model; the model returns `{ recipe, changes[] }` — a structured change list with structural anchors (`ref`) and narrative labels, cumulative against the original
- Inline diff overlay (amber highlights, strikethrough rows) and the "What changed" checklist in the bench panel both read from the same `changes` array, so they can't disagree
- Checkmarks are decorative (read-only) — users refine via natural language, not toggles
- Bench lifecycle: Discard/X collapses and resets; "Try a different tweak" soft-resets without closing; Save commits via the existing PATCH route
- Fixes a double-conversion bug in the tweak route: client sends block format (`title`, not `name`) but the server was calling `recipeWithIdToBlock()` again, causing a 400 on `title: undefined`
- Adds `ChangeKindSchema`, `ChangeEntrySchema`, `TweakResponseSchema` to `schemas.ts`; supersedes ADR-0004 with new ADR-0005

## Test plan

- Open a recipe → "Tweak this recipe" button appears in the nav bar → bench opens on the right
- Turn 1: type an instruction → recipe streams on the left, change list appears in the bench with checkmarks
- Turn 2: type a second instruction → change list updates cumulatively against the original
- "Try a different tweak" → bench stays open, log clears, recipe resets to original
- Discard / X → bench closes, recipe resets
- Save → PATCH succeeds, bench closes, toast appears, reload confirms the save
- Refusal (e.g. "make this a chocolate cake") → refusal text appears as assistant bubble, draft unchanged
- `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a multi-turn recipe refinement sidebar (Tweak Bench) for iterative recipe tweaking within a single session.
  * Added a "What changed" panel displaying all modifications relative to the original recipe.
  * Ephemeral working drafts persist while the sidebar is open; users can save changes or discard them on close.
  * Added quick-tweak suggestion chips to initiate refinement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->