### PR TITLE
fix(sidebar): clear conversation highlight when not on chat tab

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,16 +3,13 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ChatWrapper from "@/features/Chat/components/ChatWrapper";
 import InventoryWrapper from "@/features/Inventory/components/InventoryWrapper";
 import RecipeList from "@/features/RecipeList/RecipeList";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useActiveTab } from "@/hooks/useActiveTab";
+import { useRouter } from "next/navigation";
 import { Suspense } from "react";
-
-const VALID_TABS = ["chat", "pantry", "cookbook"] as const;
 
 function HomeContent() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const raw = searchParams.get("tab");
-  const activeTab = raw && (VALID_TABS as readonly string[]).includes(raw) ? raw : "chat";
+  const activeTab = useActiveTab();
 
   const setActiveTab = (tab: string) => {
     router.replace(`/?tab=${tab}`, { scroll: false });

--- a/src/features/Conversations/Conversations.tsx
+++ b/src/features/Conversations/Conversations.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useConversationContext } from "@/contexts/ConversationContext";
+import { useActiveTab } from "@/hooks/useActiveTab";
 import type { ConversationEntity } from "@/lib/conversations";
 import { ConversationItem } from "./components/ConversationItem";
 import { ConversationListSkeleton } from "./components/ConversationListSkeleton";
@@ -46,6 +47,8 @@ export function Conversations({ onItemClick }: ConversationsProps) {
     deleteConversation,
   } = useConversationContext();
 
+  const isChatActive = useActiveTab() === "chat";
+
   const committedConversations = allConversations.filter(
     (c) => (c._count?.messages ?? 0) > 0 || c.id === pendingConversationId
   );
@@ -82,7 +85,7 @@ export function Conversations({ onItemClick }: ConversationsProps) {
                     <ConversationItem
                       key={conv.id}
                       conversation={conv}
-                      isActive={conv.id === activeConversationId || conv.id === pendingConversationId}
+                      isActive={isChatActive && (conv.id === activeConversationId || conv.id === pendingConversationId)}
                       onClick={() => handleItemClick(conv.id)}
                       onRename={(newTitle) => renameConversation(conv.id, newTitle)}
                       onDelete={() => deleteConversation(conv.id)}

--- a/src/features/shared/components/AppSidebar.tsx
+++ b/src/features/shared/components/AppSidebar.tsx
@@ -4,8 +4,9 @@ import AboutPopOver from "@/components/AboutPopOver";
 import { AuthButton } from "@/features/Auth";
 import { Conversations } from "@/features/Conversations/Conversations";
 import { useConversationContext } from "@/contexts/ConversationContext";
+import { useActiveTab } from "@/hooks/useActiveTab";
 import Image from "next/image";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 const ChatIcon = () => (
   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -36,17 +37,9 @@ const NAV_ITEMS = [
 
 export function AppSidebar() {
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const { activeConversationId, pendingConversationId, conversations, startNewConversation } = useConversationContext();
 
-  const VALID_TABS = ["chat", "pantry", "cookbook"] as const;
-  const raw = searchParams.get("tab");
-  const activeTab = pathname.startsWith("/recipe")
-    ? "cookbook"
-    : (VALID_TABS as readonly string[]).includes(raw ?? "")
-    ? raw!
-    : "chat";
+  const activeTab = useActiveTab();
 
   const navigate = (tab: string) => {
     router.replace(`/?tab=${tab}`, { scroll: false });

--- a/src/hooks/useActiveTab.ts
+++ b/src/hooks/useActiveTab.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+
+export type ActiveTab = "chat" | "pantry" | "cookbook";
+
+const VALID_TABS = ["chat", "pantry", "cookbook"] as const satisfies readonly ActiveTab[];
+
+/**
+ * Single source of truth for which top-level tab is currently active.
+ * - /recipe/* routes → "cookbook"
+ * - ?tab= query param (if valid) → that tab
+ * - fallback → "chat"
+ */
+export function useActiveTab(): ActiveTab {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  if (pathname.startsWith("/recipe")) return "cookbook";
+
+  const raw = searchParams.get("tab");
+  if (raw && (VALID_TABS as readonly string[]).includes(raw)) {
+    return raw as ActiveTab;
+  }
+
+  return "chat";
+}


### PR DESCRIPTION
## Summary
- Conversation rows were staying highlighted (butter Thread Selection) when navigating to Cookbook or Pantry — violating ADR-0003 (Nav and Thread Selection must be mutually exclusive)
- Extracted a `useActiveTab` hook as a single source of truth, replacing two divergent inline derivations in `AppSidebar.tsx` and `page.tsx`
- `isActive` on conversation rows is now gated on `isChatActive` — rows only highlight when the chat tab is active

## Test plan
- With an active conversation, switch to Cookbook → no row highlighted, Cookbook nav highlighted
- Switch to Pantry → same, no row highlighted
- Switch back to Chat → correct row re-highlights
- Open a `/recipe/...` page → no row highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)