### PR TITLE
test(chat): cover More ideas button render conditions (#232)

### DIFF
--- a/src/features/Chat/components/MessageList.test.tsx
+++ b/src/features/Chat/components/MessageList.test.tsx
@@ -52,6 +52,10 @@ jest.mock("./recipe/SuggestionsBlock", () => ({
   SuggestionsBlock: () => <div data-testid="suggestions-block" />,
 }));
 
+jest.mock("./recipe/RecipeLetter", () => ({
+  RecipeLetter: () => <div data-testid="recipe-letter" />,
+}));
+
 // Mock AI Elements components
 jest.mock("@/components/ai-elements/conversation", () => ({
   Conversation: ({ children }: { children: React.ReactNode }) => (
@@ -749,6 +753,82 @@ describe("MessageList", () => {
       // Button should be focusable
       saveButton.focus();
       expect(saveButton).toHaveFocus();
+    });
+  });
+
+  describe('"More ideas" button (Cook-With responses)', () => {
+    const recipeFence = (title: string, closeness?: "close" | "stretch") =>
+      "```recipe\n" +
+      JSON.stringify({
+        title,
+        baseServings: 2,
+        ingredients: [{ name: "egg" }],
+        steps: [{ title: "Cook", body: "Cook it." }],
+        ...(closeness ? { closeness } : {}),
+      }) +
+      "\n```";
+
+    const cookWithMessage = (closeness: "close" | "stretch" = "close") =>
+      createMockMessage({
+        id: "msg-cookwith",
+        role: "assistant",
+        parts: [{ type: "text", text: recipeFence("Tomato Egg", closeness) }],
+      });
+
+    it("renders below a completed Cook-With response", () => {
+      render(
+        <MessageList {...defaultProps} messages={[cookWithMessage("close")]} />,
+      );
+
+      expect(screen.getByText("More ideas like these")).toBeInTheDocument();
+    });
+
+    it("sends 'More ideas — different from these' on click", async () => {
+      const onSend = jest.fn();
+      render(
+        <MessageList
+          {...defaultProps}
+          messages={[cookWithMessage("stretch")]}
+          onSend={onSend}
+        />,
+      );
+
+      await user.click(screen.getByText("More ideas like these"));
+
+      expect(onSend).toHaveBeenCalledWith("More ideas — different from these");
+    });
+
+    it("is hidden while the assistant is streaming", () => {
+      render(
+        <MessageList
+          {...defaultProps}
+          messages={[cookWithMessage("close")]}
+          status="streaming"
+        />,
+      );
+
+      expect(
+        screen.queryByText("More ideas like these"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render on a regular recipe response (no closeness)", () => {
+      render(
+        <MessageList
+          {...defaultProps}
+          messages={[
+            createMockMessage({
+              id: "msg-regular",
+              role: "assistant",
+              parts: [{ type: "text", text: recipeFence("Plain Recipe") }],
+            }),
+          ]}
+        />,
+      );
+
+      expect(
+        screen.queryByText("More ideas like these"),
+      ).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
Closes the last open acceptance criterion of #232. The "More ideas like these" button is already implemented in `MessageList.tsx`; this PR adds the test coverage it was missing.

New tests in `MessageList.test.tsx`:
- Button renders below a completed Cook-With response (recipe block carrying `closeness`)
- Click sends `More ideas — different from these` via `onSend`
- Button is hidden while the assistant is streaming
- Button does **not** render on a regular recipe response (no `closeness`)

`RecipeLetter` is mocked to isolate the button's render condition.

## Verification
`pnpm jest src/features/Chat/components/MessageList.test.tsx` → `Tests: 37 passed, 37 total` (4 new + 33 existing). The pre-push hook (runs `pnpm test`) passed on push.

Resolves #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the "More ideas like these" feature, validating button visibility for completed responses, click behavior, behavior during assistant responses, and exclusion from standard recipe displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->