### PR TITLE
fix(tweak): stop tweak bench freezing on the loading dots

### DIFF
--- a/src/features/RecipeDisplay/TweakBench.test.tsx
+++ b/src/features/RecipeDisplay/TweakBench.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import { TextDecoder, TextEncoder } from "util";
+import type { RecipeWithId } from "@/lib/recipes/schemas";
+import { TweakBench } from "./TweakBench";
+
+Object.assign(global, { TextEncoder, TextDecoder });
+Element.prototype.scrollIntoView = jest.fn();
+
+const recipe: RecipeWithId = {
+  id: "recipe-1",
+  userId: "user-123",
+  name: "Mapo Tofu",
+  instructions: "",
+  baseServings: 2,
+  ingredients: [{ name: "tofu", category: "Misc", amount: 1, unit: "block" }],
+  steps: [{ title: "Cook", body: "Cook it" }],
+  tags: ["spicy"],
+};
+
+const tweakResponse = {
+  recipe: {
+    title: "Mapo Tofu",
+    baseServings: 2,
+    ingredients: [{ name: "tofu", amount: "1", unit: "block" }],
+    steps: [{ title: "Cook", body: "Cook it gently" }],
+    tags: ["mild"],
+  },
+  changes: [
+    {
+      kind: "step_replaced",
+      ref: { type: "step", index: 0, basis: "workingDraft" },
+      label: "Toned down the chili",
+    },
+  ],
+};
+
+function streamOf(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    body: streamOf(JSON.stringify(tweakResponse)),
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function renderBench() {
+  return render(
+    <StrictMode>
+      <TweakBench
+        recipe={recipe}
+        userId="user-123"
+        onWorkingDraftChange={jest.fn()}
+        onClose={jest.fn()}
+        onSave={jest.fn()}
+        isSaving={false}
+      />
+    </StrictMode>,
+  );
+}
+
+describe("TweakBench streaming lifecycle (StrictMode)", () => {
+  it("clears the streaming state and reveals Save once a tweak completes", async () => {
+    renderBench();
+
+    fireEvent.click(screen.getByText("Less spicy"));
+
+    // The assistant turn should render with the change label
+    await waitFor(() =>
+      expect(screen.getByText("Toned down the chili")).toBeInTheDocument(),
+    );
+
+    // And the bench must leave the streaming state, not stay stuck on the dots
+    await waitFor(() =>
+      expect(screen.queryByText("Ah Mah is rewriting…")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Save to my cookbook")).toBeInTheDocument();
+  });
+});

--- a/src/features/RecipeDisplay/TweakBench.tsx
+++ b/src/features/RecipeDisplay/TweakBench.tsx
@@ -64,6 +64,9 @@ export function TweakBench({
   }, [recipe.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    // Restore on (re)mount — StrictMode runs setup→cleanup→setup, and without
+    // this the ref would stay false, gating setIsStreaming(false) forever.
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       abortRef.current?.abort();


### PR DESCRIPTION
## Summary
- The tweak bench in the recipe drilldown sometimes stayed stuck on the loading dots even after the `/api/recipe/[id]/tweak` endpoint responded — the assistant reply / tweaked recipe wouldn't surface and the input stayed disabled with no Save button.
- **Root cause:** `TweakBench`'s `mountedRef` was set to `false` in the effect cleanup but never restored in the setup body. Next.js enables `reactStrictMode` by default, so in dev React runs setup→cleanup→setup on mount, leaving `mountedRef.current === false` for the component's whole life. The stream `finally` gates `setIsStreaming(false)` behind that ref, so `isStreaming` got stuck `true` forever — freezing the bench on the dots.
- **Fix:** restore `mountedRef.current = true` in the effect setup body.

## Test plan
- Added `TweakBench.test.tsx` — renders under `<StrictMode>`, drives a full tweak, and asserts the streaming state clears and the Save button appears. Fails without the fix, passes with it.
- Full suite green (349 tests).
- Manual: open a saved recipe → Tweak this recipe → run a tweak → confirm the result renders, dots disappear, and "Save to my cookbook" appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TweakBench component to properly handle React StrictMode's lifecycle, preventing the component from getting stuck during mount cycles.

* **Tests**
  * Added comprehensive test suite for TweakBench streaming functionality, verifying UI behavior when tweaking recipes and confirming proper state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->