### PR TITLE
chore(design-system): prune unused chart + orphan color tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,11 +17,6 @@
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -53,9 +48,7 @@
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
 
-  --color-tertiary: var(--tertiary);
   --color-jade: var(--jade);
-  --color-jade-foreground: var(--jade-foreground);
   --color-jade-deep: var(--jade-deep);
   --color-jade-tint: var(--jade-tint);
   --color-jade-border: var(--jade-border);
@@ -145,7 +138,6 @@
 
   /* Jade — decorative accent ink (chips, pills, dots) */
   --jade: oklch(0.5 0.095 168);
-  --jade-foreground: oklch(0.97 0.02 80);
   /* Deeper jade — hard-shadow underbite / border on jade surfaces (the cooking-mode "Done" button) */
   --jade-deep: oklch(0.35 0.10 168);
   /* Pale jade fill + soft jade edge — the "N/M in your pantry" success pill */
@@ -163,11 +155,6 @@
   --input: oklch(0.815 0.038 70);
   --ring: oklch(0.56 0.135 35);
 
-  --chart-1: oklch(0.56 0.135 35);
-  --chart-2: oklch(0.5 0.095 168);
-  --chart-3: oklch(0.7 0.13 75);
-  --chart-4: oklch(0.86 0.1 88);
-  --chart-5: oklch(0.56 0.21 25);
   --sidebar: oklch(0.975 0.022 80);
   --sidebar-foreground: oklch(0.265 0.04 48);
   --sidebar-primary: oklch(0.56 0.135 35);
@@ -176,8 +163,6 @@
   --sidebar-accent-foreground: oklch(0.265 0.04 48);
   --sidebar-border: oklch(0.815 0.038 70);
   --sidebar-ring: oklch(0.56 0.135 35);
-
-  --tertiary: oklch(0.7 0.13 75);
 }
 
 .dark {
@@ -201,7 +186,6 @@
   --muted-foreground: oklch(0.7 0.03 60);
   --ink-faint: oklch(0.55 0.025 55);
   --jade: oklch(0.6 0.1 168);
-  --jade-foreground: oklch(0.95 0.025 78);
   --jade-deep: oklch(0.42 0.1 168);
   --jade-tint: oklch(0.30 0.04 168);
   --jade-border: oklch(0.48 0.07 168);
@@ -219,11 +203,6 @@
   --border-soft: oklch(1 0 0 / 8%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.66 0.14 35);
-  --chart-1: oklch(0.66 0.14 35);
-  --chart-2: oklch(0.6 0.1 168);
-  --chart-3: oklch(0.75 0.12 78);
-  --chart-4: oklch(0.5 0.075 88);
-  --chart-5: oklch(0.66 0.18 25);
   --sidebar: oklch(0.28 0.03 50);
   --sidebar-foreground: oklch(0.95 0.025 78);
   --sidebar-primary: oklch(0.66 0.14 35);
@@ -232,8 +211,6 @@
   --sidebar-accent-foreground: oklch(0.95 0.025 78);
   --sidebar-border: oklch(1 0 0 / 12%);
   --sidebar-ring: oklch(0.66 0.14 35);
-
-  --tertiary: oklch(0.75 0.12 78);
 }
 
 @layer base {

--- a/src/features/shared/components/design-system/ColorTokens.tsx
+++ b/src/features/shared/components/design-system/ColorTokens.tsx
@@ -17,7 +17,6 @@ const GROUPS: Group[] = [
       { name: "primary-tint", token: "--color-primary-tint" },
       { name: "secondary", token: "--color-secondary" },
       { name: "secondary-deep", token: "--color-secondary-deep" },
-      { name: "tertiary", token: "--color-tertiary" },
       { name: "jade", token: "--color-jade" },
       { name: "jade-deep", token: "--color-jade-deep" },
     ],


### PR DESCRIPTION
## Summary

Removes color tokens that were never used anywhere in the app — shadcn `init` boilerplate plus two orphans. Surfaced by a usage audit (no Tailwind class, no `var()` reference).

| Removed | Why |
|---|---|
| `--chart-1..5` | shadcn chart palette; **no Chart component exists** |
| `--tertiary` | orphan semantic token, never referenced |
| `--jade-foreground` | jade pills are used, but their text-color pairing never is |

Dropped from `@theme inline`, `:root`, and `.dark`. Also removed the phantom `tertiary` swatch from the `ColorTokens` design-system specimen, so the **published catalog stops advertising a color the app doesn't use**.

## Kept deliberately

The `--sidebar-*` set (8 tokens) stays — a nav sidebar is plausible later and it's a cohesive group.

## Notes

- Fully reversible: `npx shadcn add chart` re-adds chart tokens automatically if ever needed.
- `ColorTokens` is a carded design-system component, so the **claude.ai/design catalog should be re-synced** (`/design-sync`) to drop the tertiary swatch there too. Not done here (heavy op) — flagging for a follow-up.

## Test plan

- `rg` confirms zero remaining references to the pruned tokens in `src/`.
- CSS braces balanced; `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)