### PR TITLE
feat(recipe): copy recipe as clean plain text on both surfaces (#269)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -87,6 +87,12 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Helper**: `latestUserText`/`messageText` (`src/lib/chat/messageText.ts`) pull the latest user message's text parts out of `UIMessage[]`.
 - **Surfacing captured items to the UI**: captured items fire no `tool-addInventoryItem` part, so the client's tool-call handler would miss them (no toast, stale pantry). The route wraps the model stream in `createUIMessageStream` and writes a `data-capturedInventory` part listing the names; `useChatSession.onFinish` toasts + `mutate`s `/api/inventory` on it, mirroring the tool path.
 
+### Recipe is a document — Shipped Jun 2026 (#267–#269)
+- **Framing**: the recipe is a reference artifact you read, scale, and paste — exempt from chat brevity. Depth lives in the recipe, not the conversation. See [ADR-0011](./adr/0011-recipe-is-a-document.md).
+- **Recipe Notes (#267)**: new `notes?: string[]` whole-dish asides (make-ahead, storage, serving, pantry-*independent* fallbacks) end-to-end — `RecipeBlockSchema` + `Recipe` type + converters + `TweakPatchSchema` + Prisma column, rendered as a Notes section on both `RecipeLetter` and `RecipeDisplay`. Notes ride through a tweak untouched but are **not tweakable** in v1 (decision: #270 — a `notes_updated` change-kind is deferred until there's demand).
+- **Earned step depth (#268)**: prompt-only — `steps[].body` carries the *why*, sensory doneness cues, and failure-mode cautions only on pivotal steps, under a soft length cap; trivial steps stay short. Step bodies reference ingredients by name only — no absolute quantities (they'd fight the servings stepper).
+- **Copy recipe (#269)**: one shared `formatRecipeAsText(recipe, servings)` (`src/features/Recipe`) → plain text, CAPS headers, `•`/numbered lists, no markdown (survives WhatsApp/Notes). Amounts scale to the displayed servings via `scaleAmount`; amountless rows read "to taste"; sections render only when present; a "— from Ah Mah" footer. Surfaced as a **Copy recipe** button on `RecipeDisplay` (header — servings lifted out of `RecipeBody` so the header reads the current count) and in the `RecipeLetter` action bar. Excludes pantry state ("10/12 in your pantry"). **Copy shopping list stays separate** — two distinct copy intents, never collapsed into a bare "Copy".
+
 ## Next up
 
 ### Shopping list from shortfalls

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -17,7 +17,7 @@ import { useState } from "react";
 import { CookingMode, ServingsStepper } from "@/features/Recipe";
 import { toast } from "sonner";
 import useSWR, { useSWRConfig } from "swr";
-import { ScaledNum, scaleAmount } from "@/features/Recipe";
+import { ScaledNum, scaleAmount, formatRecipeAsText } from "@/features/Recipe";
 
 export interface RecipeLetterProps {
   // Partial during progressive reveal — fields fill in as the JSON streams.
@@ -166,6 +166,26 @@ export function RecipeLetter({
     navigator.clipboard.writeText(lines).then(
       () => toast.success("Shopping list copied — go get them!"),
       () => toast.error("Aiyah, couldn't copy — select and copy by hand?"),
+    );
+  };
+
+  const copyRecipe = () => {
+    const text = formatRecipeAsText(
+      {
+        title,
+        description: recipe.description,
+        totalTimeMinutes: recipe.totalTimeMinutes,
+        baseServings,
+        ingredients,
+        prep,
+        steps,
+        notes: recipe.notes,
+      },
+      servings,
+    );
+    navigator.clipboard.writeText(text).then(
+      () => toast.success("Recipe copied — paste it anywhere."),
+      () => toast.error("Aiyah, couldn't copy — try again?"),
     );
   };
 
@@ -402,6 +422,17 @@ export function RecipeLetter({
       {/* Action bar */}
       {!isStreaming && (onSave || canCook) && (
         <div className="flex gap-2 items-center pt-3 mt-4.5 border-t border-dashed border-border">
+          <button
+            onClick={copyRecipe}
+            aria-label="Copy recipe"
+            className="px-3 py-1.5 font-sans text-xs font-semibold text-foreground bg-card border border-border rounded-lg cursor-pointer shadow-[0_1px_0_var(--border-soft)] hover:bg-muted/50 transition-colors inline-flex items-center gap-1"
+          >
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+              <rect x="5" y="2" width="9" height="12" rx="1.5" stroke="currentColor" strokeWidth="1.4"/>
+              <path d="M5 4H3.5A1.5 1.5 0 0 0 2 5.5v9A1.5 1.5 0 0 0 3.5 16h7A1.5 1.5 0 0 0 12 14.5V13" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+            </svg>
+            Copy recipe
+          </button>
           {onSave && (
             isSaved ? (
               <button

--- a/src/features/Recipe/formatRecipeAsText.test.ts
+++ b/src/features/Recipe/formatRecipeAsText.test.ts
@@ -1,0 +1,88 @@
+import { formatRecipeAsText, type FormattableRecipe } from "./formatRecipeAsText";
+
+const base: FormattableRecipe = {
+  title: "Ginger Chicken & Bok Choy",
+  description: "Velvety chicken thighs, ginger that bites a little.",
+  totalTimeMinutes: 20,
+  baseServings: 2,
+  ingredients: [
+    { name: "chicken thigh", amount: "500", unit: "g", note: "boneless, bite-size" },
+    { name: "bok choy", amount: "1", unit: "bunch" },
+    { name: "salt" },
+  ],
+  prep: ["Cut chicken into bite-size pieces", "Mince 1 tbsp ginger"],
+  steps: [
+    {
+      title: "Marinate the chicken",
+      body: "Toss chicken with soy, cornstarch and sesame oil. Leave 10 min.",
+      tip: "Cornstarch gives you that velvety texture.",
+    },
+    { title: "Stir-fry", body: "Sear the chicken hot and fast, then the greens." },
+  ],
+  notes: ["Make-ahead: the sauce keeps 3 days in the fridge."],
+};
+
+describe("formatRecipeAsText", () => {
+  it("renders all sections with CAPS headers and the footer", () => {
+    const text = formatRecipeAsText(base, 2);
+    expect(text).toContain("GINGER CHICKEN & BOK CHOY");
+    expect(text).toContain("WHAT TO GATHER");
+    expect(text).toContain("BEFORE YOU START");
+    expect(text).toContain("METHOD");
+    expect(text).toContain("NOTES");
+    expect(text).toContain("— from Ah Mah");
+    expect(text).toContain("Total time: 20 min");
+    expect(text).toContain("Servings: 2");
+  });
+
+  it("contains no markdown syntax (survives a plain-text paste)", () => {
+    const text = formatRecipeAsText(base, 2);
+    expect(text).not.toMatch(/[*#_`]/);
+    expect(text).not.toMatch(/\[.*\]\(.*\)/); // no markdown links
+  });
+
+  it("scales ingredient amounts to the displayed servings", () => {
+    const text = formatRecipeAsText(base, 4); // double from base 2
+    expect(text).toContain("• 1000 g chicken thigh");
+    expect(text).toContain("• 2 bunch bok choy");
+    expect(text).toContain("Servings: 4");
+  });
+
+  it("renders amountless rows as 'to taste'", () => {
+    const text = formatRecipeAsText(base, 2);
+    expect(text).toContain("• salt, to taste");
+  });
+
+  it("appends an ingredient note after an em dash", () => {
+    const text = formatRecipeAsText(base, 2);
+    expect(text).toContain("• 500 g chicken thigh — boneless, bite-size");
+  });
+
+  it("numbers steps, leads with the title, and renders the tip", () => {
+    const text = formatRecipeAsText(base, 2);
+    expect(text).toContain("1. Marinate the chicken");
+    expect(text).toContain("   Tip: Cornstarch gives you that velvety texture.");
+    expect(text).toContain("2. Stir-fry");
+  });
+
+  it("omits sections that are absent (no empty NOTES / BEFORE YOU START)", () => {
+    const lean: FormattableRecipe = {
+      title: "Toast",
+      baseServings: 1,
+      ingredients: [{ name: "bread", amount: "2", unit: "slice" }],
+      steps: [{ title: "", body: "Toast the bread." }],
+    };
+    const text = formatRecipeAsText(lean, 1);
+    expect(text).not.toContain("NOTES");
+    expect(text).not.toContain("BEFORE YOU START");
+    expect(text).not.toContain("Total time:");
+    // titleless step renders body inline against the number
+    expect(text).toContain("1. Toast the bread.");
+  });
+
+  it("excludes user-specific pantry state", () => {
+    const text = formatRecipeAsText(base, 2);
+    expect(text).not.toMatch(/in your pantry/i);
+    expect(text).not.toMatch(/still need/i);
+  });
+});

--- a/src/features/Recipe/formatRecipeAsText.ts
+++ b/src/features/Recipe/formatRecipeAsText.ts
@@ -1,0 +1,87 @@
+import { scaleAmount } from "./scaleAmount";
+
+// The recipe as plain text for the clipboard — one formatter, two call sites
+// (RecipeLetter and RecipeDisplay), identical output. Deliberately NO markdown:
+// CAPS headers and `•`/numbered lists survive a paste into WhatsApp, Notes, or
+// any plain-text target. User-specific pantry state ("10/12 in your pantry",
+// "Still need") is excluded — this is the recipe, not the shopping context.
+
+export interface FormattableRecipe {
+  title: string;
+  description?: string;
+  totalTimeMinutes?: number;
+  baseServings: number;
+  ingredients: { name: string; amount?: string; unit?: string; note?: string }[];
+  prep?: string[];
+  steps: { title?: string; body: string; tip?: string }[];
+  notes?: string[];
+}
+
+function formatTime(minutes: number): string {
+  if (minutes < 60) return `${minutes} min`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h} h ${m} min` : `${h} h`;
+}
+
+export function formatRecipeAsText(
+  recipe: FormattableRecipe,
+  servings: number,
+): string {
+  const ratio = recipe.baseServings ? servings / recipe.baseServings : 1;
+  // Each entry is a section; blank line between sections.
+  const sections: string[] = [];
+
+  sections.push(recipe.title.toUpperCase());
+
+  if (recipe.description) sections.push(recipe.description);
+
+  const meta: string[] = [];
+  if (recipe.totalTimeMinutes)
+    meta.push(`Total time: ${formatTime(recipe.totalTimeMinutes)}`);
+  meta.push(`Servings: ${servings}`);
+  sections.push(meta.join("\n"));
+
+  if (recipe.ingredients.length > 0) {
+    const lines = recipe.ingredients.map((ing) => {
+      const scaled = ing.amount ? scaleAmount(ing.amount, ratio) : "";
+      // amount reflects the displayed servings; amountless rows read "to taste"
+      let line = scaled
+        ? `• ${scaled}${ing.unit ? ` ${ing.unit}` : ""} ${ing.name}`
+        : `• ${ing.name}, to taste`;
+      if (ing.note) line += ` — ${ing.note}`;
+      return line;
+    });
+    sections.push(["WHAT TO GATHER", ...lines].join("\n"));
+  }
+
+  if (recipe.prep && recipe.prep.length > 0) {
+    sections.push(
+      ["BEFORE YOU START", ...recipe.prep.map((p) => `• ${p}`)].join("\n"),
+    );
+  }
+
+  if (recipe.steps.length > 0) {
+    const lines = recipe.steps.flatMap((step, i) => {
+      const n = i + 1;
+      const out: string[] = [];
+      if (step.title) {
+        out.push(`${n}. ${step.title}`);
+        out.push(`   ${step.body}`);
+      } else {
+        out.push(`${n}. ${step.body}`);
+      }
+      if (step.tip) out.push(`   Tip: ${step.tip}`);
+      return out;
+    });
+    sections.push(["METHOD", ...lines].join("\n"));
+  }
+
+  if (recipe.notes && recipe.notes.length > 0) {
+    sections.push(["NOTES", ...recipe.notes.map((nt) => `• ${nt}`)].join("\n"));
+  }
+
+  sections.push("— from Ah Mah");
+
+  return sections.join("\n\n");
+}

--- a/src/features/Recipe/index.ts
+++ b/src/features/Recipe/index.ts
@@ -1,4 +1,6 @@
 export { CookingMode } from "./CookingMode";
+export { formatRecipeAsText } from "./formatRecipeAsText";
+export type { FormattableRecipe } from "./formatRecipeAsText";
 export { scaleAmount } from "./scaleAmount";
 export { ScaledNum } from "./ScaledNum";
 export { ServingsStepper } from "./ServingsStepper";

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useSessionContext } from "@/contexts/SessionContext";
-import { CookingMode, ServingsStepper } from "@/features/Recipe";
+import { CookingMode, ServingsStepper, formatRecipeAsText } from "@/features/Recipe";
 import {
   type ChangeEntry,
   type RecipeIngredient,
@@ -103,6 +103,8 @@ function changesToDiff(
 
 interface RecipeBodyProps {
   selectedRecipe: RecipeWithId;
+  servings: number;
+  onServingsChange: (next: number) => void;
   changedIngredients?: Set<number>;
   changedSteps?: Set<number>;
   deletedIngredients?: Set<number>;
@@ -113,6 +115,8 @@ interface RecipeBodyProps {
 
 function RecipeBody({
   selectedRecipe,
+  servings,
+  onServingsChange,
   changedIngredients = new Set(),
   changedSteps = new Set(),
   deletedIngredients = new Set(),
@@ -120,9 +124,6 @@ function RecipeBody({
   originalRecipe,
   showHighlights = false,
 }: RecipeBodyProps) {
-  const [servings, setServings] = useState<number>(
-    selectedRecipe.baseServings ?? 2,
-  );
   const baseServings = selectedRecipe.baseServings || 2;
   const ingredients = (selectedRecipe.ingredients || []) as RecipeIngredient[];
   const origIngredients = (originalRecipe?.ingredients || []) as RecipeIngredient[];
@@ -251,8 +252,8 @@ function RecipeBody({
               </h2>
               <ServingsStepper
                 servings={servings}
-                onDecrement={() => setServings((s) => Math.max(1, s - 1))}
-                onIncrement={() => setServings((s) => s + 1)}
+                onDecrement={() => onServingsChange(Math.max(1, servings - 1))}
+                onIncrement={() => onServingsChange(servings + 1)}
               />
             </div>
             <ul className="list-none p-0 mt-2 border-t border-border">
@@ -465,6 +466,9 @@ export default function RecipeDisplay({
 }: RecipeDisplayProps) {
   const { userId } = useSessionContext();
   const [cooking, setCooking] = useState(false);
+  // Lifted out of RecipeBody so the header "Copy recipe" action can read the
+  // currently displayed servings and scale the copied text to match.
+  const [servings, setServings] = useState<number>(recipe.baseServings ?? 2);
 
   // ── Bench state ────────────────────────────────────────────────────────────
   const [benchOpen, setBenchOpen] = useState(false);
@@ -525,6 +529,7 @@ export default function RecipeDisplay({
   useEffect(() => {
     originalRecipeRef.current = recipe;
     setWorkingDraft(recipe);
+    setServings(recipe.baseServings ?? 2);
     setChanges([]);
     setBenchOpen(false);
     setIsSaving(false);
@@ -572,6 +577,14 @@ export default function RecipeDisplay({
       setIsSaving(false);
     }
   }, [recipe.id, userId, workingDraft]);
+
+  const handleCopyRecipe = useCallback(() => {
+    const text = formatRecipeAsText(recipeWithIdToBlock(workingDraft), servings);
+    navigator.clipboard.writeText(text).then(
+      () => toast.success("Recipe copied — paste it anywhere."),
+      () => toast.error("Couldn't copy — try again?"),
+    );
+  }, [workingDraft, servings]);
 
   const handleStartCooking = () => {
     if (onStartCooking) {
@@ -628,6 +641,17 @@ export default function RecipeDisplay({
                   </button>
                 )}
                 <div className="flex items-center gap-2 ml-auto">
+                  <button
+                    onClick={handleCopyRecipe}
+                    className="inline-flex items-center gap-1.5 min-h-11 px-3 py-1.5 text-xs font-semibold text-foreground bg-card border border-border rounded-md cursor-pointer hover:bg-muted/60 transition-colors"
+                    aria-label="Copy recipe"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="shrink-0">
+                      <rect x="5" y="2" width="9" height="12" rx="1.5" stroke="currentColor" strokeWidth="1.4"/>
+                      <path d="M5 4H3.5A1.5 1.5 0 0 0 2 5.5v9A1.5 1.5 0 0 0 3.5 16h7A1.5 1.5 0 0 0 12 14.5V13" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+                    </svg>
+                    Copy recipe
+                  </button>
                   {!benchOpen && (
                     <button
                       onClick={() => setBenchOpen(true)}
@@ -658,6 +682,8 @@ export default function RecipeDisplay({
               <div className="rounded-xl border border-border bg-card overflow-hidden shadow-[0_1px_0_var(--color-border-soft)]">
                 <RecipeBody
                   selectedRecipe={workingDraft}
+                  servings={servings}
+                  onServingsChange={setServings}
                   changedIngredients={changedIngredients}
                   changedSteps={changedSteps}
                   deletedIngredients={deletedIngredients}


### PR DESCRIPTION
## Summary
Closes #269. A **Copy recipe** action that copies the whole recipe as clean plain text, on both recipe surfaces ([ADR-0011](https://github.com/alantay/ask-ah-mah/blob/main/docs/adr/0011-recipe-is-a-document.md)).

- **`formatRecipeAsText(recipe, servings)`** — one shared formatter in `src/features/Recipe`, two call sites, identical output:
  - plain text, CAPS section headers, `•`/numbered lists — **no markdown** (survives WhatsApp/Notes)
  - amounts scale to the **currently displayed servings** via `scaleAmount`; `to taste` for amountless rows
  - sections render only when present (no empty NOTES / BEFORE YOU START)
  - step `title` as the headline, `tip` rendered as `Tip:`, includes the **Recipe Notes** section, `— from Ah Mah` footer
  - excludes user-specific pantry state ("10/12 in your pantry", "Still need")
- **`RecipeDisplay`** — "Copy recipe" button in the header by Tweak / Start cooking. Servings state lifted out of `RecipeBody` so the header copies at the current stepper count.
- **`RecipeLetter`** — "Copy recipe" in the action bar, copies at the chat card's servings.
- **Copy shopping list is untouched** — two distinct copy intents, never collapsed into a bare "Copy".
- Success/error toast on copy.

## Test plan
- `src/features/Recipe/formatRecipeAsText.test.ts` (8 tests): sections-if-present, scaled amounts (2→4 doubles), `to taste`, em-dash notes, numbered steps + `Tip:`, no-markdown, no pantry state.
- Full suite: **433 passed**. `pnpm build` passes (production typecheck gate).
- The one `tsc` error in `RecipeLetter.test.tsx` is **pre-existing on `main`** (test-mock spread typing), not introduced here.
- Manual (not run here — needs a DB/dev server): open a saved recipe → bump servings → **Copy recipe** → paste into Notes/WhatsApp and confirm scaled, markdown-free text; repeat on a chat-inline recipe card; confirm **Copy shopping list** still works independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)