### PR TITLE
refactor(recipe): extract shared recipe atoms + --color-callout token

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -94,6 +94,19 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Earned step depth (#268)**: prompt-only — `steps[].body` carries the *why*, sensory doneness cues, and failure-mode cautions only on pivotal steps, under a soft length cap; trivial steps stay short. Step bodies reference ingredients by name only — no absolute quantities (they'd fight the servings stepper).
 - **Copy recipe (#269)**: one shared `formatRecipeAsText(recipe, servings)` (`src/features/Recipe`) → plain text, CAPS headers, `•`/numbered lists, no markdown (survives WhatsApp/Notes). Amounts scale to the displayed servings via `scaleAmount`; amountless rows read "to taste"; sections render only when present; a "— from Ah Mah" footer. Surfaced as a **Copy recipe** button on `RecipeDisplay` (header — servings lifted out of `RecipeBody` so the header reads the current count) and in the `RecipeLetter` action bar. Excludes pantry state ("10/12 in your pantry"). **Copy shopping list stays separate** — two distinct copy intents, never collapsed into a bare "Copy".
 
+## Design system
+
+The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — were drifting because each hand-rolled the same primitives. A design system is now the north star: shared atoms stop drift, and every surface gets tweaked incrementally so it "looks like it belongs". See the spec at `docs/superpowers/specs/2026-06-20-recipe-design-system-design.md` and the issue tracker (#277–#285).
+
+- **Shared recipe atoms (#277)**: six drift-prone primitives extracted to `src/features/shared/components/recipe/` (barrel-exported) and consumed by both surfaces:
+  - `Eyebrow` — uppercase mono-spaced section label (canonical `tracking-[0.16em]`).
+  - `SectionHeading` — serif `<h2>` ("What to gather", "Method", "Notes"); margins via `className`.
+  - `DottedList` — prep / notes bullet list, canonical aligned `·` gutter.
+  - `StepTip` — Ah Mah's per-step ochre left-bar aside, prefixed with an em-dash.
+  - `StepItem` — one numbered step in two registers: `"stamp"` (chat ink-stamp badge) or `"quiet"` (cookbook mono `1.`). Wrapper is configurable via `as` and forwards extra props/`className`, so the cookbook renders diff-aware `<li>` rows (`data-tweak-row`, highlight classes) through the same atom.
+  - `StepList` — vertical run of `StepItem`s for the simple (chat) case.
+  - New `--callout` token (`oklch(0.65 0.10 60)`, warm ochre) backs `StepTip`'s accent bar, replacing the inline `oklch(...)` literal both surfaces duplicated.
+
 ## Next up
 
 ### Shopping list from shortfalls

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,6 +41,7 @@
   --color-card: var(--card);
   --color-chat: var(--chat);
   --color-ink-faint: var(--ink-faint);
+  --color-callout: var(--callout);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -99,6 +100,9 @@
   --muted-foreground: oklch(0.46 0.038 52);
   /* Faint ink */
   --ink-faint: oklch(0.605 0.03 60);
+
+  /* Warm ochre — tip / aside accent bar (StepTip, callouts) */
+  --callout: oklch(0.65 0.10 60);
 
   /* Terracotta primary */
   --primary: oklch(0.56 0.135 35);

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -15,6 +15,7 @@ import { fetcher } from "@/lib/utils";
 import { ShoppingCart, TimerIcon } from "lucide-react";
 import { useState } from "react";
 import { CookingMode, ServingsStepper } from "@/features/Recipe";
+import { DottedList, Eyebrow, StepList } from "@/features/shared/components/recipe";
 import { toast } from "sonner";
 import useSWR, { useSWRConfig } from "swr";
 import { ScaledNum, scaleAmount, formatRecipeAsText } from "@/features/Recipe";
@@ -198,8 +199,6 @@ export function RecipeLetter({
   const timeLabel = recipe.totalTimeMinutes
     ? `${recipe.totalTimeMinutes} min`
     : null;
-  const EYEBROW_BASE =
-    "font-sans text-eyebrow font-bold tracking-widest uppercase";
 
   const showPantryPill = !!userId && !isStreaming;
   const canCook = !isStreaming && steps.length > 0;
@@ -306,12 +305,10 @@ export function RecipeLetter({
       {ingredients.length > 0 && (
         <div className="mb-5.5">
           <div className="flex items-center justify-between mb-2">
-            <span className={cn(EYEBROW_BASE, "text-muted-foreground")}>What to gather</span>
+            <Eyebrow className="text-muted-foreground">What to gather</Eyebrow>
             {!isStreaming && (
               <div className="flex items-center gap-1.5">
-                <span className="font-sans text-eyebrow font-bold tracking-[0.16em] uppercase text-ink-faint">
-                  Servings
-                </span>
+                <Eyebrow>Servings</Eyebrow>
                 <ServingsStepper
                   servings={servings}
                   onDecrement={() => setServings((s) => Math.max(1, s - 1))}
@@ -366,56 +363,19 @@ export function RecipeLetter({
       {/* Before you start — mise en place */}
       {prep && prep.length > 0 && (
         <div className="mb-5">
-          <span className={cn(EYEBROW_BASE, "text-muted-foreground block mb-2")}>Before you start</span>
-          <ul className="list-none p-0 m-0 flex flex-col">
-            {prep.map((item, i) => (
-              <li key={i} className="flex gap-2.5 items-baseline py-2 border-b border-dashed border-border last:border-none">
-                <span className="font-mono text-[11px] font-bold text-ink-faint shrink-0">·</span>
-                <span className="font-display text-sm text-foreground leading-[1.45]">{item}</span>
-              </li>
-            ))}
-          </ul>
+          <Eyebrow className="text-muted-foreground block mb-2">Before you start</Eyebrow>
+          <DottedList items={prep} />
         </div>
       )}
 
       {/* Steps — each step a conversational bubble with a numbered ink-stamp */}
-      {steps.length > 0 && (
-        <div className="flex flex-col gap-4.5">
-          {steps.map((step, i) => (
-            <div key={i} className="flex gap-3 items-start">
-              <div className="shrink-0 size-9 bg-primary text-white flex items-center justify-center font-display font-bold text-lg rounded-[50%_50%_50%_8px] -rotate-3 shadow-[inset_0_-2px_0_var(--primary-deep),0_1px_0_var(--primary-deep)]">
-                {i + 1}
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="font-display font-semibold text-base text-foreground mb-1 tracking-tight">
-                  {step.title}
-                </div>
-                <div className="font-display text-base text-foreground leading-relaxed">
-                  {step.body}
-                </div>
-                {step.tip && (
-                  <div className="mt-2 pl-3 border-l-[3px] border-[oklch(0.65_0.10_60)] font-display italic text-sm text-muted-foreground leading-relaxed">
-                    — {step.tip}
-                  </div>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+      {steps.length > 0 && <StepList steps={steps} marker="stamp" />}
 
       {/* Notes — whole-dish asides (make-ahead, storage, serving) */}
       {recipe.notes && recipe.notes.length > 0 && (
         <div className="mt-5">
-          <span className={cn(EYEBROW_BASE, "text-muted-foreground block mb-2")}>Notes</span>
-          <ul className="list-none p-0 m-0 flex flex-col">
-            {recipe.notes.map((note, i) => (
-              <li key={i} className="flex gap-2.5 items-baseline py-2 border-b border-dashed border-border last:border-none">
-                <span className="font-mono text-[11px] font-bold text-ink-faint shrink-0">·</span>
-                <span className="font-display text-sm text-foreground leading-[1.45]">{note}</span>
-              </li>
-            ))}
-          </ul>
+          <Eyebrow className="text-muted-foreground block mb-2">Notes</Eyebrow>
+          <DottedList items={recipe.notes} />
         </div>
       )}
 

--- a/src/features/RecipeDisplay/RecipeDisplay.test.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.test.tsx
@@ -80,7 +80,7 @@ describe("RecipeDisplay", () => {
       } as never);
       expect(screen.getByText("Heat the pan")).toBeInTheDocument();
       expect(screen.getByText("Put butter in a pan on medium heat.")).toBeInTheDocument();
-      expect(screen.getByText("Don't let it brown.")).toBeInTheDocument();
+      expect(screen.getByText(/Don't let it brown\./)).toBeInTheDocument();
       expect(screen.getByText("Add eggs")).toBeInTheDocument();
       expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
     });

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -4,12 +4,19 @@ import { Button } from "@/components/ui/button";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { CookingMode, ServingsStepper, formatRecipeAsText } from "@/features/Recipe";
 import {
+  DottedList,
+  Eyebrow,
+  SectionHeading,
+  StepItem,
+} from "@/features/shared/components/recipe";
+import {
   type ChangeEntry,
   type RecipeIngredient,
   type RecipeStep,
   type RecipeWithId,
   recipeWithIdToBlock,
 } from "@/lib/recipes/schemas";
+import { cn } from "@/lib/utils";
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -219,9 +226,7 @@ function RecipeBody({
               />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="font-sans text-eyebrow font-bold tracking-[0.16em] uppercase text-ink-faint mb-1">
-                From Ah Mah
-              </div>
+              <Eyebrow className="block mb-1">From Ah Mah</Eyebrow>
               <div className="font-display italic text-[15px] sm:text-base text-foreground leading-[1.5] max-w-prose">
                 {selectedRecipe.description}
               </div>
@@ -233,9 +238,7 @@ function RecipeBody({
         {selectedRecipe.totalTimeMinutes && (
           <div className="flex flex-wrap items-end gap-3 mb-7">
             <div className="flex flex-col px-3.5 py-2 bg-card border border-border rounded-lg shadow-[0_1px_0_var(--color-border-soft)] min-w-[78px]">
-              <span className="font-sans text-eyebrow font-bold tracking-[0.16em] uppercase text-ink-faint">
-                Total time
-              </span>
+              <Eyebrow>Total time</Eyebrow>
               <span className="font-display font-semibold text-[18px] text-foreground tabular-nums mt-0.5">
                 {formatTime(selectedRecipe.totalTimeMinutes)}
               </span>
@@ -247,9 +250,7 @@ function RecipeBody({
         {ingredients.length > 0 && (
           <section className="mb-9">
             <div className="flex items-center justify-between mb-1 gap-3">
-              <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight m-0">
-                What to gather
-              </h2>
+              <SectionHeading>What to gather</SectionHeading>
               <ServingsStepper
                 servings={servings}
                 onDecrement={() => onServingsChange(Math.max(1, servings - 1))}
@@ -324,91 +325,48 @@ function RecipeBody({
         {/* Before you start — mise en place */}
         {prep.length > 0 && (
           <section className="mb-9">
-            <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight mb-4">
-              Before you start
-            </h2>
-            <ul className="list-none p-0 flex flex-col">
-              {prep.map((item, i) => (
-                <li
-                  key={i}
-                  className="flex gap-3 items-baseline py-2 border-b border-dashed border-border"
-                >
-                  <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums shrink-0 w-5 text-right">
-                    ·
-                  </span>
-                  <span className="flex-1 font-display text-[15px] text-foreground leading-[1.45]">
-                    {item}
-                  </span>
-                </li>
-              ))}
-            </ul>
+            <SectionHeading className="mb-4">Before you start</SectionHeading>
+            <DottedList items={prep} />
           </section>
         )}
 
         {/* Method */}
         <section>
-          <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight mb-4">
-            Method
-          </h2>
+          <SectionHeading className="mb-4">Method</SectionHeading>
           {steps.length > 0 ? (
             <ol className="list-none p-0 flex flex-col gap-5">
               {steps.map((step, i) => {
                 const isChanged = showHighlights && changedSteps.has(i);
                 return (
-                  <li
+                  <StepItem
                     key={i}
+                    as="li"
+                    marker="quiet"
+                    n={i + 1}
+                    step={step}
                     data-tweak-row={`step-${i}`}
-                    className={`flex gap-4 transition-colors ${
-                      isChanged
-                        ? "bg-amber-200/70 dark:bg-amber-900/30 ring-1 ring-inset ring-amber-400/60 dark:ring-amber-700/50 -mx-1 px-1 rounded-lg py-1"
-                        : ""
-                    }`}
-                  >
-                    <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums pt-0.5 shrink-0 w-5 text-right">
-                      {i + 1}.
-                    </span>
-                    <div className="flex-1">
-                      {step.title && (
-                        <div className="font-display font-semibold text-[15px] text-foreground mb-0.5">
-                          {step.title}
-                        </div>
-                      )}
-                      <div className="font-display text-[15px] text-foreground leading-[1.6]">
-                        {step.body}
-                      </div>
-                      {step.tip && (
-                        <div className="mt-2 pl-3 border-l-[3px] border-[oklch(0.65_0.10_60)] font-display italic text-sm text-muted-foreground leading-relaxed">
-                          — {step.tip}
-                        </div>
-                      )}
-                    </div>
-                  </li>
+                    className={cn(
+                      "transition-colors",
+                      isChanged &&
+                        "bg-amber-200/70 dark:bg-amber-900/30 ring-1 ring-inset ring-amber-400/60 dark:ring-amber-700/50 -mx-1 px-1 rounded-lg py-1",
+                    )}
+                  />
                 );
               })}
-              {/* Deleted steps */}
+              {/* Deleted steps — diff overlay, tip suppressed */}
               {showHighlights &&
                 Array.from(deletedSteps).map((i) => {
                   const step = origSteps[i];
                   if (!step) return null;
                   return (
-                    <li
+                    <StepItem
                       key={`deleted-step-${i}`}
-                      className="flex gap-4 transition-colors line-through opacity-50"
-                    >
-                      <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums pt-0.5 shrink-0 w-5 text-right">
-                        {i + 1}.
-                      </span>
-                      <div className="flex-1">
-                        {step.title && (
-                          <div className="font-display font-semibold text-[15px] text-foreground mb-0.5">
-                            {step.title}
-                          </div>
-                        )}
-                        <div className="font-display text-[15px] text-foreground leading-[1.6]">
-                          {step.body}
-                        </div>
-                      </div>
-                    </li>
+                      as="li"
+                      marker="quiet"
+                      n={i + 1}
+                      step={{ title: step.title, body: step.body }}
+                      className="transition-colors line-through opacity-50"
+                    />
                   );
                 })}
             </ol>
@@ -424,24 +382,8 @@ function RecipeBody({
         {/* Notes — whole-dish asides (make-ahead, storage, serving) */}
         {notes.length > 0 && (
           <section className="mt-9">
-            <h2 className="font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight mb-4">
-              Notes
-            </h2>
-            <ul className="list-none p-0 flex flex-col">
-              {notes.map((note, i) => (
-                <li
-                  key={i}
-                  className="flex gap-3 items-baseline py-2 border-b border-dashed border-border"
-                >
-                  <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums shrink-0 w-5 text-right">
-                    ·
-                  </span>
-                  <span className="flex-1 font-display text-[15px] text-foreground leading-[1.45]">
-                    {note}
-                  </span>
-                </li>
-              ))}
-            </ul>
+            <SectionHeading className="mb-4">Notes</SectionHeading>
+            <DottedList items={notes} />
           </section>
         )}
       </div>

--- a/src/features/shared/components/recipe/DottedList.tsx
+++ b/src/features/shared/components/recipe/DottedList.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Dotted bullet list — prep ("Before you start") and whole-dish notes on both
+ * recipe surfaces. Canonical style is the aligned reference treatment: a
+ * right-aligned `·` marker in a fixed gutter, serif body, dashed dividers.
+ */
+export function DottedList({
+  items,
+  className,
+}: {
+  items: string[];
+  className?: string;
+}) {
+  return (
+    <ul className={cn("list-none p-0 m-0 flex flex-col", className)}>
+      {items.map((item, i) => (
+        <li
+          key={i}
+          className="flex gap-3 items-baseline py-2 border-b border-dashed border-border last:border-none"
+        >
+          <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums shrink-0 w-5 text-right">
+            ·
+          </span>
+          <span className="flex-1 font-display text-[15px] text-foreground leading-[1.45]">
+            {item}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/shared/components/recipe/Eyebrow.tsx
+++ b/src/features/shared/components/recipe/Eyebrow.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Small-caps section label — the recipe surfaces' eyebrow treatment.
+ *
+ * Canonical typography (`tracking-[0.16em]`) with a quiet `ink-faint` default.
+ * Pass `className` to override colour (e.g. `text-muted-foreground`) or layout
+ * (e.g. `block mb-2`); `twMerge` resolves the conflict in favour of `className`.
+ */
+export function Eyebrow({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "font-sans text-eyebrow font-bold tracking-[0.16em] uppercase text-ink-faint",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/features/shared/components/recipe/SectionHeading.tsx
+++ b/src/features/shared/components/recipe/SectionHeading.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Serif section heading used on the cookbook reference surface
+ * ("What to gather", "Method", "Notes"…). Pass margins via `className`.
+ */
+export function SectionHeading({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <h2
+      className={cn(
+        "font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight m-0",
+        className,
+      )}
+    >
+      {children}
+    </h2>
+  );
+}

--- a/src/features/shared/components/recipe/StepItem.test.tsx
+++ b/src/features/shared/components/recipe/StepItem.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+
+import { StepItem } from "./StepItem";
+
+const step = {
+  title: "Heat the pan",
+  body: "Put butter in a pan on medium heat.",
+  tip: "Don't let it brown.",
+};
+
+describe("StepItem", () => {
+  it("renders title, body and an em-dashed tip", () => {
+    render(<StepItem n={1} step={step} />);
+    expect(screen.getByText("Heat the pan")).toBeInTheDocument();
+    expect(
+      screen.getByText("Put butter in a pan on medium heat."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Don't let it brown\./)).toBeInTheDocument();
+  });
+
+  it("omits the tip when the step has none", () => {
+    render(<StepItem n={2} step={{ title: "Add eggs", body: "Pour in." }} />);
+    expect(screen.queryByText(/—/)).not.toBeInTheDocument();
+  });
+
+  describe("quiet register (cookbook)", () => {
+    it("renders a mono '<n>.' marker", () => {
+      render(<StepItem n={3} step={step} marker="quiet" />);
+      expect(screen.getByText("3.")).toBeInTheDocument();
+    });
+
+    it("forwards `as` and extra props to the wrapper element", () => {
+      render(
+        <ol>
+          <StepItem
+            n={1}
+            step={step}
+            marker="quiet"
+            as="li"
+            data-tweak-row="step-0"
+          />
+        </ol>,
+      );
+      const li = document.querySelector('li[data-tweak-row="step-0"]');
+      expect(li).toBeInTheDocument();
+      expect(li?.tagName).toBe("LI");
+    });
+  });
+
+  describe("stamp register (chat letter)", () => {
+    it("renders the numbered ink-stamp badge", () => {
+      render(<StepItem n={4} step={step} marker="stamp" />);
+      expect(screen.getByText("4")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/shared/components/recipe/StepItem.tsx
+++ b/src/features/shared/components/recipe/StepItem.tsx
@@ -1,0 +1,84 @@
+import type { ComponentPropsWithoutRef, ElementType } from "react";
+
+import type { RecipeStep } from "@/lib/recipes/schemas";
+import { cn } from "@/lib/utils";
+
+import { StepTip } from "./StepTip";
+
+/**
+ * A single numbered recipe step, rendered in one of two registers:
+ *
+ * - `"stamp"` — the chat *letter*: a rotated terracotta ink-stamp badge, larger
+ *   serif body. Playful, one recipe at a time.
+ * - `"quiet"` — the cookbook *reference*: a mono `1.` in a fixed gutter, denser
+ *   serif body. Scannable.
+ *
+ * Both share the title → body → {@link StepTip} structure. The wrapping element
+ * is configurable (`as`) and extra props/`className` are forwarded to it, so the
+ * cookbook can render `<li>` rows carrying its diff-overlay attributes
+ * (`data-tweak-row`, highlight classes) while the chat renders plain `<div>`s.
+ */
+type StepItemProps<T extends ElementType> = {
+  n: number;
+  step: RecipeStep;
+  marker?: "stamp" | "quiet";
+  as?: T;
+  className?: string;
+} & Omit<ComponentPropsWithoutRef<T>, "children" | "className">;
+
+const REGISTER = {
+  stamp: {
+    row: "gap-3 items-start",
+    content: "flex-1 min-w-0",
+    title: "text-base mb-1",
+    body: "text-base leading-relaxed",
+  },
+  quiet: {
+    row: "gap-4",
+    content: "flex-1",
+    title: "text-[15px] mb-0.5",
+    body: "text-[15px] leading-[1.6]",
+  },
+} as const;
+
+export function StepItem<T extends ElementType = "div">({
+  n,
+  step,
+  marker = "quiet",
+  as,
+  className,
+  ...rest
+}: StepItemProps<T>) {
+  const Wrapper = (as ?? "div") as ElementType;
+  const r = REGISTER[marker];
+
+  return (
+    <Wrapper className={cn("flex", r.row, className)} {...rest}>
+      {marker === "stamp" ? (
+        <div className="shrink-0 size-9 bg-primary text-white flex items-center justify-center font-display font-bold text-lg rounded-[50%_50%_50%_8px] -rotate-3 shadow-[inset_0_-2px_0_var(--primary-deep),0_1px_0_var(--primary-deep)]">
+          {n}
+        </div>
+      ) : (
+        <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums pt-0.5 shrink-0 w-5 text-right">
+          {n}.
+        </span>
+      )}
+      <div className={r.content}>
+        {step.title && (
+          <div
+            className={cn(
+              "font-display font-semibold text-foreground tracking-tight",
+              r.title,
+            )}
+          >
+            {step.title}
+          </div>
+        )}
+        <div className={cn("font-display text-foreground", r.body)}>
+          {step.body}
+        </div>
+        {step.tip && <StepTip>{step.tip}</StepTip>}
+      </div>
+    </Wrapper>
+  );
+}

--- a/src/features/shared/components/recipe/StepList.tsx
+++ b/src/features/shared/components/recipe/StepList.tsx
@@ -1,0 +1,27 @@
+import type { RecipeStep } from "@/lib/recipes/schemas";
+import { cn } from "@/lib/utils";
+
+import { StepItem } from "./StepItem";
+
+/**
+ * Convenience wrapper: a vertical run of {@link StepItem}s for the common case
+ * (the chat letter). Surfaces that need per-step decoration — e.g. the
+ * cookbook's diff overlay — should map {@link StepItem} directly instead.
+ */
+export function StepList({
+  steps,
+  marker = "stamp",
+  className,
+}: {
+  steps: RecipeStep[];
+  marker?: "stamp" | "quiet";
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex flex-col gap-4.5", className)}>
+      {steps.map((step, i) => (
+        <StepItem key={i} n={i + 1} step={step} marker={marker} />
+      ))}
+    </div>
+  );
+}

--- a/src/features/shared/components/recipe/StepTip.tsx
+++ b/src/features/shared/components/recipe/StepTip.tsx
@@ -1,0 +1,11 @@
+/**
+ * Ah Mah's per-step aside — an ochre left-bar callout prefixed with an em-dash.
+ * Shared signature across the chat letter and cookbook reference surfaces.
+ */
+export function StepTip({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-2 pl-3 border-l-[3px] border-callout font-display italic text-sm text-muted-foreground leading-relaxed">
+      — {children}
+    </div>
+  );
+}

--- a/src/features/shared/components/recipe/index.ts
+++ b/src/features/shared/components/recipe/index.ts
@@ -1,0 +1,6 @@
+export { Eyebrow } from "./Eyebrow";
+export { SectionHeading } from "./SectionHeading";
+export { DottedList } from "./DottedList";
+export { StepTip } from "./StepTip";
+export { StepItem } from "./StepItem";
+export { StepList } from "./StepList";


### PR DESCRIPTION
## Summary

Implements #277. The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — each hand-rolled the same primitives and were drifting. This extracts six drift-prone atoms into `src/features/shared/components/recipe/` (barrel-exported) and has both surfaces consume them:

- **`Eyebrow`** — uppercase section label (canonical `tracking-[0.16em]`).
- **`SectionHeading`** — serif `<h2>` ("What to gather", "Method", "Notes"); margins via `className`.
- **`DottedList`** — prep / notes bullet list, canonical aligned `·` gutter.
- **`StepTip`** — Ah Mah's per-step ochre left-bar aside, em-dash prefixed.
- **`StepItem`** — one numbered step in two registers: `"stamp"` (chat ink-stamp badge) or `"quiet"` (cookbook mono `1.`). Wrapper configurable via `as`; extra props/`className` forwarded — so the cookbook renders diff-aware `<li>` rows (`data-tweak-row`, highlight classes) through the same atom and the tweak bench is untouched.
- **`StepList`** — vertical run of `StepItem`s for the simple chat case.

Adds a `--callout` token (`oklch(0.65 0.10 60)`, warm ochre) backing `StepTip`'s accent bar, replacing the inline `oklch(...)` literal both surfaces duplicated.

Intentional, documented parity shifts: chat dotted lists adopt the aligned gutter; chat eyebrows move `tracking-widest` → `tracking-[0.16em]`; both step-title registers gain `tracking-tight`.

## Test plan

- `pnpm jest` — **440/440 pass**. Adds `StepItem.test.tsx` (stamp/quiet registers, `as`/prop forwarding, tip rendering); fixes a stale `RecipeDisplay` test that PR #276's em-dash tip prefix had already broken on `main`.
- Cookbook surface verified via Playwright screenshot — quiet `1.`–`4.` markers, serif headings/bodies, and the ochre `StepTip` callouts all render correctly.
- Chat `RecipeLetter` is unit-test-covered (live render needs a streaming LLM response); it consumes the same `StepList` / `Eyebrow` / `DottedList` atoms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)