### PR TITLE
fix(chat): in-flight send guard prevents double-submit during pre-send gap

### DIFF
--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -17,6 +17,7 @@ const Chat = () => {
     allMessages,
     status,
     submittedAt,
+    isSending,
     handleSendMessage,
     handleRecipeDetected,
   } = useChatSession();
@@ -105,11 +106,12 @@ const Chat = () => {
         messages={allMessages}
         status={status}
         submittedAt={submittedAt}
+        isSending={isSending}
         userId={userId}
         onSend={handleSendMessage}
         onRecipeDetected={handleRecipeDetected}
       />
-      {status === "ready" && messageCount === 0 && (
+      {status === "ready" && !isSending && messageCount === 0 && (
         <div className="px-4 pb-1">
           <div className="flex gap-2 flex-wrap max-w-5xl mx-auto">
             {/* Cook-with chip — routes to Pantry selection mode */}
@@ -133,7 +135,7 @@ const Chat = () => {
       )}
       <MessageInput
         onSendMessage={handleSendMessage}
-        disabled={status !== "ready"}
+        disabled={status !== "ready" || isSending}
       />
       <ConversationsMobileSheet open={convSheetOpen} onOpenChange={setConvSheetOpen} />
     </div>

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -28,6 +28,7 @@ interface MessageListProps {
   messages: UIMessage[];
   status: string;
   submittedAt: number | null;
+  isSending?: boolean;
   userId: string;
   onSend?: (text: string) => void;
   onRecipeDetected?: (title: string) => void;
@@ -83,6 +84,7 @@ export const MessageList = ({
   messages,
   status,
   submittedAt,
+  isSending = false,
   userId,
   onSend = () => {},
   onRecipeDetected,
@@ -438,9 +440,10 @@ export const MessageList = ({
             );
           })}
 
-          {/* Ghost loader bubble — visible while submitted, and while
-              streaming until the assistant has emitted visible content. */}
-          {shouldShowLoader(status, messages) && (
+          {/* Ghost loader bubble — visible during the pre-send gap (isSending),
+              while submitted, and while streaming until the assistant has
+              emitted visible content. */}
+          {(isSending || shouldShowLoader(status, messages)) && (
             <div className="py-4">
               <ChatLoader submittedAt={submittedAt} />
             </div>

--- a/src/features/Chat/hooks/useChatSession.test.ts
+++ b/src/features/Chat/hooks/useChatSession.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Regression tests for the in-flight send guard in useChatSession.
+ *
+ * The guard prevents duplicate submissions during the async pre-send gap
+ * (conversation creation + message save) that occurs before the AI SDK
+ * status transitions away from "ready".
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import { useChatSession } from "./useChatSession";
+
+// ── Context mocks ────────────────────────────────────────────────────────────
+
+const mockSetPendingConversation = jest.fn();
+const mockCommitConversation = jest.fn();
+
+jest.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => ({ userId: "user-1", isLoading: false }),
+}));
+
+jest.mock("@/contexts/ConversationContext", () => ({
+  useConversationContext: () => ({
+    activeConversationId: null,
+    setPendingConversation: mockSetPendingConversation,
+    commitConversation: mockCommitConversation,
+    autoTitleActiveConversation: jest.fn().mockResolvedValue(true),
+    pendingCookWithMessage: null,
+    clearCookWithMessage: jest.fn(),
+    activeConversation: null,
+  }),
+}));
+
+// ── AI SDK mocks ─────────────────────────────────────────────────────────────
+
+const mockSendMessage = jest.fn();
+
+jest.mock("@ai-sdk/react", () => ({
+  useChat: jest.fn(() => ({
+    messages: [],
+    sendMessage: mockSendMessage,
+    status: "ready",
+  })),
+}));
+
+jest.mock("ai", () => ({
+  DefaultChatTransport: jest.fn().mockImplementation(() => ({})),
+}));
+
+// ── SWR mocks ────────────────────────────────────────────────────────────────
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: [], isLoading: false, mutate: jest.fn() })),
+  mutate: jest.fn(),
+}));
+
+// ── Toast mock ───────────────────────────────────────────────────────────────
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn() },
+}));
+
+// ── Fetch mock ───────────────────────────────────────────────────────────────
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Helpers — use plain objects, not `new Response()`, because jsdom's Response
+// constructor doesn't set `.ok` reliably in the test environment.
+const okConversation = () =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ conversation: { id: "conv-1" } }),
+  });
+
+const okMessage = () =>
+  Promise.resolve({ ok: true, status: 200 });
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useChatSession — in-flight send guard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendMessage.mockResolvedValue(undefined);
+  });
+
+  it("sets isSending=true immediately on submit before fetch resolves", async () => {
+    let resolveConv!: (r: Response) => void;
+    const hangingConv = new Promise<Response>((res) => {
+      resolveConv = res;
+    });
+    mockFetch.mockReturnValueOnce(hangingConv);
+
+    const { result } = renderHook(() => useChatSession());
+
+    expect(result.current.isSending).toBe(false);
+
+    // Kick off the send but don't await it — fetch is still hanging
+    act(() => void result.current.handleSendMessage("nasi lemak"));
+
+    expect(result.current.isSending).toBe(true);
+
+    // Clean up — resolve the hanging fetch so the hook can settle
+    await act(async () => {
+      resolveConv({ ok: true, status: 200, json: () => Promise.resolve({ conversation: { id: "conv-1" } }) } as unknown as Response);
+      mockFetch.mockResolvedValue(okMessage());
+    });
+  });
+
+  it("blocks a duplicate send while one is already in flight", async () => {
+    let resolveConv!: (r: Response) => void;
+    const hangingConv = new Promise<Response>((res) => {
+      resolveConv = res;
+    });
+    // First call hangs at conversation POST; all subsequent calls succeed
+    mockFetch.mockReturnValueOnce(hangingConv);
+    mockFetch.mockResolvedValue(okMessage());
+
+    const { result } = renderHook(() => useChatSession());
+
+    // Start the first send without awaiting (stays in-flight at conv POST)
+    act(() => void result.current.handleSendMessage("char kway teow"));
+
+    // The second send should be blocked synchronously by the guard
+    await act(async () => {
+      await result.current.handleSendMessage("char kway teow");
+    });
+
+    // Only the single conversation POST should have fired — no second POST
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // sendMessage (stream) not yet called since conv fetch is still pending
+    expect(mockSendMessage).toHaveBeenCalledTimes(0);
+
+    // Clean up: resolve the first send so it can complete
+    await act(async () => {
+      resolveConv({ ok: true, status: 200, json: () => Promise.resolve({ conversation: { id: "conv-1" } }) } as unknown as Response);
+    });
+
+    // After the first send completes, exactly one stream was started
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("releases the lock and resets isSending=false when conversation creation fails", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const { result } = renderHook(() => useChatSession());
+
+    await act(async () => {
+      await result.current.handleSendMessage("hokkien mee");
+    });
+
+    expect(result.current.isSending).toBe(false);
+    expect(toast.error).toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("allows a new send after a previous one fails (lock fully released)", async () => {
+    // First send fails
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const { result } = renderHook(() => useChatSession());
+
+    await act(async () => {
+      await result.current.handleSendMessage("failed attempt");
+    });
+
+    // Now set up a successful path
+    mockFetch.mockReturnValueOnce(okConversation());
+    mockFetch.mockResolvedValue(okMessage());
+
+    await act(async () => {
+      await result.current.handleSendMessage("retry attempt");
+    });
+
+    // sendMessage called once (the retry, not the failed first attempt)
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/Chat/hooks/useChatSession.ts
+++ b/src/features/Chat/hooks/useChatSession.ts
@@ -29,6 +29,10 @@ export function useChatSession() {
   } = useConversationContext();
 
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  // Synchronous re-entrancy guard: prevents duplicate sends during the async
+  // pre-send gap (conversation create + message save) before status flips.
+  const sendingRef = useRef(false);
   const autoTitledConversations = useRef<Set<string>>(new Set());
   const autoTitlingConversations = useRef<Set<string>>(new Set());
 
@@ -166,6 +170,12 @@ export function useChatSession() {
 
   useEffect(() => {
     if (status !== "submitted") setSubmittedAt(null);
+    // Once status leaves "ready" the AI SDK's own disable logic takes over.
+    // Release the sync lock so it doesn't block re-sends after the response.
+    if (status !== "ready") {
+      sendingRef.current = false;
+      setIsSending(false);
+    }
   }, [status]);
 
   // Auto-send a Cook With What You Have message queued by the Pantry.
@@ -215,37 +225,51 @@ export function useChatSession() {
   const allMessages = [INITIAL_MESSAGE, ...savedMessagesFiltered, ...messages];
 
   const handleSendMessage = async (message: string) => {
+    // Synchronous guard: bail immediately if a send is already in progress.
+    if (sendingRef.current) return;
+    sendingRef.current = true;
+    setIsSending(true);
     setSubmittedAt(Date.now());
 
-    if (!activeConversationId) {
-      // Staging path: create conversation before sending
-      const res = await fetch("/api/conversation", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId }),
-      });
-      if (!res.ok) {
-        toast.error("Aiyah, could not start a new conversation. Try again!");
-        return;
+    try {
+      if (!activeConversationId) {
+        // Staging path: create conversation before sending
+        const res = await fetch("/api/conversation", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userId }),
+        });
+        if (!res.ok) {
+          throw new Error(`Could not start conversation (${res.status})`);
+        }
+        const { conversation } = await res.json();
+
+        // Update refs so transport injects the right id
+        convIdRef.current = conversation.id;
+        pendingConvIdRef.current = conversation.id;
+        inFlightConvIdRef.current = conversation.id;
+
+        // Optimistically show in sidebar with pending state
+        setPendingConversation(conversation);
+
+        // Save user message under the new conversation id
+        await saveMessage("user", message, conversation.id);
+      } else {
+        inFlightConvIdRef.current = activeConversationId;
+        await saveMessage("user", message);
       }
-      const { conversation } = await res.json();
 
-      // Update refs so transport injects the right id
-      convIdRef.current = conversation.id;
-      pendingConvIdRef.current = conversation.id;
-      inFlightConvIdRef.current = conversation.id;
-
-      // Optimistically show in sidebar with pending state
-      setPendingConversation(conversation);
-
-      // Save user message under the new conversation id
-      await saveMessage("user", message, conversation.id);
-    } else {
-      inFlightConvIdRef.current = activeConversationId;
-      await saveMessage("user", message);
+      // sendMessage flips status → "submitted", which releases the lock via
+      // the status effect above and hands disable/loader back to status.
+      sendMessage({ text: message });
+    } catch (err) {
+      console.error("Send failed:", err);
+      toast.error("Aiyah, could not send your message. Please try again!");
+      // Release lock so the user can retry.
+      sendingRef.current = false;
+      setIsSending(false);
+      setSubmittedAt(null);
     }
-
-    sendMessage({ text: message });
   };
 
   return {
@@ -254,6 +278,7 @@ export function useChatSession() {
     allMessages,
     status,
     submittedAt,
+    isSending,
     messagesLoading,
     handleSendMessage,
     handleRecipeDetected,


### PR DESCRIPTION
## Summary
- Adds a synchronous `sendingRef` re-entrancy guard to `handleSendMessage` — a second submit while one is already in flight returns immediately
- Adds `isSending` state that flips to `true` synchronously on submit, covering the async gap before the AI SDK `status` transitions from `"ready"` to `"submitted"`
- Loader bubble appears immediately on submit (not just once the stream starts)
- Input/send button disabled during the full gap, not just while the stream is running
- Lock releases automatically when status transitions (success path) or via catch block (failure path), allowing retry
- Typed text stays visible and greyed out during send; cleared only after the message POST succeeds
- Adds 4 regression tests covering: immediate `isSending=true`, double-send blocked, lock released on failure, retry allowed after failure

## Root cause
`handleSendMessage` awaits two network round-trips (`POST /api/conversation` in staging + `POST /api/message` always) before calling `sendMessage()`. The AI SDK `status` only flips from `"ready"` to `"submitted"` when `sendMessage()` runs — so during that gap, the input was still enabled and the loader wasn't showing. Users who saw no feedback would re-submit, creating a duplicate conversation.

## Test plan
- Open incognito (empty pantry, staging state), type a message, hit send → loader appears immediately, input greys out with text still in it
- Mash Enter or click send repeatedly during the pause → only one reply streams, only one conversation created
- After reply, send same text again → works fine (no false dedup)
- Existing conversation: same behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message input is now disabled while messages are being sent.
  * Loading indicator displays during message transmission.

* **Bug Fixes**
  * Messages can no longer be sent multiple times by rapid clicking.

* **Tests**
  * Added tests for message send behavior and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alantay/ask-ah-mah/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->