### PR TITLE
chore(design): publish Claude Design catalog via /design-sync

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,67 @@
+# design-sync notes
+
+State and corrections for future syncs of this repo to claude.ai/design.
+Read this together with `config.json` before re-running the skill.
+
+Target project: **Ask Ah Mah Design System**
+`https://claude.ai/design/p/568a7eb2-48a6-432c-b9c3-5a07da4b2df1`
+
+## This repo is off the converter's standard envelope
+
+It's a **Next.js app**, not a packaged/published design system — no `dist/`,
+no Storybook, no built package. The converter's default discovery (synth-from-all-src,
+self-installed package) does not apply. The working path is:
+
+- **Synth entry via a barrel.** `ds-entry.ts` at the repo root (gitignored) re-exports
+  only the six shared recipe atoms from `@/features/shared/components/recipe`. It is passed
+  as `cfg.entry` so the converter's PKG_DIR walk finds the repo's real `package.json`
+  instead of looking for `node_modules/ask-ah-mah/package.json` (which doesn't exist).
+  Without it the converter crashes with `ENOENT … ask-ah-mah/package.json`.
+  `ds-entry.ts` is gitignored (it's a scratch synth artifact), so recreate it at the repo
+  root before re-syncing from a clean clone:
+
+  ```ts
+  export {
+    Eyebrow, SectionHeading, DottedList, StepTip, StepItem, StepList,
+  } from "@/features/shared/components/recipe";
+  ```
+- **Component set comes from `cfg.componentSrcMap`**, not from `export *`. Exporting all
+  app src would pull in server/Prisma/Next code that can't be bundled.
+- **CSS is compiled, not shipped.** The atoms are styled by Tailwind utilities; the repo
+  ships no static stylesheet. `cfg.buildCmd` runs `@tailwindcss/cli` against
+  `ds-tailwind-input.css` (which `@import`s `src/app/globals.css` + the atom/preview
+  sources via `@source`) to produce `cfg.cssEntry` →
+  `.design-sync/.cache/ds-compiled.css`. That file is **gitignored** (lives under `.cache/`),
+  so a fresh clone must re-run `buildCmd` before validating — it is not committed.
+
+## Converter deps
+
+Installed isolated under `.ds-sync/` (gitignored) with npm, NOT the app's pnpm:
+`esbuild ts-morph @types/react @tailwindcss/cli@4.2.4 playwright` (+ chromium).
+Re-run `node .ds-sync/package-build.mjs` / `resync.mjs` from there.
+
+## Known warnings (non-blocking — do not chase)
+
+- **`[TOKENS_MISSING]` — 7 `--radix-*` custom properties.** (`--radix-select-*`,
+  `--radix-dropdown-menu-*`, `--radix-popover-*`.) These are injected at runtime by
+  Radix primitives; the six atoms don't use Radix, so they are correctly absent from the
+  shipped stylesheets. Expected. No `cfg.tokensPkg`/`provider` needed.
+- **`[FONT_REMOTE]` — Inter / Fraunces / Nunito.** The bundle pulls these from Google Fonts
+  via an `@import` in `ds-tailwind-input.css` (the app uses `next/font/google`, which has no
+  static font files to copy). The remote host serves them at runtime. Expected.
+
+## Scope
+
+Six recipe atoms only: Eyebrow, SectionHeading, DottedList, StepTip, StepItem, StepList.
+All 16 preview cells graded `good` on the absolute rubric (no Storybook reference).
+Previews are hand-authored under `.design-sync/previews/*.tsx` from real recipe usage.
+
+## Re-sync risks
+
+- If `globals.css` token names change (e.g. the `--text-eyebrow/micro/dense/emphasis`
+  scale or `--ink-faint`/`--callout`/`--primary-deep`), recompile and re-verify — the
+  atoms reference them directly.
+- New atoms must be added to BOTH `ds-entry.ts` and `cfg.componentSrcMap`, plus a preview
+  under `.design-sync/previews/` and the `@source` glob already covers that dir.
+- `_ds_sync.json` is the anchor; an unchanged component is skipped on re-sync. If the
+  Tailwind compile output drifts, the styleSha changes and everything re-verifies — correct.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,20 @@
+{
+  "projectId": "568a7eb2-48a6-432c-b9c3-5a07da4b2df1",
+  "shape": "package",
+  "pkg": "ask-ah-mah",
+  "globalName": "AskAhMah",
+  "srcDir": "src",
+  "tsconfig": "tsconfig.json",
+  "entry": "ds-entry.ts",
+  "cssEntry": ".design-sync/.cache/ds-compiled.css",
+  "buildCmd": "node .ds-sync/node_modules/.bin/tailwindcss -i .design-sync/ds-tailwind-input.css -o .design-sync/.cache/ds-compiled.css",
+  "guidelinesGlob": ["docs/design-system.md"],
+  "componentSrcMap": {
+    "Eyebrow": "src/features/shared/components/recipe/Eyebrow.tsx",
+    "SectionHeading": "src/features/shared/components/recipe/SectionHeading.tsx",
+    "DottedList": "src/features/shared/components/recipe/DottedList.tsx",
+    "StepTip": "src/features/shared/components/recipe/StepTip.tsx",
+    "StepItem": "src/features/shared/components/recipe/StepItem.tsx",
+    "StepList": "src/features/shared/components/recipe/StepList.tsx"
+  }
+}

--- a/.design-sync/ds-tailwind-input.css
+++ b/.design-sync/ds-tailwind-input.css
@@ -1,0 +1,19 @@
+/* design-sync stylesheet input — compiled by @tailwindcss/cli into the
+   bundle's _ds_bundle.css. Reuses the app's own @theme + tokens from
+   globals.css; supplies the next/font families (Inter / Fraunces / Nunito)
+   that the running app injects, here loaded remotely from Google Fonts. */
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,700;1,9..144,400;1,9..144,600&family=Inter:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&display=swap");
+
+@import "../src/app/globals.css";
+
+/* The app sets these on <html> via next/font; define them statically so the
+   bundle renders in-brand outside Next. */
+:root {
+  --font-var-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-var-display: "Fraunces", ui-serif, Georgia, serif;
+  --font-var-logo: "Nunito", ui-sans-serif, system-ui, sans-serif;
+}
+
+/* Generate utilities for the atoms and their authored previews. */
+@source "../src/features/shared/components/recipe/*.tsx";
+@source "../.design-sync/previews/*.tsx";

--- a/.design-sync/previews/DottedList.tsx
+++ b/.design-sync/previews/DottedList.tsx
@@ -1,0 +1,20 @@
+import { DottedList } from "ask-ah-mah";
+
+export const Prep = () => (
+  <DottedList
+    items={[
+      "Soak the dried mushrooms in warm water for 20 minutes, then slice",
+      "Mince 3 cloves of garlic and a thumb of ginger",
+      "Pat the chicken dry so it browns instead of steaming",
+    ]}
+  />
+);
+
+export const Notes = () => (
+  <DottedList
+    items={[
+      "Leftovers keep 3 days in the fridge — the flavour deepens overnight",
+      "No oyster sauce? A spoon of dark soy plus a pinch of sugar works",
+    ]}
+  />
+);

--- a/.design-sync/previews/Eyebrow.tsx
+++ b/.design-sync/previews/Eyebrow.tsx
@@ -1,0 +1,13 @@
+import { Eyebrow } from "ask-ah-mah";
+
+export const Default = () => <Eyebrow>What to gather</Eyebrow>;
+
+export const Method = () => <Eyebrow>Method</Eyebrow>;
+
+export const Muted = () => (
+  <Eyebrow className="text-muted-foreground">Ah Mah’s notes</Eyebrow>
+);
+
+export const AsBlock = () => (
+  <Eyebrow className="block">Before you start</Eyebrow>
+);

--- a/.design-sync/previews/SectionHeading.tsx
+++ b/.design-sync/previews/SectionHeading.tsx
@@ -1,0 +1,7 @@
+import { SectionHeading } from "ask-ah-mah";
+
+export const Gather = () => <SectionHeading>What to gather</SectionHeading>;
+
+export const Method = () => <SectionHeading>Method</SectionHeading>;
+
+export const Notes = () => <SectionHeading>Ah Mah’s notes</SectionHeading>;

--- a/.design-sync/previews/StepItem.tsx
+++ b/.design-sync/previews/StepItem.tsx
@@ -1,0 +1,21 @@
+import { StepItem } from "ask-ah-mah";
+
+const bloom = {
+  title: "Bloom the aromatics",
+  body: "Heat 2 tbsp oil over medium. Add the garlic, ginger and the white parts of the spring onion. Fry until fragrant, about 30 seconds.",
+  tip: "Low and slow here — burnt garlic turns the whole dish bitter.",
+};
+
+const sear = {
+  title: "Sear the chicken",
+  body: "Turn the heat to high and lay the chicken in a single layer. Leave it undisturbed for 2 minutes so it colours before you toss.",
+};
+
+// Chat "letter" register — rotated terracotta ink-stamp badge.
+export const Stamp = () => <StepItem n={1} step={bloom} marker="stamp" />;
+
+// Cookbook "reference" register — quiet mono "1." in a fixed gutter.
+export const Quiet = () => <StepItem n={1} step={bloom} marker="quiet" />;
+
+// A step without an Ah Mah tip.
+export const NoTip = () => <StepItem n={2} step={sear} marker="stamp" />;

--- a/.design-sync/previews/StepList.tsx
+++ b/.design-sync/previews/StepList.tsx
@@ -1,0 +1,24 @@
+import { StepList } from "ask-ah-mah";
+
+const steps = [
+  {
+    title: "Bloom the aromatics",
+    body: "Heat 2 tbsp oil over medium. Fry the garlic, ginger and white spring onion until fragrant, about 30 seconds.",
+    tip: "Low and slow — burnt garlic turns the whole dish bitter.",
+  },
+  {
+    title: "Sear the chicken",
+    body: "Turn the heat to high and lay the chicken in a single layer. Leave it 2 minutes to colour, then toss for one more.",
+  },
+  {
+    title: "Bring it together",
+    body: "Splash in the soy and oyster sauce, add a ladle of stock, and simmer until the sauce clings to everything.",
+    tip: "Taste before you salt — the sauces already carry a lot.",
+  },
+];
+
+// Chat "letter" register.
+export const Letter = () => <StepList steps={steps} marker="stamp" />;
+
+// Cookbook "reference" register.
+export const Reference = () => <StepList steps={steps} marker="quiet" />;

--- a/.design-sync/previews/StepTip.tsx
+++ b/.design-sync/previews/StepTip.tsx
@@ -1,0 +1,15 @@
+import { StepTip } from "ask-ah-mah";
+
+export const Default = () => (
+  <StepTip>
+    Don’t rush the aromatics — low heat coaxes out the sweetness before the
+    garlic catches and turns bitter.
+  </StepTip>
+);
+
+export const Texture = () => (
+  <StepTip>
+    The cornflour slurry should just coat the back of a spoon. Too thin? Let it
+    bubble one more minute.
+  </StepTip>
+);

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,8 @@ temp/
 test-results/
 .agentindex
 .agentindexignore
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+ds-entry.ts

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -114,6 +114,7 @@ The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook)
   - `Inventory` (#282): page eyebrow → `Eyebrow` atom; title → `text-display`; bodies/empty states → `text-emphasis`; buttons + selection banner → `text-dense`; category counts + item quantities → `text-micro`; pantry item names → `text-emphasis`.
   - `Recipe` / `CookingMode` (#283): step counter → `text-micro`; step body → `text-xl`; tip bar → `border-callout`; servings stepper readout → `text-emphasis`. New `--jade-deep` token (light + dark) replaces the inline `oklch(0.35 0.10 168)` border + hard-shadow on the cooking-mode "Done" button.
   - `Auth` / `SignInDialog` (#284): trigger 1px hard-shadow → `var(--border-soft)` token (was an inline `oklch(...)` literal); dialog title + description switched to `font-display` (serif brand voice) from the shadcn default sans. `AuthButton` was already clean.
+- **Catalog published to Claude Design (#285)**: the six atoms + their tokens, fonts, and guidelines are synced to a claude.ai/design project ("Ask Ah Mah Design System") via `/design-sync`, so the design agent builds on-brand with the repo's real components. Sync inputs live under `.design-sync/` (`config.json`, `ds-tailwind-input.css`, `previews/`, `NOTES.md`) and a gitignored root `ds-entry.ts` barrel; CSS is compiled from `globals.css` via Tailwind CLI at sync time. This closes the design-system epic (#277–#285).
 
 ## Next up
 


### PR DESCRIPTION
## Summary

Closes the design-system epic (#277–#285) by publishing the shared recipe atoms to **claude.ai/design** so the design agent builds on-brand with the repo's real components.

- Synced the six atoms — `Eyebrow`, `SectionHeading`, `DottedList`, `StepTip`, `StepItem`, `StepList` — plus their tokens, fonts, and the `docs/design-system.md` guideline to the "Ask Ah Mah Design System" project.
- All 16 preview cells graded `good` on the absolute rubric (this app has no Storybook reference), render check 6/6 clean.
- Two non-blocking warnings accepted and documented: `[FONT_REMOTE]` (Google Fonts, since the app uses `next/font/google`) and `[TOKENS_MISSING]` for 7 runtime-injected `--radix-*` vars the atoms don't use.

### Committed (durable re-sync inputs, under `.design-sync/`)
- `config.json` — re-sync config: `projectId`, package shape, `componentSrcMap`, the Tailwind CLI `buildCmd`.
- `ds-tailwind-input.css` — Tailwind v4 input that `@import`s `globals.css` + atom/preview sources, compiled to the bundle CSS at sync time.
- `previews/*.tsx` — hand-authored preview cards built from real recipe usage.
- `NOTES.md` — off-script workarounds (synth barrel entry, compiled-not-shipped CSS) and the known-warning context.

### Not committed (gitignored scratch/cache)
`.ds-sync/` (converter deps), `ds-bundle/` (build output), `.design-sync/.cache/`, and the root `ds-entry.ts` synth barrel — `NOTES.md` records how to recreate `ds-entry.ts` for a re-sync.

## Test plan
- `node .ds-sync/package-validate.mjs ./ds-bundle` exits clean (6/6 render, 1 non-blocking warning category).
- Open https://claude.ai/design/p/568a7eb2-48a6-432c-b9c3-5a07da4b2df1 and confirm the six recipe cards render in-brand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured design system component documentation structure and preview variants for recipe components (Eyebrow, SectionHeading, DottedList, StepList, StepItem, StepTip).
  * Updated gitignore to exclude design system build artifacts.

* **Documentation**
  * Updated progress tracking to reflect design system organization completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->