### PR TITLE
chore: gitignore temp/ and test-results/ scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ skills-lock.json
 
 # Git worktrees
 .worktrees/
+
+# AI scratch + local test output (never committed)
+temp/
+test-results/
+.agentindex
+.agentindexignore


### PR DESCRIPTION
## Summary
- Ignore `temp/` — local scratch space for AI tooling (design mockups, uploads, etc.)
- Ignore `test-results/` — Playwright run output

Neither should ever be staged or pushed; both were producing hundreds of untracked files cluttering `git status`.

## Test plan
- `git check-ignore temp/ test-results/` → both report as ignored
- `git status` no longer lists files under either directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to exclude additional development directories and temporary files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->