### PR TITLE
docs(adr): recipe is a document, exempt from chat brevity

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,3 +125,19 @@ UI label: **"Worth a small trip."** The internal term is `Stretch`.
 ## Addition
 
 An ingredient a generated recipe calls for that is not present in the user's pantry. The Addition count distinguishes Close from Stretch. Salt, pepper, water, and cooking oil are **free staples** — never counted as Additions even if absent from the pantry. Everything else in the pantry is also free; only items genuinely missing are Additions.
+
+---
+
+## Recipe Notes
+
+Whole-dish asides attached to a recipe (`notes` on the recipe block): make-ahead, storage, serving suggestions, and pantry-*independent* technique fallbacks ("no cumin? use garam masala — it's pre-toasted, add it later"). Optional, 0–4 entries, omitted for simple dishes. Rendered as a "Notes" section at the foot of the recipe.
+
+**Flagged ambiguity — `notes` vs `note`:** distinct concepts at different altitudes. The ingredient-level **`note`** (singular) tweaks *one ingredient* ("boneless, bite-size"; "not in pantry — use dry sherry"). **Recipe Notes** (`notes`, plural) speak to the *whole dish*. Recipe Notes deliberately do **not** carry pantry substitutions — those already live in the ingredient `note` and the "Ask Ah Mah for substitutions" affordance, and duplicating them here is out of lane.
+
+---
+
+## Copy recipe
+
+The action that copies the **whole recipe** as clean plain text (CAPS section headers, `•`/numbered lists — no markdown, so it survives pasting into WhatsApp/Notes), at the **currently displayed servings**. Shared formatter, surfaced on both the chat recipe card and the recipe page. Excludes user-specific pantry state.
+
+**Flagged ambiguity — vs Copy shopping list:** two distinct copy intents, never collapse into a bare "Copy." **Copy shopping list** copies *only the missing ingredients* for a shop trip. **Copy recipe** copies *the entire dish* to cook from or share. Both can coexist on the same card; the labels name the intent.

--- a/docs/adr/0011-recipe-is-a-document.md
+++ b/docs/adr/0011-recipe-is-a-document.md
@@ -1,0 +1,58 @@
+# ADR-0011 — The recipe is a document, exempt from the chat brevity principle
+
+**Status:** Accepted
+
+## Context
+
+`CHAT_SYSTEM_PROMPT` tells Ah Mah to keep responses *"tight and conversational —
+short sentences, not lectures."* That principle is load-bearing for her character.
+But it was being applied globally, including to the recipe she emits — so generated
+recipes stayed thin: terse step bodies, time-based doneness ("cook 5–7 min") rather
+than sensory cues, no make-ahead or storage guidance. Held against a Kenji/Serious-Eats
+style write-up of the same dish, the gap was real: the richer version simply cooks better
+and travels better.
+
+The resolution is to separate two artifacts that were being governed by one rule:
+
+- The **chat stream** (Ah Mah's prose, suggestions, asides) is a *conversation*. Brevity
+  governs here — this is where "not lectures" applies.
+- The **recipe** is a *document*. It has its own page, is saved to the Cookbook, gets
+  cooked from and tweaked. A reference document is allowed to be thorough; nobody calls a
+  recipe card a lecture.
+
+## Decision
+
+Scope the brevity principle to the **conversation**, and let the **recipe** carry depth.
+
+- **Depth lives inside the recipe block**, gated on *"only where it changes the
+  outcome"* — not length for its own sake. Concretely, in `steps[].body` / `steps[].tip`:
+  the *why* when non-obvious (Maillard on the browning step, not "stir the sauce"),
+  sensory doneness cues ("whites just set, yolks still jiggle"), and failure-mode
+  cautions on the pivotal step or two. A soft cap keeps most step bodies to 1–2 sentences;
+  only a pivotal step earns 3–4.
+- **A new recipe-level `notes` field** (see [CONTEXT.md → Recipe Notes](../../CONTEXT.md))
+  carries whole-dish asides: make-ahead, storage, serving, pantry-*independent* technique
+  fallbacks. Explicitly **not** pantry substitutions — those already live in the
+  ingredient `note` and the "Ask Ah Mah for substitutions" affordance.
+- **The 140-char `description` and the granny voice are unchanged.** The depth is in the
+  steps and notes, not in a longer soul-of-the-dish line and not in chattier prose.
+
+## Why not alternatives
+
+**Keep everything terse / make Ah Mah's chat chattier instead.** Rejected. Thin recipes
+were the actual complaint, and lengthening the *conversation* would damage the character
+the brevity rule protects. The split fixes the right artifact and leaves the voice intact.
+
+## Consequences
+
+- **Steps reference ingredients by name, never by absolute quantity.** Inline quantities
+  in step bodies ("Add 250 g pork") were deliberately rejected: the `ServingsStepper`
+  scales the ingredient list live (`scale = servings / baseServings`), but step text is
+  static — a scaled recipe would show "500 g" in the list and "250 g" in the step,
+  visibly contradictory, and would duplicate data the Tweak diff system must reconcile.
+  Proportional prose ("half the salt now, the rest later") is allowed because it survives
+  scaling; absolute numbers are not.
+- **"Divided" seasoning is prose, not structure.** `amount` stays a single scalar feeding
+  scaling and pantry-shortfall math; splitting an ingredient into fractional sub-uses was
+  rejected as cost without proportional gain.
+- A persisted `notes` field is added to the recipe schema and storage.


### PR DESCRIPTION
## Summary
- Adds **ADR-0011** scoping the "short sentences, not lectures" principle to the chat *conversation*, letting the recipe *artifact* carry depth (richer `steps[].body`/`tip` + a new recipe-level `notes` field).
- Records the deliberate **no** on inline step quantities and divided seasoning — they fight the `ServingsStepper` live scaling (captured in the ADR's Consequences).
- Adds **CONTEXT.md** glossary entries: **Recipe Notes** (with the `notes` vs ingredient-level `note` ambiguity flagged) and **Copy recipe** (with the vs "Copy shopping list" ambiguity flagged).

Docs only — no code changes. Implementation is tracked in #267 (notes field), #268 (step depth), #269 (copy recipe), #270 (notes tweakability decision).

## Test plan
N/A — documentation only. Verify ADR/CONTEXT links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced glossary clarifying recipe notes and copy recipe functionality
  * Added architectural decision record documenting design principles for recipe structure, including a new recipe-level notes field for guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->