### PR TITLE
docs: lean prd vision doc, mark V2 shipped, fix ADR links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Ah Mah is your friendly cooking companion who:
 2. **Install dependencies**
 
    ```bash
-   npm install
+   pnpm install
    ```
 
 3. **Set up environment variables**
@@ -108,14 +108,14 @@ Ah Mah is your friendly cooking companion who:
 4. **Set up the database**
 
    ```bash
-   npx prisma migrate dev
-   npx prisma generate
+   pnpm prisma migrate dev
+   pnpm prisma generate
    ```
 
 5. **Run the development server**
 
    ```bash
-   npm run dev
+   pnpm dev
    ```
 
 6. **Open your browser**

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,5 +1,5 @@
 ---
-description: "Next.js web app for cooking beginners with AI-powered natural language inventory management and recipe suggestions using Vercel AI SDK and Gemini Flash"
+description: "Product vision for Ask Ah Mah — a Next.js web app that helps cooking beginners turn the ingredients they already have into recipes through natural-language conversation"
 globs:
   - "**/*.{ts,tsx,js,jsx}"
   - "**/*.json"
@@ -7,299 +7,72 @@ globs:
 alwaysApply: true
 ---
 
-# Ask Ah Mah - Product Requirements Document
+# Ask Ah Mah — Product Vision
 
-## 1. Product Overview
+> **Scope of this doc:** the durable *why* and *who*. It does **not** track
+> what's built, the current architecture, or the roadmap — those drift too fast
+> to live here. For that, see:
+>
+> - **What's shipped / what's next** → [`docs/progress.md`](./progress.md)
+> - **Why things are built the way they are** → [`docs/adr/`](./adr/)
+> - **Canonical domain vocabulary** → [`CONTEXT.md`](../CONTEXT.md)
+> - **How to run it / tech stack** → [`README.md`](../README.md)
 
-### 1.1 Product Vision
+## 1. Product Vision
 
-"Ask Ah Mah" is a web application that helps cooking beginners discover recipes through natural language conversation, making cooking accessible and intuitive by managing their kitchen inventory and providing personalized recipe suggestions.
+"Ask Ah Mah" helps cooking beginners discover what to cook through natural
+language conversation. It makes cooking feel accessible and unintimidating by
+remembering what's in their kitchen and suggesting recipes built around the
+ingredients they already have.
 
-### 1.2 Problem Statement
+The persistent kitchen — inventory plus what's been cooked and saved — is the
+core moat. The app's job is to turn "I have all these ingredients but no idea
+what to make" into a recipe the user feels confident cooking.
+
+## 2. Problem Statement
 
 Beginner cooks struggle to:
 
-- Know what they can make with ingredients they have
-- Manage their kitchen inventory effectively
-- Find recipes that match their available ingredients and tools
-- Get cooking guidance in an intuitive, conversational way
-
-### 1.3 Success Metrics (Future)
-
-- User engagement: Average session time, return visits
-- Feature adoption: Inventory management usage, recipe requests per session
-- User satisfaction: Recipe completion rates, positive feedback
-
-## 2. Target Users
-
-### Primary User Persona
-
-- **Demographics**: Cooking beginners, any age
-- **Needs**: Simple recipe discovery, inventory management, cooking guidance
-- **Behavior**: Prefers natural language interaction over complex interfaces
-- **Goals**: Learn to cook with what they have available
-
-## 3. MVP Feature Requirements
-
-### 3.1 Core Features
-
-#### 3.1.1 Natural Language Inventory Management
-
-**User Stories:**
-
-- As a user, I can add ingredients to my pantry using natural language ("add eggs to pantry")
-- As a user, I can add kitchenware using natural language ("i have a kettle")
-- As a user, I can optionally specify quantities and units ("add 6 eggs" or "add 2 cups of flour")
-- As a user, I can view and edit my inventory through traditional UI elements
-
-**Acceptance Criteria:**
-
-- System recognizes and parses natural language inventory commands
-- Items are stored with optional metadata (quantity, unit)
-- Inventory persists between sessions
-- Users can manually edit inventory through UI panels
-
-#### 3.1.2 Recipe Suggestion Engine
-
-**User Stories:**
-
-- As a user, I can ask "what can I cook with what I have?" and get recipe suggestions
-- As a user, I receive 3 brief recipe suggestions that mostly use my available ingredients
-- As a user, I can see what ingredients I'm missing for each suggested recipe
-- As a user, I can ask for detailed information about any suggested recipe
-
-**Acceptance Criteria:**
-
-- AI suggests recipes based on user's pantry and kitchenware
-- Initial suggestions are brief with: name, description, key ingredients, missing ingredients, cooking time/difficulty
-- System remembers suggested recipes within the chat session
-- Detailed recipe view includes: step-by-step instructions, full ingredient list, cooking time, difficulty level, cooking tips
-- Professional markdown formatting with visual delimiters and emojis
-- Enhanced recipe format with substitutions, cooking tips, and availability markers
-
-#### 3.1.3 Chat Interface
-
-**User Stories:**
-
-- As a user, I interact with the app through a conversational chat interface
-- As a user, I can see my conversation history within the current session
-- As a user, I can reference previously suggested recipes in conversation
-
-**Acceptance Criteria:**
-
-- Chat interface with message bubbles and conversation history
-- AI maintains context for recipe suggestions within session
-- Inventory commands are processed independently (no cross-command memory needed)
-- Message persistence with full conversation history
-- Efficient JSON-based conversation storage
-
-### 3.2 UI/UX Requirements
-
-#### 3.2.1 Layout
-
-- Primary chat interface taking majority of screen space
-- Drawer-based inventory management (modern UX approach)
-- Responsive design for mobile and desktop use
-- Light and Dark mode toggle (planned)
-- Professional styling with shadcn/ui components
-
-#### 3.2.2 Inventory Management UI
-
-- Drawer-based UI for modern inventory management
-- Traditional UI elements for viewing/editing pantry items
-- Add/remove/edit functionality for ingredients and kitchenware
-- Display items with quantities/units when available
-- Toast notifications for user feedback on all operations
-
-## 4. Technical Architecture
-
-### 4.1 Technology Stack
-
-- **Frontend**: Next.js 14/15 (App Router), TypeScript, Tailwind CSS
-- **AI Integration**: Vercel AI SDK with Google Gemini Flash
-- **Data Storage**:
-  - PostgreSQL with Prisma ORM (upgraded from MVP)
-  - Single JSON conversation field per user for efficiency
-  - Message persistence with AI SDK's onFinish callback
-- **UI Components**: shadcn/ui with drawer-based inventory management
-- **Validation**: Zod for data validation
-- **Deployment**: Vercel (free tier)
-
-### 4.2 Data Structure
-
-#### 4.2.1 Inventory Item Schema
-
-interface InventoryItem {
-id: string;
-name: string;
-type: "ingredient" | "kitchenware";
-quantity?: number;
-unit?: string;
-dateAddedISO: string; // ISO8601 string
-lastUpdatedISO: string; // ISO8601 string
-}
-
-#### 4.2.2 Recipe Schema
-
-```typescript
-interface Recipe {
-  name: string;
-  description: string;
-  ingredients: Array<{
-    name: string;
-    quantity?: number;
-    unit?: string;
-    available: boolean;
-  }>;
-  instructions: string[];
-  cookingTime: number;
-  difficulty: "easy" | "medium" | "hard";
-  requiredKitchenware: string[];
-}
-```
-
-### 4.3 AI Integration Strategy
-
-#### 4.3.1 Natural Language Processing
-
-#### 4.3.1 Natural Language Processing
-
-- Use Vercel AI SDK with Gemini Flash
-- All AI calls run server-side (Route Handlers/Server Actions); never expose API keys to the client
-- Apply timeouts, retries with backoff, and per-session request budgets
-- Log prompt/response metadata (no PII) for observability
-- Implement prompt engineering for:
-  - Inventory item extraction and categorization
-  - Recipe suggestion generation
-  - Cooking instruction formatting
-
-#### 4.3.2 Prompt Structure
-
-- **Inventory Management**: Extract item name, quantity, unit, and type from natural language
-- **Recipe Suggestions**: Generate beginner-friendly recipes with substitution options, emphasize "you can do this" messaging
-- **Cooking Guidance**: Provide encouraging, step-by-step help with troubleshooting and technique explanations
-- **Substitution Logic**: Proactively suggest alternatives for missing ingredients with confidence-building language
-- **Recipe Formatting**: Professional markdown with clear sections, emojis, and visual delimiters
-- **Enhanced Instructions**: Step-by-step guidance with cooking tips and substitutions
-- **Visual Appeal**: Emoji-enhanced instructions and professional presentation
-
-## 5. Development Phases
-
-### 5.1 Phase 1: MVP Core (Weeks 1-3)
-
-- Set up Next.js project with TypeScript and Tailwind
-- Implement basic chat interface
-- Integrate Vercel AI SDK with Gemini Flash
-- Build natural language inventory management
-- Implement PostgreSQL database with Prisma (upgraded from local storage)
-
-### 5.2 Phase 2: Recipe Engine (Weeks 4-6)
-
-- Develop recipe suggestion algorithm
-- Implement recipe detail display
-- Add drawer-based inventory management UI
-- Polish chat interface and user experience
-- Enhanced recipe formatting with professional markdown
-- Message persistence and conversation history
-
-### 5.3 Phase 3: Enhancement (Weeks 7-8)
-
-- Improve AI prompts and responses
-- Add error handling and edge cases
-- Optimize performance and user experience
-- Deploy to Vercel
-- Add toast notifications and professional UI components
-- Implement comprehensive SEO metadata
-
-## 6. Additional Features Implemented (Beyond MVP)
-
-### 6.1 Enhanced Features
-
-- **Toast Notifications**: User feedback for all inventory operations using sonner
-- **Drawer-Based UI**: Modern inventory management with shadcn/ui drawer component
-- **SEO Optimization**: Comprehensive metadata and Open Graph support
-- **Enhanced Recipe Format**: Professional markdown with emojis, substitutions, and tips
-- **Message Persistence**: Full conversation history with efficient JSON storage
-- **Professional Styling**: shadcn/ui components for consistent, modern design
-
-## 7. Future Enhancements
-
-### 7.1 User Management
-
-- User accounts and authentication
-- Personal recipe history and favorites
-- Multi-device synchronization
-
-### 7.2 Advanced Features
-
-- Recipe rating and reviews
-- Nutritional information
-- Shopping list generation
-- Meal planning capabilities
-- Recipe sharing and community features
-
-### 7.3 Technical Improvements
-
-- Migration to PostgreSQL database
-- Advanced caching strategies
-- Mobile app version
-- Offline functionality
-
-## 8. Constraints and Assumptions
-
-### 8.1 Technical Constraints
-
-- Using free tiers for AI services (Gemini Flash rate limits)
-- Vercel free deployment limitations
-- No user authentication in MVP
-
-### 8.2 Assumptions
-
-- Users are comfortable with natural language interaction
-- Inventory management will be primarily conversational
-- Recipe suggestions don't need real-time updates
-- Users will primarily access via desktop/mobile web browsers
-
-## 9. Success Criteria for MVP
-
-### 9.1 Functional Success
-
-- Users can successfully add ingredients and kitchenware via natural language
-- System accurately suggests recipes based on available inventory
-- Users can get detailed cooking instructions for suggested recipes
-- Data persists between browser sessions
-- Professional UI with drawer-based inventory management
-- Enhanced recipe formatting with visual appeal
-- Toast notifications provide clear user feedback
-- Message persistence with full conversation history
-
-### 9.2 User Experience Success
-
-- Intuitive chat interface with clear conversation flow
-- Quick response times for AI interactions
-- Accessible inventory management through both chat and traditional UI
-- Modern drawer-based UI for inventory management
-- Professional styling and user feedback systems
-
-## 10. Risk Assessment
-
-### 10.1 Technical Risks
-
-- **AI API limitations**: Rate limits on free Gemini Flash tier
-- **Natural language parsing accuracy**: Complex ingredient descriptions
-- **Data persistence**: Local storage limitations for inventory data
-
-### 10.2 Mitigation Strategies
-
-- Implement graceful error handling for API failures
-- Use structured prompts to improve parsing accuracy
-- Plan migration path to proper database early
-
-## 11. Next Steps
-
-1. Set up development environment and project structure
-2. Implement basic chat interface and AI integration
-3. Build natural language inventory management system
-4. Develop recipe suggestion and detail display features
-5. Create inventory management UI panel
-6. Test, refine, and deploy MVP
+- Know what they can make with the ingredients they have on hand
+- Keep track of what's in their kitchen
+- Find recipes that match both their ingredients and their (limited) skill
+- Get cooking guidance in an intuitive, conversational way — not a wall of UI
+
+The emotional core: ingredients go bad, money gets wasted, and cooking feels
+overwhelming. The product should make the user feel encouraged, not judged.
+
+## 3. Target User
+
+- **Who:** cooking beginners, any age.
+- **Needs:** simple recipe discovery, low-friction inventory tracking,
+  confidence-building guidance.
+- **Behaviour:** prefers natural-language interaction over complex forms and
+  filters.
+- **Goal:** learn to cook with what they already have.
+
+## 4. Success Criteria
+
+Functional:
+
+- Users can add ingredients and kitchenware via natural language, and the
+  inventory persists between sessions.
+- The app suggests recipes grounded in the user's actual inventory, and is
+  honest about what's missing.
+- Users can get detailed, beginner-friendly cooking guidance for a suggestion.
+
+Experience (future, once we measure):
+
+- Engagement — average session time, return visits.
+- Adoption — inventory use, recipe requests per session.
+- Satisfaction — recipe completion, positive feedback.
+
+## 5. Durable Constraints & Assumptions
+
+- **Conversational-first.** Inventory management and recipe discovery are
+  primarily driven through chat; traditional UI is the backstop, not the front
+  door.
+- **Encouraging tone.** Every interaction should build confidence — mistakes
+  are part of learning to cook.
+- **Web-first.** Users primarily access via desktop and mobile web browsers.
+- **No real-time freshness tracking.** The app cannot reliably know what's gone
+  bad; it does not guess (see [ADR-0008](./adr/0008-no-shelf-life-ui.md)).

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -49,9 +49,9 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 
 - **Send guard** (May 2026): Fixed double-submission bug — a synchronous `sendingRef` lock and `isSending` state now cover the async pre-send gap (conversation create + message save) before the AI SDK `status` transitions from `"ready"`. Loader shows immediately on submit; input stays disabled until the request is fully in-flight.
 
-## V2 — In Progress
+## V2 — Shipped (May–Jun 2026)
 
-### Cook With What You Have — In Review (May 2026)
+### Cook With What You Have — Shipped (May 2026, #236)
 - **Selection mode** on the Pantry surface: "Cook with what you have" toggle enters a checkbox mode on ingredient and kitchenware rows. Kitchenware selection = preferred equipment (preference, not constraint — ADR-0007).
 - **CTA adapts** to selection shape: "Suggest recipe (N selected)" for ingredients, "Surprise me with [Air fryer]" for equipment-only.
 - **Submit flow**: composes a synthetic Mode 3 message ("Suggest recipes using: …"), enters Staging State via `ConversationContext`, navigates to Chat. Chat auto-sends the queued message once `status === "ready"`.
@@ -78,6 +78,8 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Loader bridges the gap**: `shouldShowLoader` keeps `ChatLoader` visible until prose, a completed block, or the first parseable streaming field exists — no raw-JSON flash.
 - **Retired** `SkeletonRecipeCard`, `WritingItOut`, and `ShimmerWord` (dead after skeleton removal). See ADR-0009.
 
+## Next up
+
 ### Shopping list from shortfalls
 - [ ] Add one-click `Add missing to shopping list` from `RecipeDisplay`.
 - [ ] Add `ShoppingList` Prisma model (`id`, `userId`, `name`, `quantity?`, `unit?`, `addedAt`, `recipeId?`).
@@ -102,7 +104,7 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 
 ## Decisions
 
-- **`shelfLife` removed** (May 2026): The field was used for amber-dot UI and Mode 3 recipe prioritization. Removed because the app cannot reliably know freshness — users freeze, restock, and manage their own food without updating the app. Recipes should be generated because the dish needs those ingredients, not because the app guesses they're expiring. See ADR-0008.
+- **`shelfLife` removed** (May 2026) — no freshness/urgency UI; the app can't reliably know what's gone bad. Full rationale → [ADR-0008](./adr/0008-no-shelf-life-ui.md).
 - **Optional quantity = "unlimited"**: unset `quantity` means the item has no limit. Avoids forcing a count on pantry staples where "do I have enough?" is never the question.
 - **Structured-on-save over streaming extraction**: metadata (`baseServings`, `ingredients`, `description`, `totalTimeMinutes`) is extracted when the user saves a recipe, not streamed inline. Simpler streaming path; extraction failures degrade gracefully without breaking the chat.
 - **Strict-unit shortfall first; cross-unit conversion deferred**: `unit` must match exactly for shortfall calculation. Cross-unit conversion (e.g. `g` vs `kg`) is a V3+ problem — the complexity isn't justified until users actually hit it.
@@ -115,5 +117,5 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Horizontal-scroll chip rail over facet sheets (cookbook)**: surfaces all tags at a glance; facet sheets added taps and hid options.
 - **Cookbook strips pantry awareness**: `RecipeDisplay` is storage, not meal planning. HAVE/NEED badges belong in the chat-inline `RecipeLetter` only.
 - **Tweak change `ref` is a non-fatal presentational hint** (Jun 2026): A tweak's `changes[].ref` only drives row highlighting for ingredient/step changes (prep/recipe-level changes aren't highlighted). The model sometimes emits unmodeled locators like `ref.type: "prep"`, which previously failed `TweakResponseSchema` and discarded an otherwise-valid recipe ("that tweak came back muddled"). `ref` now parses with `.catch(undefined)` so a malformed locator degrades to no-highlight instead of rejecting the tweak; the prompt also tells the model to omit `ref` for `prep_updated`.
-- **Tweak returns a patch, not the whole recipe** (Jun 2026): `POST /api/recipe/[id]/tweak` previously echoed the entire recipe back, so a one-line edit waited on the model regenerating every ingredient and step (~15s observed). The contract is now a **Tweak Patch**: only changed fields, with arrays sent all-or-nothing (whole array if any element changed; `[]` to clear; key omitted = keep). The client merges with the pure `applyTweakPatch(workingDraft, patch)`. The `finishReason === "length"` 422 guard is retained. See ADR-0010.
+- **Tweak returns a patch, not the whole recipe** (Jun 2026) — only changed fields come back, cutting the full-recipe echo that made one-line edits wait ~15s. Full rationale → [ADR-0010](./adr/0010-recipe-tweak-returns-a-patch.md).
 - **Decrement-on-cook dropped**: tracking what was cooked, confirming with the user, and decrementing inventory adds a confirmation surface and an "active cooking" state model that's hard to get right. The pantry is whatever the user says it is; nudges live in chat ("I used the last of the eggs"). Removed from the V2 backlog entirely.


### PR DESCRIPTION
- prd.md becomes a durable product-vision doc that links out to progress.md, ADRs, CONTEXT.md, and README instead of duplicating architecture/roadmap that drifts.
- progress.md: mark Cook-With and V2 as shipped; add a "Next up" heading; trim the shelfLife and tweak-patch decisions to one line + ADR link.
- Fix two ADR links that pointed at docs/adr/... from inside docs/ (resolved to docs/docs/adr/...).
- README: npm → pnpm in setup steps.