### PR TITLE
feat(recipe): unify cookbook step styling with chat recipe

### DIFF
--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -373,12 +373,12 @@ function RecipeBody({
                           {step.title}
                         </div>
                       )}
-                      <div className="font-sans text-[14px] text-foreground leading-[1.6]">
+                      <div className="font-display text-[15px] text-foreground leading-[1.6]">
                         {step.body}
                       </div>
                       {step.tip && (
-                        <div className="mt-1.5 text-xs text-ink-faint italic">
-                          {step.tip}
+                        <div className="mt-2 pl-3 border-l-[3px] border-[oklch(0.65_0.10_60)] font-display italic text-sm text-muted-foreground leading-relaxed">
+                          — {step.tip}
                         </div>
                       )}
                     </div>
@@ -404,7 +404,7 @@ function RecipeBody({
                             {step.title}
                           </div>
                         )}
-                        <div className="font-sans text-[14px] text-foreground leading-[1.6]">
+                        <div className="font-display text-[15px] text-foreground leading-[1.6]">
                           {step.body}
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
The cookbook recipe page and the in-chat recipe rendered the same data with noticeably different step styling. This brings the **brand signatures** across while keeping each surface's register:

- **Step body font** → `font-sans 14px` → `font-display (serif) 15px`, matching the chat recipe. Also fixes an internal inconsistency where step bodies were sans while Notes/ingredients were already serif on the same page.
- **Tip callout** → plain faint italic → the chat's signature colored left-bar + `—` em-dash prefix.
- **Kept deliberately different:** the quiet `1.` step numbers (vs the chat's ink-stamp badge), so the denser reference page stays scannable.

Net effect: same voice, calmer register — not two different designs.

## Test plan
- Open a saved recipe in the cookbook (`/recipe/[id]`) and confirm Method step bodies are serif and tips show the bar + em-dash.
- Compare against the in-chat recipe to confirm they now read as the same family.
- Verify the tweak/diff view (changed/deleted steps) still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced typography and spacing in recipe step instructions for improved readability
  * Redesigned recipe tip appearance with a left border accent and updated visual styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->