### PR TITLE
feat(tokens): primary-deep, type scale, and CTA shadow utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,6 +49,26 @@
   --color-tertiary: var(--tertiary);
   --color-jade: var(--jade);
   --color-jade-foreground: var(--jade-foreground);
+  --color-primary-deep: var(--primary-deep);
+
+  /* Kopitiam type scale — only sizes that don't map cleanly to Tailwind defaults.
+     Use Tailwind text-xs (12) / text-sm (14) / text-lg (18) / text-xl (20) for everything else.
+     Ban arbitrary text-[Npx] outside this scale. */
+  --text-micro: 11px;
+  --text-micro--line-height: 1.35;
+  --text-dense: 13px;
+  --text-dense--line-height: 1.4;
+  --text-emphasis: 15px;
+  --text-emphasis--line-height: 1.5;
+  --text-heading: 22px;
+  --text-heading--line-height: 1.15;
+  --text-display: 40px;
+  --text-display--line-height: 1;
+
+  /* CTA hard shadows — the "stamped paper" depth under the terracotta primary button.
+     Always use these tokens for the hard-shadow pattern; never reinvent inline. */
+  --shadow-cta: 0 1px 0 var(--primary-deep);
+  --shadow-cta-deep: 0 2px 0 var(--primary-deep);
 }
 
 :root {
@@ -79,6 +99,8 @@
   /* Terracotta primary */
   --primary: oklch(0.56 0.135 35);
   --primary-foreground: oklch(0.97 0.02 80);
+  /* Deeper terracotta — used for the hard-shadow underbite on primary CTAs */
+  --primary-deep: oklch(0.46 0.135 35);
 
   /* Butter — user message bubbles */
   --secondary: oklch(0.86 0.1 88);
@@ -127,6 +149,7 @@
   --chat: oklch(0.25 0.025 50);
   --primary: oklch(0.66 0.14 35);
   --primary-foreground: oklch(0.22 0.028 50);
+  --primary-deep: oklch(0.54 0.14 35);
   --secondary: oklch(0.5 0.075 88);
   --secondary-foreground: oklch(0.95 0.025 78);
   --muted: oklch(0.3 0.025 50);


### PR DESCRIPTION
## Summary

First step of the design-system audit (see chat). Adds the missing **foundation tokens** so subsequent PRs can codemod the drifted inline values onto a single source of truth. Purely additive — no existing usage is touched, so visual output is byte-identical.

### New tokens (all in \`globals.css\`)

- **\`--primary-deep\`** — the deeper terracotta currently hand-rolled inline for hard-shadow underbites under primary buttons. Today there are at least four divergent copies across Inventory, AddRecipeModal, and TweakBench (e.g. \`oklch(0.46 0.135 35)\` vs \`oklch(0.405 0.130 32)\` vs \`oklch(0.82 0.04 70)\`).
- **\`--text-micro / dense / emphasis / heading / display\`** — names for the five Ah Mah-specific sizes that don't map cleanly to Tailwind defaults (11, 13, 15, 22, 40 px). Tailwind \`text-xs / sm / lg / xl\` covers the rest. Today there are ~121 arbitrary \`text-[Npx]\` calls across the codebase, including half-pixel sizes like \`text-[9.5px]\` and \`text-[12.5px]\` that are clearly eyeballed.
- **\`--shadow-cta\` / \`--shadow-cta-deep\`** — utilities that consolidate the three drifted hard-shadow recipes into one source of truth.

### What this unblocks

- Step 2: promote a \`<CtaButton>\` variant onto shadcn \`<Button>\` and swap the 4+ hand-rolled CTAs.
- Step 3: codemod the worst type-scale offenders (\`text-[9.5px]\`, \`text-[10.5px]\`, \`text-[12.5px]\`) onto the named scale.
- Step 4: replace remaining inline \`oklch()\` calls with tokens (AddRecipeModal's red palette is the biggest offender).
- Step 5: \`docs/design-system.md\` documenting the tokens and three rules.

## Test plan

- [ ] \`pnpm build\` — no Tailwind compile errors
- [ ] Visual diff: load Pantry / Chat / Cookbook before & after — should be byte-identical (verified locally via Playwright screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)