### PR TITLE
chore(copy): unify Ah Mah's voice across UI microcopy

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,7 +59,7 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   openGraph: {
-    title: "Ask Ah Mah — Cook with Ah Mah",
+    title: "Ask Ah Mah — Cook with what you have",
     description:
       "Ah Mah remembers what's in your kitchen and cooks alongside you. No forms, no spreadsheets — just chat.",
     url: "https://ask-ah-mah.vercel.app",
@@ -77,7 +77,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Ask Ah Mah — Cook with Ah Mah",
+    title: "Ask Ah Mah — Cook with what you have",
     description:
       "Ah Mah remembers what's in your kitchen and cooks alongside you. No forms, no spreadsheets — just chat.",
     images: ["/og-image.png"],

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ const fontLogo = Nunito({
 
 export const metadata: Metadata = {
   title: {
-    default: "Ask Ah Mah — Cook with Ah Mah",
+    default: "Ask Ah Mah — Cook with what you have",
     template: "%s | Ask Ah Mah",
   },
   description:
@@ -69,7 +69,7 @@ export const metadata: Metadata = {
         url: "/og-image.png",
         width: 1200,
         height: 630,
-        alt: "Ask Ah Mah - Cooking Assistant",
+        alt: "Ask Ah Mah — your kitchen's grandmother",
       },
     ],
     locale: "en_US",

--- a/src/components/AboutPopOver/index.tsx
+++ b/src/components/AboutPopOver/index.tsx
@@ -21,10 +21,10 @@ export default function AboutPopOver({
   const copyEmail = async () => {
     try {
       await navigator.clipboard.writeText("lun.tay.work@gmail.com");
-      toast.success("Email copied to clipboard!");
+      toast.success("Email copied — drop Ah Mah a note!");
     } catch (err) {
       console.error("Failed to copy email", err);
-      toast.error("Failed to copy email");
+      toast.error("Aiyah, couldn't copy. Try again?");
     }
   };
   return (

--- a/src/features/Auth/AuthButton.tsx
+++ b/src/features/Auth/AuthButton.tsx
@@ -16,7 +16,7 @@ export function AuthButton() {
 
   const handleSignOut = async () => {
     await authClient.signOut();
-    toast.success("Signed out");
+    toast.success("See you soon, ah.");
     window.location.reload();
   };
 

--- a/src/features/Auth/SignInDialog.tsx
+++ b/src/features/Auth/SignInDialog.tsx
@@ -34,7 +34,7 @@ export function SignInDialog() {
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Sign in to Ask Ah Mah</DialogTitle>
+          <DialogTitle>Welcome to Ah Mah&rsquo;s kitchen</DialogTitle>
           <DialogDescription>
             Your kitchen stays with you across devices.
           </DialogDescription>

--- a/src/features/Chat/components/MessageList.test.tsx
+++ b/src/features/Chat/components/MessageList.test.tsx
@@ -381,7 +381,7 @@ describe("MessageList", () => {
 
       await waitFor(() => {
         expect(toast.success).toHaveBeenCalledWith(
-          "Recipe Scrambled Eggs saved!"
+          "Saved — Ah Mah will remember this one."
         );
       });
     });

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -160,7 +160,7 @@ export const MessageList = ({
         { revalidate: false, populateCache: true },
       );
 
-      toast.success(`Recipe ${name} saved!`);
+      toast.success(`Saved — Ah Mah will remember this one.`);
     } catch (error) {
       console.error("Failed to save recipe:", error);
     }
@@ -205,10 +205,10 @@ export const MessageList = ({
         { revalidate: false, populateCache: true },
       );
 
-      toast.success(`Recipe "${recipeBlock.title}" saved to cookbook!`);
+      toast.success(`"${recipeBlock.title}" — kept in your cookbook.`);
     } catch (error) {
       console.error("Failed to save recipe:", error);
-      toast.error("Could not save recipe. Try again.");
+      toast.error("Aiyah, didn't save. Try again?");
     }
   };
 

--- a/src/features/Chat/components/recipe/RecipeLetter.test.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.test.tsx
@@ -168,7 +168,7 @@ describe('NEED pill click-to-add', () => {
     render(<RecipeLetter recipe={RECIPE} />);
     fireEvent.click(screen.getByLabelText('Add bok choy to pantry'));
     await waitFor(() =>
-      expect(mockToastSuccess).toHaveBeenCalledWith('Added bok choy to your pantry'),
+      expect(mockToastSuccess).toHaveBeenCalledWith('bok choy — in the pantry now.'),
     );
     expect(global.fetch).toHaveBeenCalledWith(
       '/api/inventory',

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -95,13 +95,13 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
           payload?.error ?? `Failed to add ${ing.name} (${res.status})`;
         throw new Error(msg);
       }
-      toast.success(`Added ${ing.name} to your pantry`);
+      toast.success(`${ing.name} — in the pantry now.`);
       mutate(inventoryKey);
     } catch (err) {
       toast.error(
         err instanceof Error
           ? err.message
-          : `Couldn't add ${ing.name} — please try again`,
+          : `Aiyah, couldn't add ${ing.name}. Try again?`,
       );
     } finally {
       setInFlight((prev) => {
@@ -142,8 +142,8 @@ export function RecipeLetter({ recipe, onSave, isSaved, onSend }: RecipeLetterPr
       })
       .join("\n");
     navigator.clipboard.writeText(lines).then(
-      () => toast.success("Shopping list copied to clipboard"),
-      () => toast.error("Couldn't copy — try selecting and copying manually"),
+      () => toast.success("Shopping list copied — go get them!"),
+      () => toast.error("Aiyah, couldn't copy — select and copy by hand?"),
     );
   };
 

--- a/src/features/Chat/constants.ts
+++ b/src/features/Chat/constants.ts
@@ -27,24 +27,24 @@ export const INITIAL_MESSAGE = {
   parts: [
     {
       type: "text" as const,
-      text: `**Hello dear!** I'm Ah Mah, your cooking assistant. I'd love to help you discover delicious recipes!
+      text: `**Aiyoh, you're here — good!** I'm Ah Mah. Tell me what's in your kitchen and we cook something together, can?
 
 
-- **Tell me what ingredients you have:** "I have chicken and rice"
-- **Add items to your kitchenware:** "I have a wok" 
-- **Ask for recipe suggestions:** "What can I cook for dinner?"
+- **What you have** — "got some chicken and rice"
+- **Your tools** — "I have a wok"
+- **Or just ask** — "what can I make for dinner?"
 
 ---
 
-**What would you like to cook today?** 🍳`,
+**So — what are we cooking today?** 🍳`,
     },
   ],
 };
 
 export const SUGGESTIONS = [
   "What can I cook tonight?",
-  "I just got groceries",
-  "Something quick for one",
+  "Just back from the market",
+  "Something quick, just for me",
 ];
 
 export const LOADING_MESSAGES = [

--- a/src/features/Conversations/Conversations.tsx
+++ b/src/features/Conversations/Conversations.tsx
@@ -72,7 +72,7 @@ export function Conversations({ onItemClick }: ConversationsProps) {
         {isLoading && allConversations.length === 0 ? (
           <ConversationListSkeleton />
         ) : committedConversations.length === 0 ? (
-          <div className="italic text-ink-faint text-sm">No conversations yet</div>
+          <div className="italic text-ink-faint text-sm">No chats yet.</div>
         ) : (
           <div className="flex flex-col gap-3">
             {groups.map((group) => (

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -148,15 +148,15 @@ const Inventory = () => {
         mutate(`/api/inventory?userId=${userId}`);
         toast.success(
           items.length === 1
-            ? `${items[0].name} added`
-            : `${items.length} items added`,
+            ? `${items[0].name} — in the pantry now.`
+            : `${items.length} things, all noted down.`,
         );
       } else {
-        toast.error("Couldn't parse that — try rephrasing");
+        toast.error("Aiyah, didn't catch that — say it another way?");
       }
     } catch (e) {
       console.error("Failed to add items:", e);
-      toast.error("Couldn't add items, try again");
+      toast.error("Aiyah, couldn't note that down. Try again?");
     } finally {
       setSubmitting(false);
     }
@@ -172,15 +172,15 @@ const Inventory = () => {
       });
       if (response.ok) {
         mutate(`/api/inventory?userId=${userId}`);
-        toast.success(`${itemName} removed from inventory`);
+        toast.success(`Okay, took out the ${itemName}.`);
       } else {
         const detail = await response.text().catch(() => "");
         console.error(`DELETE /api/inventory ${response.status}:`, detail);
-        toast.error(`${itemName} failed to remove from inventory`);
+        toast.error(`Aiyah, ${itemName} won't budge. Try again?`);
       }
     } catch (e) {
       console.error("Failed to remove item:", e);
-      toast.error(`${itemName} failed to remove from inventory`);
+      toast.error(`Aiyah, ${itemName} won't budge. Try again?`);
     }
   };
 
@@ -432,7 +432,7 @@ const Inventory = () => {
 
         {!isLoading && totalCount === 0 && selectionMode && (
           <p className="font-display italic text-[14px] text-muted-foreground">
-            Your pantry is empty. Add some items first and Ah Mah can suggest what to cook.
+            Pantry&rsquo;s empty for now. Add a few things first, then Ah Mah can suggest what to cook.
           </p>
         )}
 

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -500,7 +500,7 @@ export default function RecipeDisplay({
       originalRecipeRef.current = workingDraft;
       setBenchOpen(false);
       setChanges([]);
-      toast.success("Recipe saved!");
+      toast.success("Saved — into your cookbook.");
     } catch (err) {
       console.error("[RecipeDisplay] save error:", err);
       toast.error("Couldn't save. Try again?");

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -41,9 +41,9 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
       });
       if (!res.ok) throw new Error("Delete failed");
       mutate(`/api/recipe?userId=${userId}`);
-      toast.success("Recipe deleted");
+      toast.success("Okay, thrown away.");
     } catch {
-      toast.error("Failed to delete recipe");
+      toast.error("Aiyah, couldn't throw it away. Try again?");
     }
   };
 
@@ -206,7 +206,7 @@ function CookbookEmpty({ onChatClick, onPasteClick }: { onChatClick?: () => void
         </div>
         <div>
           <div className="font-display font-semibold text-[22px] text-foreground leading-tight tracking-tight mb-1.5">
-            Your cookbook is empty.
+            Cookbook&rsquo;s empty for now.
           </div>
           <div className="font-display italic text-sm text-muted-foreground leading-relaxed">
             When something&rsquo;s worth a second go, tap <em>Save</em>. Ah Mah keeps it tidy.

--- a/src/features/RecipeList/components/AddRecipeModal.tsx
+++ b/src/features/RecipeList/components/AddRecipeModal.tsx
@@ -213,10 +213,10 @@ export function AddRecipeModal({ open, onOpenChange }: AddRecipeModalProps) {
       });
       if (!res.ok) throw new Error("Save failed");
       mutate(`/api/recipe?userId=${userId}`);
-      toast.success("Recipe saved to your cookbook");
+      toast.success("Kept in your cookbook.");
       handleOpenChange(false);
     } catch {
-      toast.error("Failed to save recipe");
+      toast.error("Aiyah, couldn't keep it. Try again?");
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## Summary
A voice-consistency pass over every user-facing string. The app already had a strong grandmother persona, but it broke at the highest-frequency touchpoints — toasts and errors were flat dev-speak. This brings them all up to the standard the best in-app copy already sets (light Singlish, warm, "aiyah → never mind → try again?").

- **Toasts & errors** persona-fied across pantry, cookbook, in-chat save, recipe letter, add-modal, and About. e.g.:
  - "Failed to delete recipe" → "Aiyah, couldn't throw it away. Try again?"
  - "{item} removed from inventory" → "Okay, took out the {item}."
  - "Could not save recipe. Try again." → "Aiyah, didn't save. Try again?"
  - "Signed out" → "See you soon, ah."
- **Onboarding greeting** rewritten from generic-assistant copy into Ah Mah's voice
- **Empty states** softened (cookbook, pantry, conversations)
- **Sign-in** title → "Welcome to Ah Mah's kitchen"
- **SEO/OG**: title → "Cook with what you have"; OG alt refreshed
- **Suggestion chip**: "I just got groceries" → "Just back from the market"
- Left already-strong copy untouched (loading messages, "She jots them down as you chat", delete-confirm, chat persona errors)

Voice dial: **light seasoning**. Scope: **everything, persona-led**.

## Test plan
- `pnpm test` — all 348 pass (2 toast-string assertions updated to match)
- Greeting + suggestions render verified via Playwright screenshot
- Trigger toasts manually (add/remove item, save/delete recipe) to confirm interpolation + new strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to match revised user-facing messages.

* **Chores**
  * Updated user-facing messaging throughout the app, including toast notifications for user actions, page titles, dialog headers, empty state text, and initial greeting content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->