### PR TITLE
fix(tweak): raise output token cap and fail cleanly on length truncation

### DIFF
--- a/src/app/api/recipe/[id]/tweak/route.test.ts
+++ b/src/app/api/recipe/[id]/tweak/route.test.ts
@@ -1,0 +1,100 @@
+import { openai } from "@ai-sdk/openai";
+import { generateText } from "ai";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+jest.mock("@ai-sdk/openai", () => ({ openai: jest.fn() }));
+
+jest.mock("ai", () => ({ generateText: jest.fn() }));
+
+jest.mock("next/server", () => {
+  const NextResponse = jest.fn((body, init) => ({
+    kind: "raw",
+    text: async () => body,
+    status: init?.status ?? 200,
+    headers: new Map(Object.entries(init?.headers ?? {})),
+  }));
+  // @ts-expect-error attach static like the real NextResponse
+  NextResponse.json = jest.fn((data: unknown, init?: { status?: number }) => ({
+    kind: "json",
+    json: async () => data,
+    status: init?.status ?? 200,
+  }));
+  return { NextRequest: jest.fn(), NextResponse };
+});
+
+const mockedGenerateText = jest.mocked(generateText);
+const mockedOpenai = jest.mocked(openai);
+
+const validRecipeBlock = {
+  id: "recipe-1",
+  title: "Mapo Tofu",
+  baseServings: 2,
+  ingredients: [{ name: "tofu" }],
+  steps: [{ title: "Cook", body: "Cook it" }],
+};
+
+const tweakJson = JSON.stringify({
+  recipe: validRecipeBlock,
+  changes: [{ kind: "step_replaced", label: "Toned it down" }],
+});
+
+const makeRequest = (body: unknown) => ({ json: async () => body }) as NextRequest;
+const params = Promise.resolve({ id: "recipe-1" });
+
+const baseBody = {
+  userId: "user-123",
+  instruction: "less spicy",
+  originalRecipe: validRecipeBlock,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+  mockedOpenai.mockReturnValue("mock-model" as unknown as ReturnType<typeof openai>);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe("POST /api/recipe/[id]/tweak", () => {
+  it("requests a generous output token ceiling (not the old 2000 cap)", async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: tweakJson,
+      finishReason: "stop",
+    } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+    await POST(makeRequest(baseBody), { params });
+
+    expect(mockedGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({ maxOutputTokens: 8000 }),
+    );
+  });
+
+  it("returns the generated text with a 200 when generation completes normally", async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: tweakJson,
+      finishReason: "stop",
+    } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+    const res = await POST(makeRequest(baseBody), { params });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(tweakJson);
+  });
+
+  it("fails cleanly with a non-2xx when generation is cut off by length", async () => {
+    const truncated = tweakJson.slice(0, 40); // half-written, as a token cap would leave it
+    mockedGenerateText.mockResolvedValue({
+      text: truncated,
+      finishReason: "length",
+    } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+    const res = await POST(makeRequest(baseBody), { params });
+
+    expect(res.status).toBe(422);
+    // The partial/truncated text must never be returned as a successful body
+    const payload = await res.json();
+    expect(JSON.stringify(payload)).not.toContain(truncated);
+    expect(payload).toHaveProperty("error");
+  });
+});

--- a/src/app/api/recipe/[id]/tweak/route.ts
+++ b/src/app/api/recipe/[id]/tweak/route.ts
@@ -1,7 +1,7 @@
 import { missingUserId } from "@/lib/http";
 import { RecipeBlockSchema, TweakResponseSchema } from "@/lib/recipes/schemas";
 import { openai } from "@ai-sdk/openai";
-import { streamText } from "ai";
+import { generateText } from "ai";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -10,6 +10,12 @@ const RecipeBlockWithIdSchema = RecipeBlockSchema.extend({ id: z.string() });
 type RecipeBlockWithId = z.infer<typeof RecipeBlockWithIdSchema>;
 
 const MAX_INSTRUCTION_LENGTH = 500;
+
+// The model echoes the whole recipe back as JSON, so output size scales with
+// recipe size. Keep the ceiling well above any realistic recipe so generation
+// isn't clipped mid-object (the old 2000 cap truncated large recipes). This is
+// a ceiling, not a target — small recipes cost the same as before.
+const MAX_OUTPUT_TOKENS = 8000;
 
 const CHANGE_KINDS = TweakResponseSchema.shape.changes.element.shape.kind.options.join(", ");
 const RECIPE_FIELDS = Object.keys(RecipeBlockSchema.shape).join(", ");
@@ -116,14 +122,31 @@ export async function POST(
       workingDraft = parsedDraft.data;
     }
 
-    const result = streamText({
+    // Buffer the full generation rather than streaming: the client parses the
+    // response as one JSON object (no incremental render), so streaming buys
+    // nothing here — and buffering lets us inspect finishReason before we
+    // respond, which a streamed response can't (status is already sent).
+    const { text, finishReason } = await generateText({
       model: openai("gpt-4.1-mini"),
       system: buildSystemPrompt(parsedOriginal.data, workingDraft),
       messages: [{ role: "user", content: instruction }],
-      maxOutputTokens: 2000,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
     });
 
-    return result.toTextStreamResponse();
+    if (finishReason === "length") {
+      // Cut off by the token cap — the partial text is unparseable JSON.
+      // Fail cleanly so the client shows a friendly message instead of
+      // receiving a successful-looking truncated body.
+      return NextResponse.json(
+        { error: "Tweak response was too long to complete." },
+        { status: 422 }
+      );
+    }
+
+    return new NextResponse(text, {
+      status: 200,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
   } catch (error) {
     console.error("[/api/recipe/[id]/tweak]", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });


### PR DESCRIPTION
Closes #256.

## Summary
The tweak route asked the model to echo the **entire recipe back as JSON** with `maxOutputTokens: 2000`. Large recipes pushed generation past that ceiling; it stopped mid-object (`finishReason: "length"`) and the partial JSON streamed back as a 200, where the client couldn't parse it — the deterministic truncation failure from #255.

This fixes the root cause server-side:
- **Raise the ceiling 2000 → 8000.** It's a ceiling, not a target — small recipes cost the same; large ones simply stop being clipped.
- **`streamText` → `generateText`.** The client buffers the whole body before `JSON.parse` (no incremental render), so streaming bought nothing — and buffering lets the route inspect `finishReason` *before* it responds, which a streamed response can't (status is already sent).
- **On `finishReason === "length"`, return `422`** instead of a truncated body. The client's existing `!res.ok` path turns it into a friendly message rather than receiving a successful-looking partial.

## Scope
- Server-only. Pairs with #257 (PR for #255), which makes the client tolerant of fenced/prose JSON and fails gracefully. This PR ensures a truncated generation never *reaches* the client as parseable-looking partial JSON.
- **Not** re-architecting to a diff/patch response — deliberate decision recorded in #256 (a ceiling bump is free for normal recipes; diff/patch would add fragile index-based apply logic for savings this app doesn't need).

## Test plan
- New `route.test.ts`: asserts `maxOutputTokens: 8000` is requested; `finishReason: "stop"` returns 200 with the generated text; `finishReason: "length"` returns 422 and never echoes the truncated text.
- Full suite: 356 passing. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)