### PR TITLE
fix(sidebar): outline-only active icons, remove conversations tagline + search

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,7 +32,7 @@ When the stream finishes (`onFinish`), `commitConversation(id)` flips `pendingCo
 
 ## Nav Selection
 
-"You are in this tab." Shown on the primary navigation items in `AppSidebar` (Chat / Pantry / Cookbook). Visual treatment: `bg-card` background, `text-foreground` label, terracotta (`text-primary`) filled icon.
+"You are in this tab." Shown on the primary navigation items in `AppSidebar` (Chat / Pantry / Cookbook). Visual treatment: `bg-card` background, `text-foreground` label, terracotta (`text-primary`) icon outline (stroke color only — no fill swap).
 
 The Chat nav item is highlighted only in **Staging State** (`activeConversationId === null && pendingConversationId === null`). Once a conversation becomes pending or committed, the Chat nav unhighlights and **Thread Selection** takes over.
 

--- a/src/features/Conversations/Conversations.tsx
+++ b/src/features/Conversations/Conversations.tsx
@@ -2,8 +2,6 @@
 
 import { useConversationContext } from "@/contexts/ConversationContext";
 import type { ConversationEntity } from "@/lib/conversations";
-import { useState } from "react";
-import { CONVERSATIONS_SEARCH_PLACEHOLDER } from "./constants";
 import { ConversationItem } from "./components/ConversationItem";
 import { ConversationListSkeleton } from "./components/ConversationListSkeleton";
 
@@ -47,20 +45,12 @@ export function Conversations({ onItemClick }: ConversationsProps) {
     renameConversation,
     deleteConversation,
   } = useConversationContext();
-  const [search, setSearch] = useState("");
 
-  // Only show conversations that have at least one message
   const committedConversations = allConversations.filter(
     (c) => (c._count?.messages ?? 0) > 0 || c.id === pendingConversationId
   );
 
-  const filtered = search.trim()
-    ? committedConversations.filter((c) =>
-        (c.title ?? "New chat").toLowerCase().includes(search.toLowerCase())
-      )
-    : committedConversations;
-
-  const groups = groupConversations(filtered);
+  const groups = groupConversations(committedConversations);
 
   const handleItemClick = (id: string) => {
     setActiveConversation(id);
@@ -70,42 +60,16 @@ export function Conversations({ onItemClick }: ConversationsProps) {
   return (
     <div className="flex flex-col h-full gap-3">
       {/* Header */}
-      <div>
-        <div className="font-display italic font-medium text-[22px] text-foreground leading-tight">
-          Conversations
-        </div>
-        <div className="text-xs text-ink-faint mt-0.5">Each kitchen session, kept</div>
-      </div>
-
-      {/* Search */}
-      <div className="relative">
-        <svg
-          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-faint pointer-events-none"
-          width="12"
-          height="12"
-          viewBox="0 0 16 16"
-          fill="none"
-        >
-          <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.5" />
-          <path d="M11 11l3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder={CONVERSATIONS_SEARCH_PLACEHOLDER}
-          className="bg-card border border-border rounded-lg pl-7 pr-3 py-1.5 text-sm w-full outline-none focus:border-primary transition-colors"
-        />
+      <div className="font-display italic font-medium text-[22px] text-foreground leading-tight">
+        Conversations
       </div>
 
       {/* List */}
       <div className="flex-1 min-h-0 overflow-y-auto">
         {isLoading && allConversations.length === 0 ? (
           <ConversationListSkeleton />
-        ) : filtered.length === 0 ? (
-          <div className="italic text-ink-faint text-sm">
-            {search ? "No results" : "No conversations yet"}
-          </div>
+        ) : committedConversations.length === 0 ? (
+          <div className="italic text-ink-faint text-sm">No conversations yet</div>
         ) : (
           <div className="flex flex-col gap-3">
             {groups.map((group) => (

--- a/src/features/Conversations/constants.ts
+++ b/src/features/Conversations/constants.ts
@@ -1,1 +1,0 @@
-export const CONVERSATIONS_SEARCH_PLACEHOLDER = "Search conversations…";

--- a/src/features/shared/components/AppSidebar.tsx
+++ b/src/features/shared/components/AppSidebar.tsx
@@ -13,23 +13,11 @@ const ChatIcon = () => (
   </svg>
 );
 
-const ChatIconFilled = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
-    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-  </svg>
-);
-
 const PantryIcon = () => (
   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
     <line x1="3" y1="6" x2="21" y2="6" />
     <path d="M16 10a4 4 0 01-8 0" />
-  </svg>
-);
-
-const PantryIconFilled = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
-    <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
   </svg>
 );
 
@@ -40,16 +28,10 @@ const CookbookIcon = () => (
   </svg>
 );
 
-const CookbookIconFilled = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
-    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
-  </svg>
-);
-
 const NAV_ITEMS = [
-  { id: "chat",     label: "New Chat",  Icon: ChatIcon,     IconFilled: ChatIconFilled },
-  { id: "pantry",   label: "Pantry",    Icon: PantryIcon,   IconFilled: PantryIconFilled },
-  { id: "cookbook", label: "Cookbook",  Icon: CookbookIcon, IconFilled: CookbookIconFilled },
+  { id: "chat",     label: "New Chat",  Icon: ChatIcon     },
+  { id: "pantry",   label: "Pantry",    Icon: PantryIcon   },
+  { id: "cookbook", label: "Cookbook",  Icon: CookbookIcon },
 ] as const;
 
 export function AppSidebar() {
@@ -99,7 +81,7 @@ export function AppSidebar() {
 
       {/* Primary nav */}
       <nav className="px-2 pb-2 flex flex-col gap-0.5 shrink-0">
-        {NAV_ITEMS.map(({ id, label, Icon, IconFilled }) => {
+        {NAV_ITEMS.map(({ id, label, Icon }) => {
           const isActive = id === "chat" ? isNewChatActive : activeTab === id;
           return (
             <button
@@ -113,7 +95,7 @@ export function AppSidebar() {
               ].join(" ")}
             >
               <span className={isActive ? "text-primary" : ""}>
-                {isActive ? <IconFilled /> : <Icon />}
+                <Icon />
               </span>
               {label}
             </button>


### PR DESCRIPTION
## Summary

- **Nav icons**: active state now only changes the icon's stroke color to terracotta — no more swap to a filled/blob variant. Removes the three unused `*IconFilled` SVG components.
- **Conversations panel**: removed the "Each kitchen session, kept" tagline and the search input. Title-only search added little value over scrolling + date grouping (Today / Yesterday / Earlier). Cleans up dead `search` state, `filtered` logic, and the `CONVERSATIONS_SEARCH_PLACEHOLDER` constant.
- **CONTEXT.md**: updated Nav Selection entry to reflect the new outline-only icon treatment.

## Test plan

- [ ] Active nav item (Pantry, Cookbook) shows outlined icon in terracotta — no filled blob
- [ ] Inactive nav items remain muted, no regressions
- [ ] Conversations panel shows only the heading + date-grouped list — no tagline, no search box
- [ ] Empty state still shows "No conversations yet"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated navigation icon styling guidelines.

* **Refactor**
  * Removed search functionality from the Conversations interface.
  * Simplified primary navigation icons to use a consistent outline style instead of active/inactive variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->