### PR TITLE
style(conversations): align history sidebar to design system

### DIFF
--- a/src/features/Conversations/Conversations.tsx
+++ b/src/features/Conversations/Conversations.tsx
@@ -34,7 +34,7 @@ export function Conversations({ onItemClick }: ConversationsProps) {
   return (
     <div className="flex flex-col h-full gap-3">
       {/* Header */}
-      <div className="font-display italic font-medium text-[22px] text-foreground leading-tight">
+      <div className="font-display italic font-medium text-heading text-foreground">
         Conversations
       </div>
 
@@ -43,7 +43,7 @@ export function Conversations({ onItemClick }: ConversationsProps) {
         {isLoading && allConversations.length === 0 ? (
           <ConversationListSkeleton />
         ) : committedConversations.length === 0 ? (
-          <div className="italic text-ink-faint text-sm">No chats yet.</div>
+          <div className="font-display italic text-ink-faint text-sm">No chats yet.</div>
         ) : (
           <div className="flex flex-col gap-2">
             {committedConversations.map((conv) => (


### PR DESCRIPTION
## Summary

Implements #280. Conversations was the closest-to-aligned surface in the #279 audit; this closes its two gaps:

- Rail header `text-[22px]` → `text-heading` (named scale role, §2).
- Italic "No chats yet" empty state gains `font-display` — italic asides speak in Ah Mah's serif voice (§1).

Conversation rows were already aligned (serif `font-display` titles, `secondary` card-lift active state). Row titles stay at `text-sm` — a deliberate sidebar size and a standard utility, not an arbitrary px to tokenise.

## Test plan

`pnpm jest src/features/Conversations` — 12/12 pass. Lint clean. Visual: header renders identically (22px), empty state now serif-italic.

Closes #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for the Conversations section headers and empty state messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->