### PR TITLE
style(auth): align sign-in dialog to design system

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -111,6 +111,7 @@ The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook)
 - **Per-surface alignment (#280–#284)**: each surface tweaked until it "belongs" — swap raw `text-[Npx]` for named scale tokens, raw `oklch(...)` for semantic tokens, and inline eyebrows for the `Eyebrow` atom.
   - `Conversations` (#280): header → `text-heading`, empty state → `font-display`.
   - `RecipeList` (#281): page header, cards, sidebar, and Add-recipe modal mapped to the scale; sidebar category labels now use the `Eyebrow` atom. New `--danger` / `--danger-border` / `--danger-tint` tokens (hue 27, light + dark) replace the modal's inline error-state `oklch(...)` literals.
+  - `Auth` / `SignInDialog` (#284): trigger 1px hard-shadow → `var(--border-soft)` token (was an inline `oklch(...)` literal); dialog title + description switched to `font-display` (serif brand voice) from the shadcn default sans. `AuthButton` was already clean.
 
 ## Next up
 

--- a/src/features/Auth/SignInDialog.tsx
+++ b/src/features/Auth/SignInDialog.tsx
@@ -28,14 +28,16 @@ export function SignInDialog() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <button className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-semibold text-foreground bg-card border border-border rounded-lg shadow-[0_1px_0_oklch(0.82_0.04_70)] hover:bg-background transition-colors cursor-pointer">
+        <button className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-semibold text-foreground bg-card border border-border rounded-lg shadow-[0_1px_0_var(--border-soft)] hover:bg-background transition-colors cursor-pointer">
           Sign in
         </button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Welcome to Ah Mah&rsquo;s kitchen</DialogTitle>
-          <DialogDescription>
+          <DialogTitle className="font-display tracking-tight">
+            Welcome to Ah Mah&rsquo;s kitchen
+          </DialogTitle>
+          <DialogDescription className="font-display italic">
             Your kitchen stays with you across devices.
           </DialogDescription>
         </DialogHeader>


### PR DESCRIPTION
## Summary
Aligns the **Auth** surface to the design system (#284) — the last of the per-surface alignment issues. Per the audit in `docs/design-system.md`.

- **SignInDialog**: trigger's 1px hard-shadow now uses the `--border-soft` token (was an inline `oklch(0.82 0.04 70)` literal — the same house "lift" the cooking-mode exit button already uses); dialog title + description switched to `font-display` (the serif brand voice) instead of shadcn's default sans, closing the voice gap on this surface.
- **AuthButton**: already on tokens + Tailwind defaults — no changes.

## Test plan
- `pnpm eslint src/features/Auth` — clean.
- Visual: the "Sign in" trigger keeps its paper lift; opening the dialog shows "Welcome to Ah Mah's kitchen" + subtitle in the serif voice, consistent with the rest of the app, in light + dark.

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)