### PR TITLE
style(recipe-list): align cards, sidebar + add-recipe modal to design system

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -107,6 +107,11 @@ The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook)
   - `StepList` — vertical run of `StepItem`s for the simple (chat) case.
   - New `--callout` token (`oklch(0.65 0.10 60)`, warm ochre) backs `StepTip`'s accent bar, replacing the inline `oklch(...)` literal both surfaces duplicated.
 
+- **Design-system guide + audit (#278–#279)**: `docs/design-system.md` is the written north star — voice, named type scale, semantic color roles, rhythm, the two registers, and the six atoms — with a per-surface gap audit driving the alignment issues.
+- **Per-surface alignment (#280–#284)**: each surface tweaked until it "belongs" — swap raw `text-[Npx]` for named scale tokens, raw `oklch(...)` for semantic tokens, and inline eyebrows for the `Eyebrow` atom.
+  - `Conversations` (#280): header → `text-heading`, empty state → `font-display`.
+  - `RecipeList` (#281): page header, cards, sidebar, and Add-recipe modal mapped to the scale; sidebar category labels now use the `Eyebrow` atom. New `--danger` / `--danger-border` / `--danger-tint` tokens (hue 27, light + dark) replace the modal's inline error-state `oklch(...)` literals.
+
 ## Next up
 
 ### Shopping list from shortfalls

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,9 @@
   --color-chat: var(--chat);
   --color-ink-faint: var(--ink-faint);
   --color-callout: var(--callout);
+  --color-danger: var(--danger);
+  --color-danger-border: var(--danger-border);
+  --color-danger-tint: var(--danger-tint);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -103,6 +106,13 @@
 
   /* Warm ochre — tip / aside accent bar (StepTip, callouts) */
   --callout: oklch(0.65 0.10 60);
+
+  /* Danger — error states (form validation, the "couldn't read" banner).
+     `danger` is the strong status ink (badge); `danger-border` the active edge
+     + ring; `danger-tint` the pale fill behind an error message. */
+  --danger: oklch(0.52 0.16 27);
+  --danger-border: oklch(0.78 0.10 27);
+  --danger-tint: oklch(0.97 0.04 27);
 
   /* Terracotta primary */
   --primary: oklch(0.56 0.135 35);
@@ -171,6 +181,9 @@
   --ink-faint: oklch(0.55 0.025 55);
   --jade: oklch(0.6 0.1 168);
   --jade-foreground: oklch(0.95 0.025 78);
+  --danger: oklch(0.66 0.18 27);
+  --danger-border: oklch(0.5 0.12 27);
+  --danger-tint: oklch(0.32 0.06 27);
   --accent: oklch(0.34 0.025 50);
   --accent-foreground: oklch(0.95 0.025 78);
   --destructive: oklch(0.66 0.18 25);

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useSessionContext } from "@/contexts/SessionContext";
+import { Eyebrow } from "@/features/shared/components/recipe";
 import { RecipeWithId } from "@/lib/recipes/schemas";
 import { fetcher } from "@/lib/utils";
 import { useRouter } from "next/navigation";
@@ -85,13 +86,11 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
           already labels this surface and the chip rail carries `All · N`. */}
       <div className="px-4 sm:px-9 pt-3 sm:pt-6 pb-[18px] sm:border-b sm:border-border flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 sm:gap-6 shrink-0">
         <div className="hidden sm:block">
-          <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground mb-1.5">
-            Worth cooking again
-          </div>
-          <h1 className="font-display font-semibold text-[40px] text-foreground leading-none tracking-tight">
+          <Eyebrow className="block mb-1.5">Worth cooking again</Eyebrow>
+          <h1 className="font-display font-semibold text-display text-foreground leading-none tracking-tight">
             Your kept recipes
           </h1>
-          <p className="font-display italic text-[15px] text-muted-foreground mt-2">
+          <p className="font-display italic text-emphasis text-muted-foreground mt-2">
             {isEmpty
               ? "Empty for now. Cook something with Ah Mah, then save the ones you'd cook again."
               : (() => {
@@ -111,7 +110,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
             <>
               {tagEntries.length > 0 && <button
                 onClick={() => setMobileFilterOpen(true)}
-                className="sm:hidden shrink-0 flex items-center gap-1.5 px-3 py-[7px] font-sans text-[13px] font-medium text-muted-foreground bg-card border border-border rounded-full cursor-pointer hover:text-foreground transition-colors"
+                className="sm:hidden shrink-0 flex items-center gap-1.5 px-3 py-[7px] font-sans text-dense font-medium text-muted-foreground bg-card border border-border rounded-full cursor-pointer hover:text-foreground transition-colors"
               >
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
                   <path d="M1 3h10M3 6h6M5 9h2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
@@ -132,7 +131,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
                   placeholder="Search your cookbook…"
-                  className="flex-1 bg-transparent border-none outline-none text-[13px] placeholder:text-muted-foreground text-foreground min-w-0"
+                  className="flex-1 bg-transparent border-none outline-none text-dense placeholder:text-muted-foreground text-foreground min-w-0"
                 />
               </label>
             </>
@@ -140,7 +139,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
           <Button
             variant="cta"
             onClick={() => setShowAdd(true)}
-            className="shrink-0 gap-1.5 px-3 py-[7px] font-sans text-[13px] font-semibold rounded-full"
+            className="shrink-0 gap-1.5 px-3 py-[7px] font-sans text-dense font-semibold rounded-full"
           >
             <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="size-[12px]">
               <path d="M6 1v10M1 6h10" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
@@ -171,7 +170,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
           ) : isEmpty ? (
             <CookbookEmpty onChatClick={onChatClick} onPasteClick={() => setShowAdd(true)} />
           ) : filtered.length === 0 ? (
-            <p className="font-display italic text-[14px] text-muted-foreground">
+            <p className="font-display italic text-emphasis text-muted-foreground">
               {activeTags.size > 0
                 ? "Nothing matches those filters. Try removing one?"
                 : "Nothing matches. Try a different word?"}
@@ -207,7 +206,7 @@ function CookbookEmpty({ onChatClick, onPasteClick }: { onChatClick?: () => void
           </svg>
         </div>
         <div>
-          <div className="font-display font-semibold text-[22px] text-foreground leading-tight tracking-tight mb-1.5">
+          <div className="font-display font-semibold text-heading text-foreground leading-tight tracking-tight mb-1.5">
             Cookbook&rsquo;s empty for now.
           </div>
           <div className="font-display italic text-sm text-muted-foreground leading-relaxed">
@@ -218,13 +217,13 @@ function CookbookEmpty({ onChatClick, onPasteClick }: { onChatClick?: () => void
           <Button
             variant="cta"
             onClick={onChatClick}
-            className="self-start px-3.5 py-2 text-[13px] font-semibold"
+            className="self-start px-3.5 py-2 text-dense font-semibold"
           >
             Ask Ah Mah for a recipe →
           </Button>
           <button
             onClick={onPasteClick}
-            className="self-start font-sans text-[12px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            className="self-start font-sans text-dense text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
           >
             or paste one you&rsquo;ve found
           </button>

--- a/src/features/RecipeList/components/AddRecipeModal.tsx
+++ b/src/features/RecipeList/components/AddRecipeModal.tsx
@@ -239,7 +239,7 @@ export function AddRecipeModal({ open, onOpenChange }: AddRecipeModalProps) {
         {step === "extracting" ? (
           <div className="px-5 sm:px-6 pt-5 pb-4 border-b border-border shrink-0 flex items-center gap-3">
             <div className="w-4 h-4 rounded-full border-2 border-border border-t-primary shrink-0 [animation:modalSpin_0.9s_linear_infinite]" />
-            <span className="font-display italic text-[15px] text-foreground">
+            <span className="font-display italic text-emphasis text-foreground">
               Ah Mah is reading your recipe…
             </span>
           </div>
@@ -253,10 +253,10 @@ export function AddRecipeModal({ open, onOpenChange }: AddRecipeModalProps) {
                 </svg>
               </div>
               <div>
-                <h2 className="font-display font-semibold text-[20px] sm:text-[22px] text-foreground tracking-tight leading-tight">
+                <h2 className="font-display font-semibold text-heading text-foreground tracking-tight leading-tight">
                   Add a recipe
                 </h2>
-                <p className="hidden sm:block font-display italic text-[13px] text-muted-foreground mt-1 leading-snug">
+                <p className="hidden sm:block font-display italic text-dense text-muted-foreground mt-1 leading-snug">
                   Paste any recipe text — Ah Mah will read it and tidy it up for you.
                 </p>
               </div>
@@ -297,7 +297,7 @@ export function AddRecipeModal({ open, onOpenChange }: AddRecipeModalProps) {
                     "font-sans text-dense text-foreground placeholder:text-muted-foreground leading-relaxed",
                     "outline-none transition-all",
                     error
-                      ? "border-[oklch(0.78_0.10_27)] ring-[3px] ring-[oklch(0.78_0.10_27)/0.12]"
+                      ? "border-danger-border ring-[3px] ring-danger-border/12"
                       : text
                       ? "border-primary ring-[3px] ring-primary/10"
                       : "border-border focus:border-primary focus:ring-[3px] focus:ring-primary/10",
@@ -305,11 +305,11 @@ export function AddRecipeModal({ open, onOpenChange }: AddRecipeModalProps) {
                 />
 
                 {error && (
-                  <div className="flex gap-2.5 items-start px-3 py-2.5 rounded-lg bg-[oklch(0.97_0.04_27)] border border-[oklch(0.85_0.08_27)] shrink-0">
-                    <div className="w-[18px] h-[18px] rounded-full bg-[oklch(0.52_0.16_27)] text-white text-[11px] font-bold flex items-center justify-center shrink-0 mt-0.5">
+                  <div className="flex gap-2.5 items-start px-3 py-2.5 rounded-lg bg-danger-tint border border-danger-border shrink-0">
+                    <div className="w-[18px] h-[18px] rounded-full bg-danger text-white text-micro font-bold flex items-center justify-center shrink-0 mt-0.5">
                       !
                     </div>
-                    <div className="font-sans text-[12px] text-foreground leading-[1.5]">
+                    <div className="font-sans text-dense text-foreground leading-[1.5]">
                       <span className="font-semibold">Ah Mah couldn&rsquo;t find a recipe in this.</span>{" "}
                       <span className="text-muted-foreground">
                         Try pasting just the recipe portion — usually the ingredients and steps.

--- a/src/features/RecipeList/components/RecipeCard.tsx
+++ b/src/features/RecipeList/components/RecipeCard.tsx
@@ -61,7 +61,7 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
           }}
         >
           {isOptimistic && (
-            <span className="font-mono text-eyebrow tracking-widest text-foreground/40 uppercase">
+            <span className="font-mono text-eyebrow tracking-[0.16em] text-foreground/40 uppercase">
               Saving…
             </span>
           )}
@@ -91,7 +91,7 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
           style={{ maskImage: "linear-gradient(to right, black calc(100% - 28px), transparent 100%)" }}
         >
           {recipe.totalTimeMinutes && (
-            <span className="flex items-center gap-1 font-mono text-[11px] text-ink-faint shrink-0">
+            <span className="flex items-center gap-1 font-mono text-micro text-ink-faint shrink-0">
               <svg width="11" height="11" viewBox="0 0 16 16" fill="none" className="shrink-0">
                 <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.4" />
                 <path d="M8 4.5V8l2.5 2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
@@ -102,7 +102,7 @@ export default function RecipeCard({ recipe, onSelect, onDelete }: RecipeCardPro
           {recipe.tags?.map((tag, i) => (
             <span
               key={`${tag}-${i}`}
-              className="shrink-0 text-[11px] font-medium px-2 py-0.5 border border-border rounded-full text-muted-foreground"
+              className="shrink-0 text-micro font-medium px-2 py-0.5 border border-border rounded-full text-muted-foreground"
             >
               {tag}
             </span>

--- a/src/features/RecipeList/components/RecipeSidebar.tsx
+++ b/src/features/RecipeList/components/RecipeSidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TAG_SETS, TagCategory, getTagCategory } from "@/lib/recipes/tagColors";
+import { Eyebrow } from "@/features/shared/components/recipe";
 import { useState } from "react";
 
 const VISIBLE_LIMIT = 5;
@@ -82,7 +83,7 @@ export function RecipeSidebar({
               {activeTags.size > 0 && (
                 <button
                   onClick={onClear}
-                  className="text-[11px] text-primary hover:opacity-70 transition-opacity cursor-pointer"
+                  className="text-micro text-primary hover:opacity-70 transition-opacity cursor-pointer"
                 >
                   Clear all
                 </button>
@@ -130,7 +131,7 @@ function SidebarHeader({
     <div className="flex items-center justify-end px-4 py-3 shrink-0">
       <button
         onClick={onClear}
-        className="text-[11px] text-primary hover:opacity-70 transition-opacity cursor-pointer"
+        className="text-micro text-primary hover:opacity-70 transition-opacity cursor-pointer"
       >
         Clear all
       </button>
@@ -195,9 +196,7 @@ function CollapsibleTagGroup({
 
   return (
     <section>
-      <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground/60 mb-1.5 px-1">
-        {label}
-      </p>
+      <Eyebrow className="block mb-1.5 px-1">{label}</Eyebrow>
       <div className="flex flex-col">
         {visible.map((tag) => (
           <CheckboxRow
@@ -211,7 +210,7 @@ function CollapsibleTagGroup({
         {hidden > 0 && (
           <button
             onClick={() => setExpanded(true)}
-            className="self-start px-1 py-[5px] text-[12px] font-semibold text-primary hover:text-primary/70 transition-colors cursor-pointer"
+            className="self-start px-1 py-[5px] text-dense font-semibold text-primary hover:text-primary/70 transition-colors cursor-pointer"
           >
             + {hidden} more
           </button>
@@ -219,7 +218,7 @@ function CollapsibleTagGroup({
         {expanded && tags.length > VISIBLE_LIMIT && (
           <button
             onClick={() => setExpanded(false)}
-            className="self-start px-1 py-[5px] text-[12px] font-semibold text-ink-faint hover:text-muted-foreground transition-colors cursor-pointer"
+            className="self-start px-1 py-[5px] text-dense font-semibold text-ink-faint hover:text-muted-foreground transition-colors cursor-pointer"
           >
             Show less
           </button>
@@ -266,7 +265,7 @@ function CheckboxRow({
         )}
       </span>
       <span
-        className={`flex-1 text-[12px] leading-snug truncate transition-colors ${
+        className={`flex-1 text-dense leading-snug truncate transition-colors ${
           checked ? "text-foreground font-medium" : "text-muted-foreground"
         }`}
       >


### PR DESCRIPTION
## Summary
Aligns the **RecipeList / Cookbook** surface to the design system (#281) — swap raw type sizes for named scale tokens, inline error-state `oklch()` literals for semantic `--danger` tokens, and inline eyebrows for the `Eyebrow` atom. Per the per-surface audit in `docs/design-system.md`.

- **RecipeList**: page eyebrow → `Eyebrow` atom; title → `text-display`; bodies → `text-emphasis`; chrome (filter / search / Add / empty CTA) → `text-dense` / `text-heading`.
- **RecipeCard**: time + tag pills → `text-micro`; "Saving…" eyebrow tracking → canonical `0.16em`.
- **RecipeSidebar**: category labels → `Eyebrow` atom; "Clear all" → `text-micro`; tag rows + expand toggles → `text-dense`.
- **AddRecipeModal**: heading → `text-heading`; subcopy + error banner → `text-dense`; error badge → `text-micro`.
- **globals.css**: new `--danger` / `--danger-border` / `--danger-tint` tokens (hue 27, light + dark) replacing the modal's inline error-state `oklch(...)` literals.

Intentionally left: the `text-[9px]` filter-count bubble (no sub-scale role) and `RecipeCard`'s layered elevation shadow (tracked separately as a `--shadow-card` token follow-up).

## Test plan
- `pnpm jest src/features/RecipeList` — green (3/3).
- `pnpm eslint` — no new errors (pre-existing warnings only).
- Visual: cookbook page header, cards, tag sidebar, and the Add-recipe modal (incl. the "couldn't read" error banner) render with no scale/color regressions in light + dark.

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)