### PR TITLE
style(cooking-mode): align cooking mode + servings stepper to design system

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -107,6 +107,9 @@ The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook)
   - `StepList` — vertical run of `StepItem`s for the simple (chat) case.
   - New `--callout` token (`oklch(0.65 0.10 60)`, warm ochre) backs `StepTip`'s accent bar, replacing the inline `oklch(...)` literal both surfaces duplicated.
 
+- **Per-surface alignment (#280–#284)**: each surface tweaked until it "belongs" — raw `text-[Npx]` / inline `oklch(...)` swapped for named scale + semantic-color tokens.
+  - `Recipe` / `CookingMode` (#283): step counter → `text-micro`; step body → `text-xl`; tip bar → `border-callout`; servings stepper readout → `text-emphasis`. New `--jade-deep` token (light + dark) replaces the inline `oklch(0.35 0.10 168)` border + hard-shadow on the cooking-mode "Done" button.
+
 ## Next up
 
 ### Shopping list from shortfalls

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,6 +50,7 @@
   --color-tertiary: var(--tertiary);
   --color-jade: var(--jade);
   --color-jade-foreground: var(--jade-foreground);
+  --color-jade-deep: var(--jade-deep);
   --color-primary-deep: var(--primary-deep);
   --color-primary-tint: var(--primary-tint);
   --color-secondary-deep: var(--secondary-deep);
@@ -121,6 +122,8 @@
   /* Jade — decorative accent ink (chips, pills, dots) */
   --jade: oklch(0.5 0.095 168);
   --jade-foreground: oklch(0.97 0.02 80);
+  /* Deeper jade — hard-shadow underbite / border on jade surfaces (the cooking-mode "Done" button) */
+  --jade-deep: oklch(0.35 0.10 168);
 
   /* Accent — neutral interactive hover surface (kraft, paper-toned) */
   --accent: oklch(0.89 0.028 70);
@@ -171,6 +174,7 @@
   --ink-faint: oklch(0.55 0.025 55);
   --jade: oklch(0.6 0.1 168);
   --jade-foreground: oklch(0.95 0.025 78);
+  --jade-deep: oklch(0.42 0.1 168);
   --accent: oklch(0.34 0.025 50);
   --accent-foreground: oklch(0.95 0.025 78);
   --destructive: oklch(0.66 0.18 25);

--- a/src/features/Recipe/CookingMode.tsx
+++ b/src/features/Recipe/CookingMode.tsx
@@ -80,7 +80,7 @@ export function CookingMode({ title, steps, prep, onExit }: CookingModeProps) {
           <div className="font-display font-semibold text-base text-foreground leading-tight tracking-tight truncate max-w-[240px] sm:max-w-none">
             {title}
           </div>
-          <div className="font-sans text-[11px] text-ink-faint mt-0.5 tabular-nums">
+          <div className="font-sans text-micro text-ink-faint mt-0.5 tabular-nums">
             Step {current + 1} of {total}
           </div>
         </div>
@@ -112,12 +112,12 @@ export function CookingMode({ title, steps, prep, onExit }: CookingModeProps) {
           </div>
         </div>
 
-        <div className="font-display text-[1.25rem] leading-relaxed text-foreground">
+        <div className="font-display text-xl leading-relaxed text-foreground">
           {step.body}
         </div>
 
         {step.tip && (
-          <div className="mt-5 pl-4 border-l-[3px] border-[oklch(0.65_0.10_60)] font-display italic text-base text-muted-foreground leading-relaxed">
+          <div className="mt-5 pl-4 border-l-[3px] border-callout font-display italic text-base text-muted-foreground leading-relaxed">
             — {step.tip}
           </div>
         )}
@@ -149,7 +149,7 @@ export function CookingMode({ title, steps, prep, onExit }: CookingModeProps) {
         ) : (
           <button
             onClick={onExit}
-            className="flex-[2] py-3 font-sans text-sm font-semibold text-white bg-jade border border-[oklch(0.35_0.10_168)] rounded-xl shadow-[0_2px_0_oklch(0.35_0.10_168)] hover:opacity-90 transition-opacity cursor-pointer"
+            className="flex-[2] py-3 font-sans text-sm font-semibold text-white bg-jade border border-jade-deep rounded-xl shadow-[0_2px_0_var(--jade-deep)] hover:opacity-90 transition-opacity cursor-pointer"
           >
             Done — all finished!
           </button>

--- a/src/features/Recipe/ServingsStepper.tsx
+++ b/src/features/Recipe/ServingsStepper.tsx
@@ -24,7 +24,7 @@ export function ServingsStepper({
       >
         −
       </button>
-      <span className="min-w-11 text-center font-display font-semibold text-[15px] text-foreground tabular-nums">
+      <span className="min-w-11 text-center font-display font-semibold text-emphasis text-foreground tabular-nums">
         {servings}
       </span>
       <button


### PR DESCRIPTION
## Summary
Aligns the **Recipe / CookingMode** surface to the design system (#283) — raw type sizes and inline `oklch()` literals swapped for named scale + semantic-color tokens. Per the per-surface audit in `docs/design-system.md`.

- **CookingMode**: step counter → `text-micro`; step body → `text-xl` (was an arbitrary `1.25rem`); tip bar → `border-callout` (was an inline ochre `oklch(...)` literal duplicating the `StepTip` accent).
- **ServingsStepper**: servings readout → `text-emphasis`.
- **globals.css**: new `--jade-deep` token (light + dark) replacing the inline `oklch(0.35 0.10 168)` border + hard-shadow on the cooking-mode "Done" button — mirrors the existing `--primary-deep` / `--secondary-deep` underbite pattern.

The cooking-mode step body stays intentionally large (`text-xl`) — the across-the-kitchen reading register — using a Tailwind default rather than a one-off pixel value.

## Test plan
- `pnpm jest src/features/Recipe` — green (32/32).
- `pnpm eslint` — clean.
- Visual: enter cooking mode from a structured recipe; step counter, body, tip bar, Prev/Next, and the final jade "Done" button render correctly in light + dark; servings stepper readout unchanged in size.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)