### PR TITLE
style(recipe-atoms): use named type scale instead of raw px sizes

### DIFF
--- a/src/features/shared/components/recipe/DottedList.tsx
+++ b/src/features/shared/components/recipe/DottedList.tsx
@@ -19,10 +19,10 @@ export function DottedList({
           key={i}
           className="flex gap-3 items-baseline py-2 border-b border-dashed border-border last:border-none"
         >
-          <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums shrink-0 w-5 text-right">
+          <span className="font-mono text-dense font-bold text-ink-faint tabular-nums shrink-0 w-5 text-right">
             ·
           </span>
-          <span className="flex-1 font-display text-[15px] text-foreground leading-[1.45]">
+          <span className="flex-1 font-display text-emphasis text-foreground leading-[1.45]">
             {item}
           </span>
         </li>

--- a/src/features/shared/components/recipe/SectionHeading.tsx
+++ b/src/features/shared/components/recipe/SectionHeading.tsx
@@ -14,7 +14,7 @@ export function SectionHeading({
   return (
     <h2
       className={cn(
-        "font-display font-semibold text-[24px] sm:text-[26px] text-foreground tracking-tight m-0",
+        "font-display font-semibold text-heading text-foreground tracking-tight m-0",
         className,
       )}
     >

--- a/src/features/shared/components/recipe/StepItem.tsx
+++ b/src/features/shared/components/recipe/StepItem.tsx
@@ -36,8 +36,8 @@ const REGISTER = {
   quiet: {
     row: "gap-4",
     content: "flex-1",
-    title: "text-[15px] mb-0.5",
-    body: "text-[15px] leading-[1.6]",
+    title: "text-emphasis mb-0.5",
+    body: "text-emphasis leading-[1.6]",
   },
 } as const;
 
@@ -59,7 +59,7 @@ export function StepItem<T extends ElementType = "div">({
           {n}
         </div>
       ) : (
-        <span className="font-mono text-[13px] font-bold text-ink-faint tabular-nums pt-0.5 shrink-0 w-5 text-right">
+        <span className="font-mono text-dense font-bold text-ink-faint tabular-nums pt-0.5 shrink-0 w-5 text-right">
           {n}.
         </span>
       )}


### PR DESCRIPTION
## Summary

Closes #299. Brings the shared recipe atoms into adherence with the published design-system type scale by replacing arbitrary `text-[Npx]` sizes with named tokens.

- **SectionHeading**: `text-[24px] sm:text-[26px]` → `text-heading` (22px)
- **StepItem** (`quiet` register): `title`/`body` `text-[15px]` → `text-emphasis`; quiet marker `text-[13px]` → `text-dense`
- **DottedList**: marker `text-[13px]` → `text-dense`; body `text-[15px]` → `text-emphasis`

Explicit `leading-[...]` is preserved where it intentionally diverges from the token line-height. The `stamp` register keeps `text-base`/`text-lg` (allowed Tailwind defaults).

## ⚠️ Deliberate visual change to flag

`SectionHeading` had no exact named-scale step at 24/26px. Rather than invent a step or leave a raw size, it consolidates onto the canonical `text-heading` (22px) per the design system. This is a small shrink **and** drops the `sm:` responsive bump. Intentional — calling it out for review.

## Test plan

- `eslint` clean on the three edited files
- No `text-[` raw sizes remain in the atoms
- Visually confirm cookbook section headings + step/dotted lists still read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)