### PR TITLE
test(chat): fix message input expectations

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,12 @@ const createJestConfig = nextJest({
 const customJestConfig: Config = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testEnvironment: "jsdom",
-  testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/", "<rootDir>/.claude/"],
+  testPathIgnorePatterns: [
+    "<rootDir>/.next/",
+    "<rootDir>/node_modules/",
+    "<rootDir>/.claude/",
+    "<rootDir>/.worktrees/",
+  ],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },

--- a/src/features/Chat/components/MessageInput.test.tsx
+++ b/src/features/Chat/components/MessageInput.test.tsx
@@ -200,6 +200,7 @@ describe("MessageInput", () => {
       await waitFor(() => {
         expect(mockOnSendMessage).toHaveBeenCalledTimes(1);
         expect(mockOnSendMessage).toHaveBeenCalledWith("Hello, world!");
+        expect(input).toHaveValue("");
       });
     });
 
@@ -239,6 +240,9 @@ describe("MessageInput", () => {
       fireEvent.submit(form);
 
       expect(handleSubmit).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(mockOnSendMessage).toHaveBeenCalledWith("Test message");
+      });
     });
 
     it("should handle Enter key submission", async () => {
@@ -385,10 +389,11 @@ describe("MessageInput", () => {
       const button = screen.getByTestId("button");
 
       expect(input).not.toBeDisabled();
-      expect(button).not.toBeDisabled();
+      expect(button).toBeDisabled();
 
       await user.type(input, "This should work");
       expect(input).toHaveValue("This should work");
+      expect(button).not.toBeDisabled();
     });
   });
 
@@ -552,6 +557,7 @@ describe("MessageInput", () => {
       // Focus input
       input.focus();
       expect(input).toHaveFocus();
+      await user.type(input, "Ready to send");
 
       // Tab to button
       await user.tab();


### PR DESCRIPTION
## Summary
- Ignore local .worktrees in Jest discovery
- Update MessageInput tests to expect the send button to stay disabled until text is entered
- Await async submit effects to avoid React act warnings

## Tests
- pnpm test --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test assertions to better verify input component submission behavior, disabled state transitions, and focus management during user interactions.

* **Chores**
  * Updated test configuration formatting for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->