### PR TITLE
style(recipe): align ingredient-row typography to named scale

### DIFF
--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -335,10 +335,10 @@ export function RecipeLetter({
                     isLastTwo && "border-none",
                   )}
                 >
-                  <span className="flex-[0_0_64px] font-mono text-xs font-semibold text-foreground text-right tabular-nums">
+                  <span className="flex-[0_0_64px] font-mono text-dense font-semibold text-foreground text-right tabular-nums">
                     {amountLabel ? <ScaledNum>{amountLabel}</ScaledNum> : ""}
                   </span>
-                  <span className="flex-1 font-display text-sm text-foreground leading-tight">
+                  <span className="flex-1 font-display text-emphasis text-foreground">
                     {ing.name}
                     {ing.note && (
                       <span className="text-muted-foreground italic text-xs">

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -273,7 +273,7 @@ function RecipeBody({
                     }`}
                   >
                     <span
-                      className={`basis-20 sm:basis-24 shrink-0 text-[13px] text-foreground text-right ${
+                      className={`basis-20 sm:basis-24 shrink-0 text-dense text-foreground text-right ${
                         scaled != null
                           ? "font-mono font-semibold tabular-nums"
                           : "font-display italic text-muted-foreground"
@@ -283,7 +283,7 @@ function RecipeBody({
                         ? `${formatAmount(scaled)}${ing.unit ? ` ${ing.unit}` : ""}`
                         : "to taste"}
                     </span>
-                    <span className="flex-1 font-display text-[15px] text-foreground leading-[1.4]">
+                    <span className="flex-1 font-display text-emphasis text-foreground">
                       {ing.name}
                     </span>
                   </li>
@@ -302,7 +302,7 @@ function RecipeBody({
                       className="flex items-baseline gap-3 py-2.5 border-b border-dashed border-border transition-colors line-through opacity-50"
                     >
                       <span
-                        className={`basis-20 sm:basis-24 shrink-0 text-[13px] text-foreground text-right ${
+                        className={`basis-20 sm:basis-24 shrink-0 text-dense text-foreground text-right ${
                           scaled != null
                             ? "font-mono font-semibold tabular-nums"
                             : "font-display italic text-muted-foreground"
@@ -312,7 +312,7 @@ function RecipeBody({
                           ? `${formatAmount(scaled)}${ing.unit ? ` ${ing.unit}` : ""}`
                           : "to taste"}
                       </span>
-                      <span className="flex-1 font-display text-[15px] text-foreground leading-[1.4]">
+                      <span className="flex-1 font-display text-emphasis text-foreground">
                         {ing.name}
                       </span>
                     </li>


### PR DESCRIPTION
## Summary

The two recipe surfaces rendered ingredient rows at slightly different sizes — a small drift left over from the design-system epic:

- **Chat** (`RecipeLetter`) used raw `text-sm` (14px) names and `text-xs` (12px) quantities.
- **Cookbook** (`RecipeDisplay`) used raw `text-[15px]` names and `text-[13px]` quantities.

Both now use the named scale tokens — `text-emphasis` (15px) and `text-dense` (13px) — so ingredient names and quantities match across chat and cookbook *and* follow the design-system scale instead of raw pixels (cookbook's deleted-ingredient rows too).

The two intentional **registers** are left untouched: stamp-vs-quiet step markers, and the chat card-grid vs cookbook plain-list ingredient layouts. Those are design intent, not drift.

## Test plan

- `npx jest RecipeLetter RecipeDisplay` → 35/35 pass.
- Open a recipe in chat and the same recipe in the cookbook; confirm ingredient name + quantity sizing now match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography styling for recipe ingredient displays, adjusting font sizing and emphasis for ingredient amounts and names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->