### PR TITLE
fix(chat): collapse two competing suggestion sets in empty-chat hero

### DIFF
--- a/src/features/Chat/components/ChatEmptyState.tsx
+++ b/src/features/Chat/components/ChatEmptyState.tsx
@@ -4,8 +4,6 @@ import Image from "next/image";
 
 import { Stamp } from "@/features/shared/components/Stamp";
 
-import { SUGGESTIONS } from "../constants";
-
 // The three example openers, echoing the initial greeting bullets. Tapping one
 // sends it straight to Ah Mah as a quick start.
 const PROMPTS = [
@@ -13,9 +11,6 @@ const PROMPTS = [
   { label: "Your tools", example: "I have a wok" },
   { label: "Or just ask", example: "What can I make for dinner?" },
 ] as const;
-
-const chip =
-  "inline-flex items-center min-h-11 px-3.5 text-xs text-muted-foreground border border-border rounded-full hover:border-border-soft hover:text-foreground transition-colors cursor-pointer";
 
 interface ChatEmptyStateProps {
   onSend: (text: string) => void;
@@ -73,17 +68,13 @@ export function ChatEmptyState({ onSend, onCookWith }: ChatEmptyStateProps) {
           ))}
         </div>
 
-        {/* Quick-start chips */}
-        <div className="mt-6 flex flex-wrap justify-center gap-2">
-          <button onClick={onCookWith} className={chip}>
-            🥬 Cook with what I have →
-          </button>
-          {SUGGESTIONS.map((s) => (
-            <button key={s} onClick={() => onSend(s)} className={chip}>
-              {s}
-            </button>
-          ))}
-        </div>
+        {/* Secondary path — browse the pantry instead of typing an opener */}
+        <button
+          onClick={onCookWith}
+          className="mt-6 inline-flex min-h-11 items-center gap-1.5 text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline cursor-pointer"
+        >
+          🥬 Or pick from your pantry →
+        </button>
       </div>
     </div>
   );

--- a/src/features/Chat/constants.ts
+++ b/src/features/Chat/constants.ts
@@ -41,12 +41,6 @@ export const INITIAL_MESSAGE = {
   ],
 };
 
-export const SUGGESTIONS = [
-  "What can I cook tonight?",
-  "Just back from the market",
-  "Something quick, just for me",
-];
-
 export const LOADING_MESSAGES = [
   "Ah Mah is getting ready...",
   "Preparing your cooking assistant...",


### PR DESCRIPTION
## Summary
- The first-run chat hero showed **two** parallel suggestion systems — three opener cards *and* a row of four quick-start chips — that both just injected a message, reading as redundant ("two sets of suggestions").
- "Just back from the market" fired a vague line Ah Mah couldn't do anything useful with.
- Keep the three opener cards as the single suggestion set.
- Replace the chip row with one understated text link **"🥬 Or pick from your pantry →"** that still routes to the pantry selector via `onCookWith`, so it reads as a distinct *secondary path* rather than a fourth suggestion.
- Remove the now-dead `SUGGESTIONS` array from `constants.ts`.

## Test plan
- Open a fresh chat (Staging State / no messages) and confirm: three opener cards render, tapping one sends the example to Ah Mah.
- Confirm the single "Or pick from your pantry →" link appears below the cards and routes into the pantry selector.
- Confirm the old chips ("What can I cook tonight?", "Just back from the market", "Something quick, just for me") are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced quick-start suggestion chips with a "pick from your pantry" button in the chat empty state interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->