### PR TITLE
fix(layout): cap container at 1280px on 2xl+ screens

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ function HomeContent() {
 
   return (
     <div className="bg-background h-full lg:h-full flex flex-col">
-      <main className="xl:container mx-auto h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] lg:flex-1 lg:min-h-0">
+      <main className="xl:container 2xl:max-w-screen-xl mx-auto h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] lg:flex-1 lg:min-h-0">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col pt-2 lg:pt-0">
           {/* Tab strip — hidden on desktop (sidebar handles nav) */}
           <TabsList className="lg:hidden">


### PR DESCRIPTION
## Summary
- Adds `2xl:max-w-screen-xl` to the main container in `page.tsx`
- Prevents `xl:container` from expanding to 1536px on 2xl+ screens (1920px monitors etc.)
- Keeps the layout consistently centered at 1280px on all large screens

## Test plan
- View the app on a wide monitor (≥1536px) and confirm the content no longer has excessive side margins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the main container styling on the homepage to utilize wider maximum-width settings on larger screens, enhancing the layout presentation while maintaining existing responsive behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->