### PR TITLE
fix(styles): move markdown list defaults into @layer base

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -256,27 +256,33 @@
 ::-webkit-scrollbar-thumb:hover {
   background-color: var(--muted-foreground);
 }
-ol {
-  list-style-type: decimal;
-  padding-left: 1.5em;
-}
+/* Markdown list defaults (chat prose, legacy recipe markdown). Kept in
+   @layer base so Tailwind utilities (list-none, pl-0, list-decimal, …) can
+   override them on purpose-built components — unlayered rules here would beat
+   every utility class regardless of specificity. */
+@layer base {
+  ol {
+    list-style-type: decimal;
+    padding-left: 1.5em;
+  }
 
-ol li {
-  margin-left: 0em;
-  padding-left: 0.25em;
-}
+  ol li {
+    margin-left: 0em;
+    padding-left: 0.25em;
+  }
 
-ul {
-  list-style-type: disc;
-  padding-left: 1.5em;
-}
+  ul {
+    list-style-type: disc;
+    padding-left: 1.5em;
+  }
 
-ul li {
-  margin-left: 0em;
-}
+  ul li {
+    margin-left: 0em;
+  }
 
-ol li::marker {
-  letter-spacing: -0.1em;
+  ol li::marker {
+    letter-spacing: -0.1em;
+  }
 }
 
 blockquote {


### PR DESCRIPTION
## Summary
The global `ol`/`ul`/`li` markdown defaults in `globals.css` were **unlayered**, so they beat every Tailwind list utility (`list-none`, `pl-0`, `list-decimal`, …) regardless of specificity — in the CSS cascade, unlayered rules outrank all `@layer`s, and Tailwind utilities live in `@layer utilities`.

The practical effect: any component using a real `<ul>`/`<li>` silently got disc bullets + a 1.5em indent that **could not be removed via class names**. The Market Tips shortfall list hit exactly this (worked around there by switching to `<div>` rows).

This wraps the rules in `@layer base`, which:
- **keeps markdown bullets** — the base rule still wins over Tailwind's preflight list reset, since it's declared later in the same layer; and
- **lets purpose-built components opt out** with normal utilities.

## Test plan
Verified on a scratch page via computed styles:

| Element | `list-style-type` | `padding-left` |
|---|---|---|
| plain `<ul>` (markdown) | `disc` | 24px |
| plain `<ol>` | `decimal` | 24px |
| `<ul class="list-none pl-0">` | `none` | 0px ✅ (was `disc`/24px before) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)