### PR TITLE
feat: Cook With What You Have — pantry selection, Mode 3 prompt, recipe captions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,3 +75,43 @@ A single turn within a **Tweak Bench** session. The user types one refinement in
 The AI call goes through a dedicated route (`POST /api/recipe/[id]/tweak`), separate from the chat pipeline.
 
 Related: [ADR-0005](docs/adr/0005-tweak-bench-multi-turn.md)
+
+---
+
+## Cook With What You Have
+
+The Pantry-rooted interaction where a user enters selection mode, marks a **Featured Selection** of pantry items (and optionally preferred kitchenware), and submits to spawn a new **Conversation**. The assistant streams a **Close Recipe** and a **Stretch Recipe** in that conversation. The selection is a transient front-door payload — it lives only long enough to compose the first message, then clears.
+
+Entry points: a CTA at the top of the Pantry, and a suggestion chip in the Chat **Staging State** that navigates to Pantry and enters selection mode.
+
+Related: [ADR-0006](docs/adr/0006-cook-with-what-you-have-is-a-conversation.md), [ADR-0007](docs/adr/0007-pantry-selection-is-feature-emphasis.md)
+
+---
+
+## Featured Selection
+
+The set of pantry items the user has marked to *star* in a Cook With What You Have submission. Items can be ingredients or kitchenware. The selection is **emphasis, not constraint** — non-selected pantry items remain fair game for the model to use silently; selected items must appear or be addressed.
+
+Related: [ADR-0007](docs/adr/0007-pantry-selection-is-feature-emphasis.md)
+
+---
+
+## Close Recipe
+
+The first recipe slot in a Cook With What You Have response. Uses 0–2 **Additions** beyond the user's pantry; the model is told to prefer fewer. Omitted entirely (with a one-line explanation) when the Featured Selection is too sparse to support any recipe at 0–2 additions.
+
+UI label: **"Right now."** The internal term is `Close`.
+
+---
+
+## Stretch Recipe
+
+The second recipe slot in a Cook With What You Have response. Uses 3–4 Additions beyond pantry, with a hard cap of 4. Always present in the response, even when the Close Recipe is omitted.
+
+UI label: **"Worth a small trip."** The internal term is `Stretch`.
+
+---
+
+## Addition
+
+An ingredient a generated recipe calls for that is not present in the user's pantry. The Addition count distinguishes Close from Stretch. Salt, pepper, water, and cooking oil are **free staples** — never counted as Additions even if absent from the pantry. Everything else in the pantry is also free; only items genuinely missing are Additions.

--- a/docs/adr/0006-cook-with-what-you-have-is-a-conversation.md
+++ b/docs/adr/0006-cook-with-what-you-have-is-a-conversation.md
@@ -1,0 +1,36 @@
+# ADR-0006 — Cook With What You Have lives inside the Conversation model
+
+**Status:** Accepted
+
+## Context
+
+"Cook With What You Have" lets the user select items in their pantry and request recipe suggestions. The output is at least one (usually two) generated recipes — a **Close Recipe** and a **Stretch Recipe**.
+
+Two architectural questions had to be answered:
+
+1. **Does the submission create a Conversation, or is it a one-shot endpoint that returns recipes inline?**
+2. **If it's a Conversation, does it reuse `/api/chat`, or get a dedicated route like Recipe Tweak did in [ADR-0004](0004-recipe-tweak-uses-dedicated-route.md)?**
+
+The Tweak Bench precedent (ADR-0004 / ADR-0005) goes the other way — Recipe Tweak is its own route. A future reader will reasonably ask: why does this feature *not* follow the same pattern?
+
+## Decisions
+
+### Cook With What You Have spawns a new Conversation
+
+A submission creates a `Conversation` row exactly the same way a first chat message does (per [ADR-0002](0002-conversation-requires-at-least-one-message.md)). The **Featured Selection** is formatted into a synthetic user message — e.g. *"Suggest recipes using: tomato, tofu — featuring air fryer"* — that is persisted and visible in the thread. The assistant then streams the Close + Stretch recipes as a normal assistant turn.
+
+After submission, the Pantry selection clears. The Conversation is the only durable record of what was asked.
+
+### The pipeline is `/api/chat`, not a new route
+
+The submission goes through the existing chat pipeline. `CHAT_SYSTEM_PROMPT` gains a Mode 3 — "Cook With What You Have" — that branches on the synthetic message pattern and produces exactly two recipes (or one, when Close is infeasible) with the Close/Stretch contract.
+
+The "More ideas like these" button sends a second synthetic message (*"More ideas — different from these"*) in the same Conversation. The model has the prior recipes in context (`CONTEXT_WINDOW = 15`) and avoids repeats without needing the original selection payload re-attached.
+
+## Why not alternatives
+
+**One-shot endpoint returning recipes inline on the Pantry page.** This was the second-cheapest option to build but introduces a third recipe-creation path alongside Chat and `/api/recipe/extract`. Worse, it has no natural home for the "More ideas" follow-up — either we'd build a parallel chat surface inside Pantry or we'd lose the multi-turn affordance entirely. Using a Conversation gets multi-turn iteration, auto-titling, history, and recipe persistence for free.
+
+**Dedicated route, following ADR-0004.** Recipe Tweak's dedicated route exists because a tweak is single-turn, ephemeral, and operates on an *existing* recipe — none of the chat pipeline's machinery (conversation persistence, inventory tools, multi-step logic) applies. Cook With What You Have is the opposite: every piece of that machinery is exactly what we need. `getInventory` is part of the prompt's input. `proposeRecipe` is the output convention. Conversation persistence is the storage model. A dedicated route would replicate `/api/chat/route.ts` almost line-for-line.
+
+**Hidden synthetic message (assistant turn appears unprompted).** Considered for cleaner aesthetics. Rejected because scrolling back in the thread would be incomprehensible — a recipe response with no visible question. The synthetic message is the *receipt* of what was asked and keeps the thread legible forever.

--- a/docs/adr/0007-pantry-selection-is-feature-emphasis.md
+++ b/docs/adr/0007-pantry-selection-is-feature-emphasis.md
@@ -1,0 +1,40 @@
+# ADR-0007 — Pantry selection signals feature-emphasis, not hard constraint
+
+**Status:** Accepted
+
+## Context
+
+The Cook With What You Have feature lets the user select pantry items before asking for recipes. The feature name reads as a hard constraint: "the recipe must use ONLY what I have." That literal reading is the most natural one — and it's the wrong one.
+
+Three semantics were considered for what a **Featured Selection** means to the model:
+
+1. **Hard constraint** — recipe must use *only* the selected items (plus a free-staples whitelist).
+2. **Strong preference with budget** — selected items are starred, but the model may call for a small number of missing items as **Additions**.
+3. **Hint** — selected items are emphasis, the model is free to use the rest of the pantry as well as the selection.
+
+Future PR reviewers will reach for option 1 because it matches the feature name. This ADR exists to prevent that drift.
+
+## Decision
+
+Selection signals **feature-emphasis**, with the response structured as two recipes:
+
+- **Close Recipe** — 0–2 Additions, prefer fewer. Honors the spirit of "cook with what you have" while permitting the model to suggest a single missing item when the selection is otherwise pathological.
+- **Stretch Recipe** — 3–4 Additions, hard cap at 4. Always present in the response.
+
+Beyond the selection itself, the whole pantry is free — items in the pantry the user did *not* check are still used silently. Only items genuinely missing from the pantry count as Additions. Salt, pepper, water, and cooking oil are free regardless.
+
+The selection is a *preference signal*, not a fence. The user is saying "feature these"; they are not saying "ignore the rest of my kitchen."
+
+## Why not alternatives
+
+**Pure hard constraint (option 1).** Most literal reading of the feature name, and the most attractive choice for honesty. Rejected because, in practice, zero-addition recipes from a typical user selection are usually pathological — "plain rice with tofu," "boiled noodles with tomato." The model is forced to write slop to honor the constraint, and the user blames the model. The Stretch slot — even with the floor of zero — would be the recipe the user actually wants anyway.
+
+**Hint with no budget (option 3).** Without a numeric contract, the model drifts toward "any recipe that incidentally uses one of these ingredients," and the feature collapses into "chat, but with a preselected prompt." The Close/Stretch split with explicit Addition counts is what makes the response distinguishable from a free-form chat suggestion.
+
+**Single recipe instead of two.** A single Close-only response leaves Stretch ideas unreachable without a second user turn. A single Stretch-only response abandons the "cook tonight, no shopping" promise. The two-recipe structure lets the response carry both contracts in one streaming turn; neither can be added later without a UX retrofit.
+
+## Consequences
+
+- **UI copy diverges from the glossary.** Cards are labeled *"Right now"* and *"Worth a small trip"*, not "Close" and "Stretch." The glossary terms are internal; the captions are the product promise.
+- **Shelf-life prioritization is part of the contract.** The model sees `shelfLife` for every pantry item and is instructed to prioritize short-shelf ingredients. This is the latent justification for keeping `shelfLife` in the data model — see [progress.md](../progress.md) for context.
+- **Kitchenware selection follows the same metaphor.** Selecting a wok = "prefer recipes that use a wok," not "only use a wok." Selecting nothing = any equipment is fair game.

--- a/docs/adr/0007-pantry-selection-is-feature-emphasis.md
+++ b/docs/adr/0007-pantry-selection-is-feature-emphasis.md
@@ -27,7 +27,7 @@ The selection is a *preference signal*, not a fence. The user is saying "feature
 
 ## Why not alternatives
 
-**Pure hard constraint (option 1).** Most literal reading of the feature name, and the most attractive choice for honesty. Rejected because, in practice, zero-addition recipes from a typical user selection are usually pathological — "plain rice with tofu," "boiled noodles with tomato." The model is forced to write slop to honor the constraint, and the user blames the model. The Stretch slot — even with the floor of zero — would be the recipe the user actually wants anyway.
+**Pure hard constraint (option 1).** Most literal reading of the feature name, and the most attractive choice for honesty. Rejected because, in practice, zero-addition recipes from a typical user selection are usually pathological — "plain rice with tofu," "boiled noodles with tomato." The model is forced to write slop to honor the constraint, and the user blames the model. The Stretch slot — even with the floor of 3 additions — would be the recipe the user actually wants anyway.
 
 **Hint with no budget (option 3).** Without a numeric contract, the model drifts toward "any recipe that incidentally uses one of these ingredients," and the feature collapses into "chat, but with a preselected prompt." The Close/Stretch split with explicit Addition counts is what makes the response distinguishable from a free-form chat suggestion.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -47,6 +47,17 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 
 ## V2 — In Progress
 
+### Cook With What You Have — In Review (May 2026)
+- **Selection mode** on the Pantry surface: "Cook with what you have" toggle enters a checkbox mode on ingredient and kitchenware rows. Kitchenware selection = preferred equipment (preference, not constraint — ADR-0007).
+- **CTA adapts** to selection shape: "Suggest recipe (N selected)" for ingredients, "Surprise me with [Air fryer]" for equipment-only.
+- **Short-shelf shortcut**: "Select use-soon items" button pre-selects all amber-dot ingredients in one tap — cashes in the `shelfLife` tracking from V1.
+- **Submit flow**: composes a synthetic Mode 3 message ("Suggest recipes using: …"), enters Staging State via `ConversationContext`, navigates to Chat. Chat auto-sends the queued message once `status === "ready"`.
+- **Mode 3 prompt**: new section in `CHAT_SYSTEM_PROMPT`. Close Recipe (0–2 Additions, `closeness: "close"`) + Stretch Recipe (3–4 Additions, `closeness: "stretch"`). Additions = items not in pantry; free staples: salt/pepper/oil/water.
+- **Recipe cards**: render "Right now" / "Worth a small trip" caption chip when `closeness` is set.
+- **More ideas button**: shown below Cook-With response pairs; sends "More ideas — different from these" in same Conversation.
+- **Chat staging chip**: "🥬 Cook with what I have →" routes to Pantry and auto-enters selection mode via `?selectionMode=1` URL param.
+- Key decisions: ADR-0006 (reuses `/api/chat`, not a dedicated route), ADR-0007 (selection = emphasis not constraint).
+
 ### Recipe Tweak UI (Direction C) — Shipped May 2026
 - **5-state interactive flow** inside `RecipeDisplay`: resting → open → streaming → preview → saved.
 - **State 1 (Resting)**: inline dashed-border "Want Ah Mah to tweak this?" button below the Ah Mah note section.

--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -101,6 +101,43 @@ ${PROMPT_FRAGMENTS.tagCatalog}
   Do NOT invent variants (e.g. "minced-beef" → use "beef"; "tortilla" or "wrap" → use "bread"; "one-pan" → use "one-pot"). Do NOT use ingredient names as tags (no "onion", "garlic", etc.).
 - A brief warm sentence BEFORE the block is fine (e.g. "Here it is — the way I make it:").
 
+## Mode 3 — Cook With What You Have
+
+Triggered when the user message starts with **"Suggest recipes using:"** or **"More ideas — different from these"**.
+
+Call \`getInventory\` first. Then produce **exactly 2 \`\`\`recipe blocks** in order: one Close, one Stretch. Omit the Close block (with one plain-text sentence explaining why) only when the selection is too sparse to produce a coherent dish at 0–2 additions.
+
+### Addition budget
+
+An **Addition** is an ingredient the recipe calls for that is NOT in the user's pantry.
+- **Free staples** (never count as Additions): salt, pepper, water, cooking oil.
+- Everything else already in the pantry is also free — pantry items the user did not select are still available to use silently.
+- Only items genuinely absent from the pantry are Additions.
+
+### Close recipe (emit first)
+- **0–2 Additions. Hard cap: 2. Prefer 0 or 1 when achievable.**
+- Add \`"closeness": "close"\` to the recipe JSON.
+- Use the FEATURED INGREDIENTS and any other pantry items freely. Draw on PREFERRED EQUIPMENT if provided.
+- Short-shelf items (shelfLife: "short") must appear if they make sense for the dish — prioritize using them up.
+
+### Stretch recipe (emit second)
+- **3–4 Additions. Hard cap: 4.**
+- Add \`"closeness": "stretch"\` to the recipe JSON.
+- Must be a meaningfully different dish or technique from the Close recipe — not just a variation of the same thing.
+- Same shelf-life and equipment guidance as above.
+
+### FEATURED INGREDIENTS and PREFERRED EQUIPMENT
+
+The user message will list them explicitly, e.g.:
+\`Suggest recipes using: tomato, tofu, chilli oil — featuring air fryer\`
+
+- **FEATURED INGREDIENTS**: must appear in both recipes. They are emphasis, not constraint — the full pantry is still in scope.
+- **PREFERRED EQUIPMENT**: prefer recipes that use the listed equipment. If no recipe at the right addition budget naturally fits, write the recipe that makes most sense and add one line: *"Goes beautifully in a [equipment] — just adjust the timing to [X] min."*
+
+### "More ideas" follow-up
+
+When triggered by **"More ideas — different from these"**, produce another Close + Stretch pair. You have the prior recipes in context — produce dishes that are clearly different in main protein, cuisine, or technique. Do not repeat any dish title from earlier in this conversation.
+
 ## Routing rules
 
 | Situation | Action |
@@ -110,6 +147,7 @@ ${PROMPT_FRAGMENTS.tagCatalog}
 | "What can I cook?", "any ideas?" (no specific dish, no fresh inventory mention) | getInventory → \`\`\`suggestions block |
 | User names a specific dish ("Make me guacamole") or picks a suggestion | getInventory → \`\`\`recipe directly (swap notes on missing ingredients) |
 | Ambiguous specific-dish ask (e.g. "basil rice" — multiple legit interpretations) | getInventory → \`\`\`suggestions block with variants |
+| Message starts with "Suggest recipes using:" or "More ideas — different from these" | Mode 3 — Cook With What You Have |
 | "Show me other recipes" | getInventory → \`\`\`suggestions block |
 | General cooking question (no recipe needed) | Plain text, no block |
 

--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -25,7 +25,7 @@ When choosing units in the ingredient list, prefer the units the user already ha
 
 # Output format
 
-You have two output modes. ALWAYS emit exactly one action per response (a fenced block or a tool call, placed after any brief prose). NEVER mix modes in a single message. NEVER use the old ----- delimiters.
+You have three output modes. ALWAYS emit exactly one action per response (a fenced block or a tool call, placed after any brief prose). NEVER mix modes in a single message. NEVER use the old ----- delimiters. Exception: Mode 3 (Cook With What You Have) emits exactly two \`\`\`recipe blocks in a single response — one Close, then one Stretch.
 
 ## Mode 1 — Suggestions (open-ended "what can I cook?" asks)
 
@@ -129,9 +129,9 @@ An **Addition** is an ingredient the recipe calls for that is NOT in the user's 
 ### FEATURED INGREDIENTS and PREFERRED EQUIPMENT
 
 The user message will list them explicitly, e.g.:
-\`Suggest recipes using: tomato, tofu, chilli oil — featuring air fryer\`
+\`Suggest recipes using: tomato, tofu, chilli oil. Kitchenware: air fryer\`
 
-- **FEATURED INGREDIENTS**: must appear in both recipes. They are emphasis, not constraint — the full pantry is still in scope.
+- **FEATURED INGREDIENTS**: must appear in both recipes. They are emphasis, not constraint — the full pantry is still in scope. If the message says "no featured ingredients", no specific ingredient is required — produce the best recipes given the PREFERRED EQUIPMENT and full pantry.
 - **PREFERRED EQUIPMENT**: prefer recipes that use the listed equipment. If no recipe at the right addition budget naturally fits, write the recipe that makes most sense and add one line: *"Goes beautifully in a [equipment] — just adjust the timing to [X] min."*
 
 ### "More ideas" follow-up

--- a/src/contexts/ConversationContext.tsx
+++ b/src/contexts/ConversationContext.tsx
@@ -31,6 +31,11 @@ interface ConversationContextType {
   renameConversation: (id: string, title: string) => Promise<void>;
   autoTitleActiveConversation: (title: string) => Promise<boolean>;
   deleteConversation: (id: string) => Promise<void>;
+  // Cook With What You Have: a pending synthetic message queued by the Pantry.
+  // useChatSession watches this and auto-sends it once status is "ready".
+  pendingCookWithMessage: string | null;
+  queueCookWithMessage: (message: string) => void;
+  clearCookWithMessage: () => void;
 }
 
 const ConversationContext = createContext<ConversationContextType | undefined>(
@@ -48,6 +53,7 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
   });
 
   const [pendingConversationId, setPendingConversationId] = useState<string | null>(null);
+  const [pendingCookWithMessage, setPendingCookWithMessage] = useState<string | null>(null);
 
   // Fetch the conversations list
   const listKey = userId ? `/api/conversation?userId=${userId}` : null;
@@ -252,6 +258,9 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
         renameConversation,
         autoTitleActiveConversation,
         deleteConversation,
+        pendingCookWithMessage,
+        queueCookWithMessage: setPendingCookWithMessage,
+        clearCookWithMessage: () => setPendingCookWithMessage(null),
       }}
     >
       {children}

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -4,6 +4,7 @@ import { useConversationContext } from "@/contexts/ConversationContext";
 import { ConversationsMobileSheet } from "@/features/Conversations";
 import { useChatSession } from "./hooks/useChatSession";
 import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import ConversationItemMenu from "@/features/Conversations/components/ConversationItemMenu";
 import { MessageInput } from "./components/MessageInput";
 import { MessageList } from "./components/MessageList";
@@ -25,6 +26,7 @@ const Chat = () => {
     renameConversation,
     deleteConversation,
   } = useConversationContext();
+  const router = useRouter();
 
   const [convSheetOpen, setConvSheetOpen] = useState(false);
   const [mobileRenaming, setMobileRenaming] = useState(false);
@@ -110,15 +112,22 @@ const Chat = () => {
       {status === "ready" && messageCount === 0 && (
         <div className="px-4 pb-1">
           <div className="flex gap-2 flex-wrap max-w-5xl mx-auto">
-          {SUGGESTIONS.map((s) => (
+            {/* Cook-with chip — routes to Pantry selection mode */}
             <button
-              key={s}
-              onClick={() => handleSendMessage(s)}
-              className="inline-flex items-center min-h-11 px-3.5 text-[12.5px] text-muted-foreground border border-border rounded-full hover:border-border-soft hover:text-foreground transition-colors cursor-pointer"
+              onClick={() => router.replace("/?tab=pantry&selectionMode=1")}
+              className="inline-flex items-center gap-1.5 min-h-11 px-3.5 text-[12.5px] text-muted-foreground border border-border rounded-full hover:border-border-soft hover:text-foreground transition-colors cursor-pointer"
             >
-              {s}
+              🥬 Cook with what I have →
             </button>
-          ))}
+            {SUGGESTIONS.map((s) => (
+              <button
+                key={s}
+                onClick={() => handleSendMessage(s)}
+                className="inline-flex items-center min-h-11 px-3.5 text-[12.5px] text-muted-foreground border border-border rounded-full hover:border-border-soft hover:text-foreground transition-colors cursor-pointer"
+              >
+                {s}
+              </button>
+            ))}
           </div>
         </div>
       )}

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -353,6 +353,29 @@ export const MessageList = ({
                   {/* Skeleton appended while recipe fence is still open */}
                   {hasOpenFence && <SkeletonRecipeCard />}
 
+                  {/* "More ideas" button — shown on completed Cook-With responses */}
+                  {!hasOpenFence &&
+                    status === "ready" &&
+                    isLastMsg &&
+                    blocks.some(
+                      (b) => b.kind === "recipe" && b.payload.closeness,
+                    ) && (
+                      <div className="mt-3">
+                        <button
+                          onClick={() =>
+                            onSend?.("More ideas — different from these")
+                          }
+                          className="inline-flex items-center gap-2 px-3.5 py-2 text-[12.5px] font-semibold text-muted-foreground border border-border rounded-full hover:border-border-soft hover:text-foreground transition-colors cursor-pointer"
+                        >
+                          <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                            <path d="M2 8a6 6 0 1 0 6-6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                            <path d="M5 5L2 8l3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                          </svg>
+                          More ideas like these
+                        </button>
+                      </div>
+                    )}
+
                   {/* Legacy recipe save buttons */}
                   {!hasOpenFence &&
                     blocks.some((b) => b.kind === "legacy") &&

--- a/src/features/Chat/components/recipe/RecipeLetter.test.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.test.tsx
@@ -50,8 +50,8 @@ const RECIPE: RecipeLetterProps['recipe'] = {
   title: 'Ginger Chicken',
   baseServings: 2,
   ingredients: [
-    { name: 'chicken thigh', category: 'Protein', amount: '500', unit: 'g' },
-    { name: 'bok choy', category: 'Vegetable', amount: '1', unit: 'bunch' },
+    { name: 'chicken thigh', category: 'Protein', amount: '500', unit: 'g', note: undefined },
+    { name: 'bok choy', category: 'Vegetable', amount: '1', unit: 'bunch', note: undefined },
   ],
   steps: [
     { title: 'Marinate', body: 'Toss chicken with soy.' },

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -43,6 +43,7 @@ interface RecipeData {
   prep?: string[];
   steps: Step[];
   tags?: string[];
+  closeness?: "close" | "stretch";
 }
 
 export interface RecipeLetterProps {
@@ -200,8 +201,23 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
     );
   }
 
+  const closenessLabel =
+    recipe.closeness === "close"
+      ? "Right now"
+      : recipe.closeness === "stretch"
+        ? "Worth a small trip"
+        : null;
+
   return (
     <div className="border-y border-border-soft px-4 sm:px-[26px] pt-5 pb-[22px] relative">
+      {/* Cook-With closeness caption */}
+      {closenessLabel && (
+        <div className="mb-3">
+          <span className="inline-flex items-center gap-1 font-sans text-[10px] font-bold tracking-[0.16em] uppercase px-2 py-0.5 rounded-full border border-dashed border-primary/40 text-primary bg-primary/5">
+            {recipe.closeness === "close" ? "✓" : "↗"} {closenessLabel}
+          </span>
+        </div>
+      )}
       {/* Title */}
       <div className="font-display text-3xl font-semibold text-foreground leading-[1.05] tracking-tight mb-2">
         {recipe.title}

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import { useSessionContext } from "@/contexts/SessionContext";
-import {
-  Category,
-  InventoryItem,
-} from "@/lib/inventory/schemas";
+import { InventoryItem } from "@/lib/inventory/schemas";
 
 type GetInventoryResponse = {
   kitchenwareInventory: InventoryItem[];
   ingredientInventory: InventoryItem[];
 };
 import { ingredientMatches } from "@/lib/recipes/matchIngredient";
+import { RecipeBlock, RecipeIngredientModel } from "@/lib/recipes/schemas";
 import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils";
 import { ShoppingCart, TimerIcon } from "lucide-react";
@@ -20,35 +18,9 @@ import { toast } from "sonner";
 import useSWR, { useSWRConfig } from "swr";
 import { ScaledNum, scaleAmount } from "@/features/Recipe";
 
-interface Ingredient {
-  name: string;
-  category?: Category;
-  amount?: string;
-  unit?: string;
-  note?: string;
-}
-
-interface Step {
-  title: string;
-  body: string;
-  tip?: string;
-}
-
-interface RecipeData {
-  title: string;
-  description?: string;
-  totalTimeMinutes?: number;
-  baseServings: number;
-  ingredients: Ingredient[];
-  prep?: string[];
-  steps: Step[];
-  tags?: string[];
-  closeness?: "close" | "stretch";
-}
-
 export interface RecipeLetterProps {
-  recipe: RecipeData;
-  onSave?: (recipe: RecipeData) => void;
+  recipe: RecipeBlock;
+  onSave?: (recipe: RecipeBlock) => void;
   isSaved?: boolean;
   onSend?: (text: string) => void;
 }
@@ -99,7 +71,7 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
     fetcher,
   );
 
-  const addToPantry = async (ing: Ingredient) => {
+  const addToPantry = async (ing: RecipeIngredientModel) => {
     if (!userId || inFlight.has(ing.name)) return;
     setInFlight((prev) => new Set(prev).add(ing.name));
     try {

--- a/src/features/Chat/hooks/useChatSession.ts
+++ b/src/features/Chat/hooks/useChatSession.ts
@@ -175,8 +175,9 @@ export function useChatSession() {
     if (status !== "ready") return;
     if (activeConversationId !== null) return; // only in staging
     const msg = pendingCookWithMessage;
-    clearCookWithMessage();
-    void handleSendMessage(msg);
+    handleSendMessage(msg)
+      .then(() => clearCookWithMessage())
+      .catch((err) => console.error("Cook-with auto-send failed:", err));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingCookWithMessage, status, activeConversationId]);
 

--- a/src/features/Chat/hooks/useChatSession.ts
+++ b/src/features/Chat/hooks/useChatSession.ts
@@ -24,6 +24,8 @@ export function useChatSession() {
     setPendingConversation,
     commitConversation,
     autoTitleActiveConversation,
+    pendingCookWithMessage,
+    clearCookWithMessage,
   } = useConversationContext();
 
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
@@ -165,6 +167,18 @@ export function useChatSession() {
   useEffect(() => {
     if (status !== "submitted") setSubmittedAt(null);
   }, [status]);
+
+  // Auto-send a Cook With What You Have message queued by the Pantry.
+  // Fires once status is "ready" and the session is in staging state.
+  useEffect(() => {
+    if (!pendingCookWithMessage) return;
+    if (status !== "ready") return;
+    if (activeConversationId !== null) return; // only in staging
+    const msg = pendingCookWithMessage;
+    clearCookWithMessage();
+    void handleSendMessage(msg);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingCookWithMessage, status, activeConversationId]);
 
   const handleRecipeDetected = useCallback(
     (recipeTitle: string) => {

--- a/src/features/Inventory/Inventory.test.ts
+++ b/src/features/Inventory/Inventory.test.ts
@@ -1,0 +1,41 @@
+import { buildCookWithMessage } from "./Inventory";
+import type { InventoryItem } from "@/lib/inventory/schemas";
+
+function makeIngredient(name: string): InventoryItem {
+  return { id: name, userId: "u1", name, type: "ingredient", shelfLife: "medium" };
+}
+
+function makeEquipment(name: string): InventoryItem {
+  return { id: name, userId: "u1", name, type: "kitchenware", shelfLife: "long" };
+}
+
+describe("buildCookWithMessage", () => {
+  it("ingredients only — no equipment section", () => {
+    const msg = buildCookWithMessage(
+      [makeIngredient("tomato"), makeIngredient("tofu")],
+      [],
+    );
+    expect(msg).toBe("Suggest recipes using: tomato, tofu");
+  });
+
+  it("ingredients + equipment", () => {
+    const msg = buildCookWithMessage(
+      [makeIngredient("chicken"), makeIngredient("bok choy")],
+      [makeEquipment("air fryer")],
+    );
+    expect(msg).toBe("Suggest recipes using: chicken, bok choy — featuring air fryer");
+  });
+
+  it("equipment only (no ingredients)", () => {
+    const msg = buildCookWithMessage([], [makeEquipment("wok")]);
+    expect(msg).toBe("Suggest recipes using:  — featuring wok");
+  });
+
+  it("multiple equipment items joined with comma", () => {
+    const msg = buildCookWithMessage(
+      [makeIngredient("egg")],
+      [makeEquipment("wok"), makeEquipment("rice cooker")],
+    );
+    expect(msg).toBe("Suggest recipes using: egg — featuring wok, rice cooker");
+  });
+});

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -15,8 +15,8 @@ type GetInventoryResponse = {
 };
 import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
 import { InventoryItemRow } from "./components/InventoryItemRow";
@@ -107,6 +107,17 @@ const Inventory = () => {
   const { userId } = useSessionContext();
   const { queueCookWithMessage, startNewConversation } = useConversationContext();
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Auto-enter selection mode when routed from Chat chip (?selectionMode=1)
+  useEffect(() => {
+    if (searchParams.get("selectionMode") === "1") {
+      setSelectionMode(true);
+      setSelectedIds(new Set());
+      // Clear the param without re-rendering the parent
+      router.replace("/?tab=pantry", { scroll: false });
+    }
+  }, [searchParams, router]);
 
   const { data, error, isLoading } = useSWR<GetInventoryResponse>(
     userId ? `/api/inventory?userId=${userId}` : null,

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -90,10 +90,11 @@ export function buildCookWithMessage(
 ): string {
   const names = selectedIngredients.map((i) => i.name).join(", ");
   const equipment = selectedEquipment.map((i) => i.name).join(", ");
+  const ingredientClause = names || "no featured ingredients";
   if (equipment) {
-    return `Suggest recipes using: ${names} — featuring ${equipment}`;
+    return `Suggest recipes using: ${ingredientClause}. Kitchenware: ${equipment}`;
   }
-  return `Suggest recipes using: ${names}`;
+  return `Suggest recipes using: ${ingredientClause}`;
 }
 
 const Inventory = () => {

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -385,15 +385,57 @@ const Inventory = () => {
 
         {/* Selection mode banner — desktop */}
         {selectionMode && (
-          <div className="hidden sm:flex items-center gap-2 mb-4 px-3 py-2.5 bg-primary/5 border border-dashed border-primary/30 rounded-lg">
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="text-primary shrink-0">
-              <path d="M3 8l3.5 3.5L13 4.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-            <span className="font-display italic text-[13px] text-muted-foreground">
-              {totalSelected === 0
-                ? "Tap items to feature them — Ah Mah will build recipes around your picks."
-                : `${totalSelected} item${totalSelected !== 1 ? "s" : ""} selected`}
-            </span>
+          <div className="hidden sm:flex items-center justify-between gap-2 mb-4 px-3 py-2.5 bg-primary/5 border border-dashed border-primary/30 rounded-lg">
+            <div className="flex items-center gap-2">
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="text-primary shrink-0">
+                <path d="M3 8l3.5 3.5L13 4.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+              <span className="font-display italic text-[13px] text-muted-foreground">
+                {totalSelected === 0
+                  ? "Tap items to feature them — Ah Mah will build recipes around your picks."
+                  : `${totalSelected} item${totalSelected !== 1 ? "s" : ""} selected`}
+              </span>
+            </div>
+            {ingredientInventory.some((i) => i.shelfLife === "short") && (
+              <button
+                onClick={() => {
+                  const shortIds = ingredientInventory
+                    .filter((i) => i.shelfLife === "short")
+                    .map((i) => i.id);
+                  setSelectedIds((prev) => {
+                    const next = new Set(prev);
+                    shortIds.forEach((id) => next.add(id));
+                    return next;
+                  });
+                }}
+                className="shrink-0 inline-flex items-center gap-1 font-sans text-[10.5px] font-semibold text-[oklch(0.5_0.12_50)] border border-dashed border-[oklch(0.7_0.08_50)] rounded-full px-2 py-0.5 hover:bg-[oklch(0.97_0.03_60)] transition-colors cursor-pointer"
+              >
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-tertiary" />
+                Select use-soon
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Selection mode short-shelf shortcut — mobile */}
+        {selectionMode && ingredientInventory.some((i) => i.shelfLife === "short") && (
+          <div className="sm:hidden mb-3">
+            <button
+              onClick={() => {
+                const shortIds = ingredientInventory
+                  .filter((i) => i.shelfLife === "short")
+                  .map((i) => i.id);
+                setSelectedIds((prev) => {
+                  const next = new Set(prev);
+                  shortIds.forEach((id) => next.add(id));
+                  return next;
+                });
+              }}
+              className="inline-flex items-center gap-1 font-sans text-[11px] font-semibold text-[oklch(0.5_0.12_50)] border border-dashed border-[oklch(0.7_0.08_50)] rounded-full px-2.5 py-1 hover:bg-[oklch(0.97_0.03_60)] transition-colors cursor-pointer"
+            >
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-tertiary" />
+              Select use-soon items
+            </button>
           </div>
         )}
 

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useConversationContext } from "@/contexts/ConversationContext";
 import { useSessionContext } from "@/contexts/SessionContext";
 import {
   Category,
@@ -12,7 +13,9 @@ type GetInventoryResponse = {
   kitchenwareInventory: InventoryItem[];
   ingredientInventory: InventoryItem[];
 };
+import { cn } from "@/lib/utils";
 import { fetcher } from "@/lib/utils";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
@@ -31,10 +34,16 @@ const CategoryCard = ({
   label,
   items,
   onRemove,
+  selectionMode,
+  selectedIds,
+  onToggle,
 }: {
   label: string;
   items: InventoryItem[];
   onRemove: (name: string) => void;
+  selectionMode?: boolean;
+  selectedIds?: Set<string>;
+  onToggle?: (id: string) => void;
 }) => (
   <section className="bg-card border border-border rounded-lg p-4 shadow-[0_1px_0_var(--color-border-soft)]">
     <div className="flex items-baseline justify-between border-b border-dashed border-border pb-2 mb-2">
@@ -47,7 +56,14 @@ const CategoryCard = ({
     </div>
     <ul className="list-none p-0 m-0">
       {items.map((item) => (
-        <InventoryItemRow key={item.id} item={item} onRemove={onRemove} />
+        <InventoryItemRow
+          key={item.id}
+          item={item}
+          onRemove={onRemove}
+          selectionMode={selectionMode}
+          selected={selectedIds?.has(item.id)}
+          onToggle={onToggle}
+        />
       ))}
     </ul>
   </section>
@@ -67,11 +83,30 @@ function groupIngredients(items: InventoryItem[]) {
   })).filter((g) => g.items.length > 0);
 }
 
+/** Composes the synthetic user message for Cook With What You Have. */
+export function buildCookWithMessage(
+  selectedIngredients: InventoryItem[],
+  selectedEquipment: InventoryItem[],
+): string {
+  const names = selectedIngredients.map((i) => i.name).join(", ");
+  const equipment = selectedEquipment.map((i) => i.name).join(", ");
+  if (equipment) {
+    return `Suggest recipes using: ${names} — featuring ${equipment}`;
+  }
+  return `Suggest recipes using: ${names}`;
+}
+
 const Inventory = () => {
   const [isAdding, setIsAdding] = useState(false);
   const [draft, setDraft] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
   const { userId } = useSessionContext();
+  const { queueCookWithMessage, startNewConversation } = useConversationContext();
+  const router = useRouter();
 
   const { data, error, isLoading } = useSWR<GetInventoryResponse>(
     userId ? `/api/inventory?userId=${userId}` : null,
@@ -137,6 +172,55 @@ const Inventory = () => {
     }
   };
 
+  const toggleItem = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const enterSelectionMode = () => {
+    setSelectionMode(true);
+    setSelectedIds(new Set());
+  };
+
+  const exitSelectionMode = () => {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  };
+
+  const handleCookWithSubmit = () => {
+    const allItems = [
+      ...(data?.ingredientInventory ?? []),
+      ...(data?.kitchenwareInventory ?? []),
+    ];
+    const selectedIngredients = allItems.filter(
+      (i) => selectedIds.has(i.id) && i.type !== "kitchenware",
+    );
+    const selectedEquipment = allItems.filter(
+      (i) => selectedIds.has(i.id) && i.type === "kitchenware",
+    );
+
+    if (selectedIngredients.length === 0 && selectedEquipment.length === 0) return;
+
+    const message = buildCookWithMessage(selectedIngredients, selectedEquipment);
+
+    // Reset selection — Conversation owns context from here
+    exitSelectionMode();
+
+    // Put Chat in staging state and queue the message
+    startNewConversation();
+    queueCookWithMessage(message);
+
+    // Navigate to chat tab
+    router.replace("/?tab=chat");
+  };
+
   if (error) return <div>Error: {error.message}</div>;
 
   const { ingredientInventory = [], kitchenwareInventory = [] } = data || {};
@@ -146,8 +230,27 @@ const Inventory = () => {
   );
   const totalCount = ingredientInventory.length + kitchenwareInventory.length;
 
+  // Selection counts
+  const allItems = [...ingredientInventory, ...kitchenwareInventory];
+  const selectedIngredients = allItems.filter(
+    (i) => selectedIds.has(i.id) && i.type !== "kitchenware",
+  );
+  const selectedEquipment = allItems.filter(
+    (i) => selectedIds.has(i.id) && i.type === "kitchenware",
+  );
+  const totalSelected = selectedIds.size;
+
+  const ctaLabel = (() => {
+    if (totalSelected === 0) return "Select items to cook";
+    if (selectedIngredients.length === 0 && selectedEquipment.length > 0) {
+      const names = selectedEquipment.map((i) => i.name).join(" & ");
+      return `Surprise me with ${names}`;
+    }
+    return `Suggest recipe (${totalSelected} selected)`;
+  })();
+
   return (
-    <div className="h-full overflow-y-auto">
+    <div className={cn("h-full overflow-y-auto", selectionMode && "pb-24")}>
       <div className="px-4 sm:px-9 pt-4 sm:pt-7 pb-5">
         {/* Header — hidden on mobile (tab strip already labels this surface) */}
         <div className="hidden sm:flex sm:items-end sm:justify-between sm:gap-6 mb-5">
@@ -172,46 +275,94 @@ const Inventory = () => {
               </p>
             )}
           </div>
-          {!isAdding && (
-            <button
-              onClick={() => setIsAdding(true)}
-              className="inline-flex items-center gap-1.5 px-3.5 py-2 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity shrink-0"
-            >
-              <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
-                <path
-                  d="M6 1.5V10.5M1.5 6H10.5"
-                  stroke="currentColor"
-                  strokeWidth="1.7"
-                  strokeLinecap="round"
-                />
-              </svg>
-              Add to pantry
-            </button>
+          <div className="flex items-center gap-2 shrink-0">
+            {!selectionMode ? (
+              <>
+                {totalCount > 0 && (
+                  <button
+                    onClick={enterSelectionMode}
+                    className="inline-flex items-center gap-1.5 px-3.5 py-2 text-[13px] font-semibold text-foreground bg-card border border-border rounded-lg cursor-pointer hover:bg-muted transition-colors"
+                  >
+                    Cook with what you have
+                  </button>
+                )}
+                {!isAdding && (
+                  <button
+                    onClick={() => setIsAdding(true)}
+                    className="inline-flex items-center gap-1.5 px-3.5 py-2 text-[13px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 transition-opacity shrink-0"
+                  >
+                    <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+                      <path
+                        d="M6 1.5V10.5M1.5 6H10.5"
+                        stroke="currentColor"
+                        strokeWidth="1.7"
+                        strokeLinecap="round"
+                      />
+                    </svg>
+                    Add to pantry
+                  </button>
+                )}
+              </>
+            ) : (
+              <button
+                onClick={exitSelectionMode}
+                className="inline-flex items-center gap-1.5 px-3.5 py-2 text-[13px] font-semibold text-muted-foreground bg-card border border-border rounded-lg cursor-pointer hover:bg-muted transition-colors"
+              >
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+                  <path d="M3 3l10 10M13 3L3 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                </svg>
+                Cancel
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Mobile header row */}
+        <div className="sm:hidden mb-3 flex items-center justify-between gap-2">
+          {!selectionMode ? (
+            <>
+              {totalCount > 0 && (
+                <button
+                  onClick={enterSelectionMode}
+                  className="inline-flex items-center gap-1.5 min-h-11 px-3 py-1.5 text-[12.5px] font-semibold text-foreground bg-card border border-border rounded-lg cursor-pointer"
+                >
+                  Cook with what you have
+                </button>
+              )}
+              {!isAdding && (
+                <button
+                  onClick={() => setIsAdding(true)}
+                  className="inline-flex items-center gap-1.5 min-h-11 px-3 py-1.5 text-[12.5px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)] ml-auto"
+                >
+                  <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
+                    <path
+                      d="M6 1.5V10.5M1.5 6H10.5"
+                      stroke="currentColor"
+                      strokeWidth="1.7"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                  Add to pantry
+                </button>
+              )}
+            </>
+          ) : (
+            <div className="flex items-center justify-between w-full">
+              <span className="font-display italic text-[14px] text-muted-foreground">
+                {totalSelected > 0 ? `${totalSelected} selected` : "Tap items to select"}
+              </span>
+              <button
+                onClick={exitSelectionMode}
+                className="inline-flex items-center gap-1.5 min-h-11 px-3 py-1.5 text-[12.5px] font-semibold text-muted-foreground bg-card border border-border rounded-lg cursor-pointer"
+              >
+                Cancel
+              </button>
+            </div>
           )}
         </div>
 
-        {/* Mobile-only add button (header is hidden) */}
-        {!isAdding && (
-          <div className="sm:hidden mb-3 flex justify-end">
-            <button
-              onClick={() => setIsAdding(true)}
-              className="inline-flex items-center gap-1.5 min-h-11 px-3 py-1.5 text-[12.5px] font-semibold text-primary-foreground bg-primary border border-primary rounded-lg cursor-pointer shadow-[0_1px_0_oklch(0.46_0.135_35)]"
-            >
-              <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
-                <path
-                  d="M6 1.5V10.5M1.5 6H10.5"
-                  stroke="currentColor"
-                  strokeWidth="1.7"
-                  strokeLinecap="round"
-                />
-              </svg>
-              Add to pantry
-            </button>
-          </div>
-        )}
-
-        {/* Use-soon legend — mobile only (desktop shows it in the header) */}
-        {ingredientInventory.some((i) => i.shelfLife === "short") && (
+        {/* Use-soon legend — mobile only */}
+        {!selectionMode && ingredientInventory.some((i) => i.shelfLife === "short") && (
           <p className="sm:hidden mb-3 font-display italic text-[13px] text-muted-foreground flex items-center gap-1.5">
             <span
               aria-hidden="true"
@@ -221,7 +372,21 @@ const Inventory = () => {
           </p>
         )}
 
-        {isAdding && (
+        {/* Selection mode banner — desktop */}
+        {selectionMode && (
+          <div className="hidden sm:flex items-center gap-2 mb-4 px-3 py-2.5 bg-primary/5 border border-dashed border-primary/30 rounded-lg">
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="text-primary shrink-0">
+              <path d="M3 8l3.5 3.5L13 4.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+            <span className="font-display italic text-[13px] text-muted-foreground">
+              {totalSelected === 0
+                ? "Tap items to feature them — Ah Mah will build recipes around your picks."
+                : `${totalSelected} item${totalSelected !== 1 ? "s" : ""} selected`}
+            </span>
+          </div>
+        )}
+
+        {isAdding && !selectionMode && (
           <Card className="mb-5">
             <CardHeader>
               <CardTitle className="font-display text-xl tracking-tight">
@@ -265,13 +430,19 @@ const Inventory = () => {
           </p>
         )}
 
-        {!isLoading && totalCount === 0 && !isAdding && (
+        {!isLoading && totalCount === 0 && !isAdding && !selectionMode && (
           <p className="font-display italic text-[14px] text-muted-foreground">
             Nothing in yet. Tell Ah Mah what you&rsquo;ve got &mdash; &ldquo;a bit of ginger, some eggs&rdquo; is enough.
           </p>
         )}
 
-        {/* Category masonry — CSS columns let cards flow and pack vertical gaps */}
+        {!isLoading && totalCount === 0 && selectionMode && (
+          <p className="font-display italic text-[14px] text-muted-foreground">
+            Your pantry is empty. Add some items first and Ah Mah can suggest what to cook.
+          </p>
+        )}
+
+        {/* Category masonry */}
         {totalCount > 0 && (
           <div className="columns-1 sm:columns-2 lg:columns-3 xl:columns-4 gap-3 [&>*]:break-inside-avoid [&>*]:mb-3">
             {ingredientGroups.map((group) => (
@@ -280,6 +451,9 @@ const Inventory = () => {
                 label={group.label}
                 items={group.items}
                 onRemove={removeItem}
+                selectionMode={selectionMode}
+                selectedIds={selectedIds}
+                onToggle={toggleItem}
               />
             ))}
             {equipmentItems.length > 0 && (
@@ -287,11 +461,34 @@ const Inventory = () => {
                 label="Equipment"
                 items={equipmentItems}
                 onRemove={removeItem}
+                selectionMode={selectionMode}
+                selectedIds={selectedIds}
+                onToggle={toggleItem}
               />
             )}
           </div>
         )}
       </div>
+
+      {/* Sticky bottom CTA — only in selection mode */}
+      {selectionMode && (
+        <div className="fixed bottom-0 left-0 right-0 z-20 px-4 py-3 bg-background/90 backdrop-blur-sm border-t border-border sm:absolute sm:bottom-0 sm:left-0 sm:right-0">
+          <div className="max-w-5xl mx-auto">
+            <button
+              onClick={handleCookWithSubmit}
+              disabled={totalSelected === 0}
+              className={cn(
+                "w-full py-3 px-4 rounded-xl font-semibold text-[14px] transition-all",
+                totalSelected > 0
+                  ? "bg-primary text-primary-foreground shadow-[0_1px_0_oklch(0.46_0.135_35)] hover:opacity-90 cursor-pointer"
+                  : "bg-muted text-muted-foreground cursor-not-allowed",
+              )}
+            >
+              {ctaLabel}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/Inventory/components/InventoryItemRow.tsx
+++ b/src/features/Inventory/components/InventoryItemRow.tsx
@@ -32,7 +32,14 @@ export function InventoryItemRow({
       <li
         role="checkbox"
         aria-checked={selected}
+        tabIndex={0}
         onClick={() => onToggle?.(item.id)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle?.(item.id);
+          }
+        }}
         className={cn(
           "flex items-center gap-2.5 py-1.5 border-b border-dotted border-border last:border-0 cursor-pointer select-none transition-colors",
           selected && "text-foreground",

--- a/src/features/Inventory/components/InventoryItemRow.tsx
+++ b/src/features/Inventory/components/InventoryItemRow.tsx
@@ -1,13 +1,23 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import { InventoryItem } from "@/lib/inventory/schemas";
 
 interface InventoryItemRowProps {
   item: InventoryItem;
   onRemove: (itemName: string) => void;
+  selectionMode?: boolean;
+  selected?: boolean;
+  onToggle?: (itemId: string) => void;
 }
 
-export function InventoryItemRow({ item, onRemove }: InventoryItemRowProps) {
+export function InventoryItemRow({
+  item,
+  onRemove,
+  selectionMode = false,
+  selected = false,
+  onToggle,
+}: InventoryItemRowProps) {
   const qty =
     item.quantity && item.unit
       ? `${item.quantity} ${item.unit}`
@@ -16,6 +26,56 @@ export function InventoryItemRow({ item, onRemove }: InventoryItemRowProps) {
         : item.unit
           ? item.unit
           : "";
+
+  if (selectionMode) {
+    return (
+      <li
+        role="checkbox"
+        aria-checked={selected}
+        onClick={() => onToggle?.(item.id)}
+        className={cn(
+          "flex items-center gap-2.5 py-1.5 border-b border-dotted border-border last:border-0 cursor-pointer select-none transition-colors",
+          selected && "text-foreground",
+        )}
+      >
+        <span
+          className={cn(
+            "shrink-0 w-4 h-4 rounded border flex items-center justify-center transition-colors",
+            selected
+              ? "bg-primary border-primary text-primary-foreground"
+              : "border-border bg-transparent",
+          )}
+        >
+          {selected && (
+            <svg width="9" height="9" viewBox="0 0 10 10" fill="none">
+              <path
+                d="M1.5 5L4 7.5L8.5 2.5"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
+        </span>
+        <span className="font-display text-[14px] leading-snug flex items-baseline gap-1.5 min-w-0 flex-1">
+          {item.shelfLife === "short" && (
+            <span
+              aria-label="Short shelf life"
+              title="Short shelf life — use soon"
+              className="inline-block h-1.5 w-1.5 rounded-full bg-tertiary shrink-0"
+            />
+          )}
+          <span className="truncate">{item.name}</span>
+        </span>
+        {qty && (
+          <span className="font-mono text-[11.5px] text-ink-faint tabular-nums shrink-0">
+            {qty}
+          </span>
+        )}
+      </li>
+    );
+  }
 
   return (
     <li className="group flex items-baseline gap-2 py-1.5 border-b border-dotted border-border last:border-0">

--- a/src/lib/recipes/schemas.ts
+++ b/src/lib/recipes/schemas.ts
@@ -39,6 +39,9 @@ export const RecipeBlockSchema = z.object({
   prep: z.array(z.string()).optional(),
   steps: z.array(RecipeStepSchema),
   tags: z.array(z.string()).optional(),
+  // Set by the model in Cook With What You Have (Mode 3) responses only.
+  // "close" = 0–2 additions (UI: "Right now"); "stretch" = 3–4 additions (UI: "Worth a small trip").
+  closeness: z.enum(["close", "stretch"]).optional(),
 });
 export type RecipeBlock = z.infer<typeof RecipeBlockSchema>;
 


### PR DESCRIPTION
## Summary

Implements the "Cook With What You Have" feature end-to-end, closing issues #229, #230, #231, #232, #233, #234.

The user selects pantry items (ingredients to feature, kitchenware as preferred equipment), submits, and lands in a new Conversation with a **Close Recipe** ("Right now") and a **Stretch Recipe** ("Worth a small trip"). A "More ideas like these" button pulls another pair without retyping.

Key design decisions documented in ADR-0006 and ADR-0007.

## What's in this PR (commit order)

1. **Docs** — CONTEXT.md glossary (Cook With What You Have, Featured Selection, Close Recipe, Stretch Recipe, Addition) + ADR-0006 + ADR-0007
2. **Mode 3 prompt** — new `CHAT_SYSTEM_PROMPT` section triggered by `"Suggest recipes using: …"` / `"More ideas — different from these"`. Close = 0–2 additions, Stretch = 3–4. `closeness` field added to `RecipeBlockSchema`. RecipeLetter renders "Right now" / "Worth a small trip" caption chip.
3. **Pantry selection mode** — mode toggle, checkboxes on ingredient + kitchenware rows, sticky bottom CTA, "Select use-soon items" shortcut, submit wires to `ConversationContext.queueCookWithMessage` + `router.replace("/?tab=chat")`
4. **Chat integrations** — "More ideas like these" button on completed Cook-With responses; "🥬 Cook with what I have →" chip in Chat Staging State routes to `?tab=pantry&selectionMode=1`
5. **Chrome polish** — short-shelf pre-select shortcut, mobile sticky CTA, empty-pantry messaging, selection mode banner
6. **progress.md** updated

## Test plan

- [ ] Pantry: tap "Cook with what you have" → checkboxes appear, remove buttons hide
- [ ] Select 2–3 ingredients → CTA shows count, tap → lands in Chat, synthetic message visible, model streams Close + Stretch with captions
- [ ] Select equipment-only → CTA says "Surprise me with [name]"
- [ ] "Select use-soon items" shortcut selects amber-dot items
- [ ] Cancel exits selection mode cleanly
- [ ] Chat staging chip → Pantry enters selection mode automatically
- [ ] "More ideas like these" appears after Cook-With response, sends follow-up
- [ ] Existing chat modes (Questions, Recipe-by-name, addInventoryItem) work unchanged
- [ ] 344 tests pass: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Cook With What You Have" selection mode to pick pantry items and equipment and submit for recipe suggestions.
  * Two recipe types returned per request: Close (few additions) and Stretch (more additions); cards show closeness badges.
  * "More ideas like these" button to generate non-repeating alternatives; chat navigation and an auto-send flow from selection mode.

* **Documentation**
  * Added glossary, progress notes, and architecture decision records describing the new flow and UI behavior.

* **Tests**
  * Added unit tests covering message composition for selection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->