### PR TITLE
fix(tweak): tolerate fenced/prose JSON and fail gracefully

### DIFF
--- a/src/features/RecipeDisplay/TweakBench.test.tsx
+++ b/src/features/RecipeDisplay/TweakBench.test.tsx
@@ -45,31 +45,41 @@ function streamOf(text: string): ReadableStream<Uint8Array> {
   });
 }
 
-beforeEach(() => {
+const validBody = JSON.stringify(tweakResponse);
+
+function mockTweakBody(body: string) {
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
-    body: streamOf(JSON.stringify(tweakResponse)),
+    body: streamOf(body),
   }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  mockTweakBody(validBody);
 });
 
 afterEach(() => {
   jest.restoreAllMocks();
 });
 
-function renderBench() {
-  return render(
+function renderBench(onWorkingDraftChange: jest.Mock = jest.fn()) {
+  render(
     <StrictMode>
       <TweakBench
         recipe={recipe}
         userId="user-123"
-        onWorkingDraftChange={jest.fn()}
+        onWorkingDraftChange={onWorkingDraftChange}
         onClose={jest.fn()}
         onSave={jest.fn()}
         isSaving={false}
       />
     </StrictMode>,
   );
+  return onWorkingDraftChange;
 }
+
+const appliedWith = (label: string) =>
+  expect.arrayContaining([expect.objectContaining({ label })]);
 
 describe("TweakBench streaming lifecycle (StrictMode)", () => {
   it("clears the streaming state and reveals Save once a tweak completes", async () => {
@@ -87,5 +97,57 @@ describe("TweakBench streaming lifecycle (StrictMode)", () => {
       expect(screen.queryByText("Ah Mah is rewriting…")).not.toBeInTheDocument(),
     );
     expect(screen.getByText("Save to my cookbook")).toBeInTheDocument();
+  });
+});
+
+describe("TweakBench tolerant response parsing", () => {
+  it("applies a bare-JSON response (no regression)", async () => {
+    const onChange = renderBench();
+    fireEvent.click(screen.getByText("Less spicy"));
+    await waitFor(() => expect(screen.getByText("Toned down the chili")).toBeInTheDocument());
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), appliedWith("Toned down the chili"));
+  });
+
+  it("applies a ```json fenced response", async () => {
+    mockTweakBody("```json\n" + validBody + "\n```");
+    const onChange = renderBench();
+    fireEvent.click(screen.getByText("Less spicy"));
+    await waitFor(() => expect(screen.getByText("Toned down the chili")).toBeInTheDocument());
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), appliedWith("Toned down the chili"));
+    // Raw fence text must never reach the chat
+    expect(screen.queryByText(/```json/)).not.toBeInTheDocument();
+  });
+
+  it("applies a response prefixed with prose", async () => {
+    mockTweakBody("Sure, here's the updated recipe: " + validBody);
+    const onChange = renderBench();
+    fireEvent.click(screen.getByText("Less spicy"));
+    await waitFor(() => expect(screen.getByText("Toned down the chili")).toBeInTheDocument());
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), appliedWith("Toned down the chili"));
+  });
+
+  it("shows a friendly message (not raw JSON) for a truncated response", async () => {
+    mockTweakBody(validBody.slice(0, 80)); // cut off mid-object, as a token cap would
+    const onChange = renderBench();
+    fireEvent.click(screen.getByText("Less spicy"));
+    await waitFor(() =>
+      expect(screen.getByText("Aiyah, that tweak came back muddled. Try again?")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/"recipe"/)).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalledWith(expect.anything(), appliedWith("Toned down the chili"));
+    // Streaming state still clears (the #254 fix stays intact)
+    expect(screen.queryByText("Ah Mah is rewriting…")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a plain-text refusal from the model verbatim", async () => {
+    mockTweakBody("Aiyah, that would be a totally different dish, not a tweak.");
+    const onChange = renderBench();
+    fireEvent.click(screen.getByText("Less spicy"));
+    await waitFor(() =>
+      expect(
+        screen.getByText("Aiyah, that would be a totally different dish, not a tweak."),
+      ).toBeInTheDocument(),
+    );
+    expect(onChange).not.toHaveBeenCalledWith(expect.anything(), appliedWith("Toned down the chili"));
   });
 });

--- a/src/features/RecipeDisplay/TweakBench.tsx
+++ b/src/features/RecipeDisplay/TweakBench.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { extractJsonObject, looksLikeJsonAttempt } from "@/lib/recipes/extractJsonObject";
 import type { ChangeEntry, RecipeWithId } from "@/lib/recipes/schemas";
 import {
   recipeBlockToRecipeWithId,
@@ -30,6 +31,12 @@ interface TweakBenchProps {
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const QUICK_TWEAKS = ["Less spicy", "Make it quicker", "More servings", "Swap for pantry staples"];
+
+// Friendly fallbacks — shown when the model's reply can't be applied. Never
+// surface raw/partial JSON to the user.
+const MUDDLED_MESSAGE = "Aiyah, that tweak came back muddled. Try again?";
+const GENERIC_ERROR_MESSAGE = "Aiyah, something went wrong. Try again?";
+const EMPTY_REFUSAL_FALLBACK = "Ah Mah couldn't do that one. Try a different instruction?";
 
 // ─── TweakBench ──────────────────────────────────────────────────────────────
 
@@ -134,7 +141,29 @@ export function TweakBench({
 
         if (abortController.signal.aborted) return;
 
-        const parsedJson = JSON.parse(accumulated);
+        // The model is asked for pure JSON, but may wrap it in fences, prefix
+        // prose, refuse in plain text, or get truncated by the token cap.
+        const extracted = extractJsonObject(accumulated);
+
+        if (!extracted) {
+          // No recoverable object. If it still *looked* like JSON, it's garbled
+          // or truncated — hide it behind a friendly message rather than dumping
+          // raw text. Otherwise treat it as the model's plain-text refusal.
+          const text = looksLikeJsonAttempt(accumulated)
+            ? MUDDLED_MESSAGE
+            : accumulated.trim() || EMPTY_REFUSAL_FALLBACK;
+          setTurns((prev) => [...prev, { kind: "refusal", text }]);
+          return;
+        }
+
+        let parsedJson: unknown;
+        try {
+          parsedJson = JSON.parse(extracted);
+        } catch {
+          setTurns((prev) => [...prev, { kind: "refusal", text: MUDDLED_MESSAGE }]);
+          return;
+        }
+
         const parsedResponse = TweakResponseSchema.safeParse(parsedJson);
 
         if (parsedResponse.success) {
@@ -148,23 +177,12 @@ export function TweakBench({
           ]);
         } else {
           console.warn("[TweakBench] invalid tweak payload:", parsedResponse.error.flatten());
-          setTurns((prev) => [
-            ...prev,
-            { kind: "refusal", text: "Aiyah, that tweak came back muddled. Try again?" },
-          ]);
+          setTurns((prev) => [...prev, { kind: "refusal", text: MUDDLED_MESSAGE }]);
         }
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;
-        if (err instanceof SyntaxError) {
-          const refusalText = accumulated.trim() || "Ah Mah couldn't do that one. Try a different instruction?";
-          setTurns((prev) => [...prev, { kind: "refusal", text: refusalText }]);
-          return;
-        }
         console.error("[TweakBench] stream error:", err);
-        setTurns((prev) => [
-          ...prev,
-          { kind: "refusal", text: "Aiyah, something went wrong. Try again?" },
-        ]);
+        setTurns((prev) => [...prev, { kind: "refusal", text: GENERIC_ERROR_MESSAGE }]);
       } finally {
         if (mountedRef.current && abortRef.current === abortController) {
           abortRef.current = null;

--- a/src/lib/recipes/extractJsonObject.test.ts
+++ b/src/lib/recipes/extractJsonObject.test.ts
@@ -1,0 +1,65 @@
+import { extractJsonObject, looksLikeJsonAttempt } from "./extractJsonObject";
+
+describe("extractJsonObject", () => {
+  it("returns a bare JSON object unchanged", () => {
+    expect(extractJsonObject('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it("unwraps a ```json fenced object", () => {
+    expect(extractJsonObject('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it("unwraps an unlabelled ``` fenced object", () => {
+    expect(extractJsonObject('```\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it("extracts an object preceded by prose", () => {
+    expect(extractJsonObject('Here is the updated recipe: {"a":1} enjoy!')).toBe('{"a":1}');
+  });
+
+  it("handles nested objects", () => {
+    expect(extractJsonObject('{"a":{"b":2},"c":3}')).toBe('{"a":{"b":2},"c":3}');
+  });
+
+  it("does not stop at braces inside strings", () => {
+    expect(extractJsonObject('{"a":"} not the end {"}')).toBe('{"a":"} not the end {"}');
+  });
+
+  it("respects escaped quotes inside strings", () => {
+    expect(extractJsonObject('{"a":"she said \\"hi\\""}')).toBe('{"a":"she said \\"hi\\""}');
+  });
+
+  it("returns null for a truncated object (no matching close brace)", () => {
+    expect(extractJsonObject('{"recipe":{"title":"Haina')).toBeNull();
+  });
+
+  it("returns null for a truncated fenced object", () => {
+    expect(extractJsonObject('```json\n{"recipe":{"title":"Haina')).toBeNull();
+  });
+
+  it("returns null for plain prose with no object", () => {
+    expect(extractJsonObject("Aiyah, that would be a totally different dish.")).toBeNull();
+  });
+});
+
+describe("looksLikeJsonAttempt", () => {
+  it("is true for a bare object", () => {
+    expect(looksLikeJsonAttempt('{"a":1}')).toBe(true);
+  });
+
+  it("is true for a truncated object", () => {
+    expect(looksLikeJsonAttempt('{"recipe":{"title":"Haina')).toBe(true);
+  });
+
+  it("is true for a ```json fence even before any brace", () => {
+    expect(looksLikeJsonAttempt("```json\n")).toBe(true);
+  });
+
+  it("is true for a fenced (truncated) object", () => {
+    expect(looksLikeJsonAttempt('```json\n{"recipe":')).toBe(true);
+  });
+
+  it("is false for a plain-text refusal", () => {
+    expect(looksLikeJsonAttempt("Aiyah, that would be a totally different dish.")).toBe(false);
+  });
+});

--- a/src/lib/recipes/extractJsonObject.ts
+++ b/src/lib/recipes/extractJsonObject.ts
@@ -1,0 +1,61 @@
+// Tolerant extraction of a JSON object from a model response that is supposed
+// to be pure JSON but sometimes arrives wrapped in markdown fences, prefixed
+// with prose, or truncated mid-object (e.g. when generation hits a token cap).
+
+/** Strip a leading ```/```json fence (and its trailing fence, if present). */
+function stripCodeFence(text: string): string {
+  const t = text.trim();
+  const openFence = /^```[a-zA-Z]*[ \t]*\r?\n?/;
+  if (!openFence.test(t)) return t;
+  return t.replace(openFence, "").replace(/\r?\n?```[ \t]*$/, "");
+}
+
+/**
+ * Return the first balanced `{ … }` object found in `text`, unwrapping a
+ * surrounding markdown code fence and ignoring any leading/trailing prose.
+ * Braces and quotes inside JSON strings are handled. Returns `null` when no
+ * complete, balanced object is present (no object at all, or a truncated one).
+ */
+export function extractJsonObject(text: string): string | null {
+  const cleaned = stripCodeFence(text);
+  const start = cleaned.indexOf("{");
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < cleaned.length; i++) {
+    const ch = cleaned[i];
+
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) return cleaned.slice(start, i + 1);
+    }
+  }
+
+  return null; // unbalanced — truncated or malformed
+}
+
+/**
+ * Whether `text` looks like an attempt at a JSON response (vs. a plain-text
+ * refusal). Used to decide whether an unparseable response should be hidden
+ * behind a friendly message (looked like JSON but broke) or surfaced as-is
+ * (the model deliberately replied in prose).
+ */
+export function looksLikeJsonAttempt(text: string): boolean {
+  const t = text.trim();
+  if (/^```json/i.test(t)) return true;
+  return stripCodeFence(t).trim().startsWith("{");
+}


### PR DESCRIPTION
Closes #255.

## Summary
The tweak bench assumed the `/api/recipe/[id]/tweak` endpoint returns **pure JSON** and ran `JSON.parse` on the raw stream. Any deviation — markdown-fenced JSON, a prose lead-in, or a truncated object — threw and dumped the raw text straight into a chat bubble, with the tweak silently not applying.

This adds a tolerant extractor and routes outcomes sensibly:
- **Fenced (```` ```json ````) or prose-prefixed valid JSON** → now parses and applies normally.
- **Garbled / truncated JSON** → friendly "came back muddled" message; raw/partial JSON is never shown.
- **The model's intentional plain-text refusals** (the route prompts it to refuse in prose for nonsensical requests) → still surfaced verbatim, distinguished from broken JSON via `looksLikeJsonAttempt`.

## Key pieces
- New pure, unit-tested helpers in `src/lib/recipes/extractJsonObject.ts`: `extractJsonObject` (fence-aware, string/escape-aware balanced-object scan) and `looksLikeJsonAttempt`.
- `TweakBench` parse path rewritten to extract → parse → validate, with no `SyntaxError`-as-control-flow.

## Scope
- Client resilience + graceful failure only. The **truncation root cause** (output token cap) is handled separately in #256 — this PR ensures a truncated response fails *cleanly* rather than dumping partial JSON.

## Test plan
- `extractJsonObject.test.ts` — 15 cases (bare, fenced, unlabelled fence, prose-prefixed, nested, braces-in-strings, escaped quotes, truncated, truncated-fenced, prose-only).
- `TweakBench.test.tsx` — applies bare/fenced/prose-prefixed; friendly message (no raw JSON) for truncated; verbatim plain-text refusal; streaming state still clears (#254 intact).
- Full suite: 373 passing. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tolerance for AI model response parsing when tweaking recipes, now handling various formats including fenced code blocks and prose-embedded content.
  * Improved error messaging for malformed or refused responses.

* **Tests**
  * Extended test coverage for multiple response format scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->