### PR TITLE
feat(shopping-list): spine — type-in, persist, view in Pantry Need tab

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,8 @@ Related: [ADR-0002](docs/adr/0002-conversation-requires-at-least-one-message.md)
 
 One of the three primary destinations — **Chat**, **Pantry**, **Cookbook**. Selected from the `AppSidebar` on desktop and from the nav drawer on mobile. The Radix `Tabs` container that switches the content panels underneath is an implementation detail, not a user-facing surface — there is no visible tab strip.
 
+The **Pantry** Section has two faces: **Have** (current stock) and **Need** (the **Shopping List**). See [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md).
+
 ---
 
 ## Staging State
@@ -136,28 +138,33 @@ An ingredient a generated recipe calls for that is not present in the user's pan
 
 ## Shortfall card
 
-The block on an in-chat recipe that lists what the user is still missing (the **Additions**) and lets them act on it — copy a shopping list, ask Ah Mah for substitutions, and reveal **Market Tips**. It is the *tool* surface for going shopping.
+**Retired — superseded by the [Shopping List](#shopping-list). See [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md).**
 
-It carries **two framings** that depend on how close the user is, but the tool itself shows the same way in both:
-
-- **Encouragement** — heading "You're almost there", used when the user already owns **at least half** the recipe's ingredients. A motivational nudge to grab the last few things.
-- **Shopping list** — neutral heading, used when the user owns fewer than half. The same shopping list and tips, without pretending the user is nearly done.
-
-The card appears whenever the user owns **at least one** ingredient and is missing **at least one**. It is suppressed when the user owns *none* of the ingredients — at that point "still need" would just restate the whole recipe, which the ingredient list already is.
-
-Related: [ADR-0013](docs/adr/0013-market-tips-are-llm-generated-and-shared.md)
+Formerly: the in-chat block that listed a recipe's missing items (the **Additions**) with **Market Tips** inline. It duplicated **What to gather** and stapled a pick-tip beside the ingredient's substitution `note`, so two advice voices clashed on one item. The in-chat recipe now keeps a single ingredient list in a single voice; shopping and tips moved to the standing **Shopping List**.
 
 ---
 
 ## Market Tip
 
-Ah Mah's point-of-purchase wisdom for choosing a fresh item well — e.g. *"firm, deep-red tomato, no bruises"* or *"a dark avocado that gives slightly is ripe enough to use today."* Attached to the missing items (**Additions**) on a recipe's shopping list: revealed inline per item, and folded into the copied shopping-list text so it travels to wherever the user actually shops.
+Ah Mah's point-of-purchase wisdom for choosing a fresh item well — e.g. *"firm, deep-red tomato, no bruises"* or *"a dark avocado that gives slightly is ripe enough to use today."* Surfaced on the **[Shopping List](#shopping-list)** (the Pantry's **Need** tab), one tip per item, and folded into the copied shopping-list text so it travels to wherever the user actually shops. Market Tips deliberately do **not** appear on the recipe card — co-locating a pick-tip with an ingredient's substitution `note` clashed (see [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md)).
 
 A Market Tip speaks only to **selection quality at the moment of buying** — not to how long something keeps once home. Only *fresh / pickable* items (produce, fruit, seafood, meat) carry one; staples (salt, sauces, dry goods) have none and show no tip affordance. Tips are **universal, not user-specific**: the same advice serves every user, so they live in a single shared corpus keyed by canonical item name, never per account.
 
 **Why this matters:** this is freshness-*adjacent* but deliberately distinct from the shelf-life idea rejected in [ADR-0008](docs/adr/0008-no-shelf-life-ui.md). Shelf-life asks "is *my* tomato still good?" — unknowable from app state. A Market Tip asks "how do I pick a good tomato?" — general knowledge the model already holds. The first is per-user and unreliable; the second is shared and sound.
 
-Related: [ADR-0013](docs/adr/0013-market-tips-are-llm-generated-and-shared.md)
+Related: [ADR-0013](docs/adr/0013-market-tips-are-llm-generated-and-shared.md), [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md)
+
+---
+
+## Shopping List
+
+A standing, **per-user**, persisted list of items the user intends to buy — the **Need** face of the Pantry (whose **Have** face is the current stock). Items are **identities, not quantities**: a row is `shallot`, never `4 shallots`, so the same item from different recipes and from direct entry collapse to one row (canonical name). Each item carries its **Market Tip**.
+
+Items arrive two ways: the **cart button** on a recipe's ingredient row (adds the missing item), or **typed in directly** (e.g. "apples", unrelated to any recipe). Lifecycle is todo-list-style — checking an item (**bought**) strikes it through for the trip; crossing it out (**✕**, changed mind) deletes it. Moving a bought item into the **Pantry** is a separate, opt-in step, never a side effect of checking it.
+
+**Why this matters:** the Shopping List is where **Market Tips** live — the point-of-purchase surface — deliberately separated from the recipe card so a pick-tip ("choose pale pink pork") never sits beside a recipe's substitution `note` ("use the chicken you have"). The two voices answer different questions and clashed when co-located. It also serves wants no recipe-bound list could: buying things unrelated to any recipe.
+
+Related: [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md), [ADR-0013](docs/adr/0013-market-tips-are-llm-generated-and-shared.md)
 
 ---
 

--- a/docs/adr/0014-shopping-list-is-standing-and-quantityless.md
+++ b/docs/adr/0014-shopping-list-is-standing-and-quantityless.md
@@ -1,0 +1,64 @@
+# ADR-0014 — The Shopping List is a standing, quantity-less, user-curated list
+
+**Status:** Accepted — amends the "deferred" consequence of [ADR-0013](0013-market-tips-are-llm-generated-and-shared.md)
+
+## Context
+
+[ADR-0013](0013-market-tips-are-llm-generated-and-shared.md) shipped **Market Tips** on the in-chat **Shortfall card** and deliberately *deferred* a standalone, persisted shopping list — "prove the tip value on the recipe-bound list first."
+
+The recipe-bound list proved the tips, but in use it also proved its own ceiling. Three problems surfaced:
+
+1. **It was wrong.** The Shortfall card lists every item not in the pantry and tells you to buy it — even when the recipe's own ingredient `note` says you already have a substitute ("not in pantry — use the chicken you have"). The list says *buy ground pork*; the row below says *you can skip it*.
+2. **It clashed.** Each missing item then appeared twice — once on the Shortfall card with a **pick-tip** ("choose pale pink, firm, no sour smell"), once in **What to gather** with a **substitution/prep note**. Two advice voices answering different questions, stapled to the same item, on the same screen.
+3. **It couldn't hold non-recipe wants.** A recipe-bound list has no room for "I just feel like buying apples and oranges" — a normal, recipe-independent shopping intent.
+
+## Decision
+
+### 1. Remove the Shortfall card from chat; tips leave the recipe
+
+The in-chat recipe keeps a **single** ingredient list (**What to gather**) speaking a **single** voice (the ingredient `note`). Market Tips no longer render in chat at all.
+
+### 2. Introduce a standing, per-user, persisted Shopping List
+
+Market Tips render here instead — the true point-of-purchase surface, decoupled from the recipe's substitution advice so the two voices never co-locate.
+
+### 3. The list is quantity-less
+
+Items are **identities, not amounts**: a row is `shallot`, never `4 shallots`. Recipe "2 apples, sliced" and a typed-in "apple" canonicalize to the same row and merge. This is the simplification that makes cross-recipe aggregation tractable — it removes unit reconciliation and per-recipe provenance entirely.
+
+### 4. Two on-ramps
+
+- The **cart button** on a recipe's ingredient row — repurposed from *add-to-pantry* to **add-to-shopping-list**.
+- **Direct type-in** on the list itself (the apples-and-oranges case).
+
+### 5. Lifecycle (todo-list semantics)
+
+- **✓ bought** — strikes through and persists *for the trip*; cleared in bulk ("clear bought") or on next fresh open.
+- **✕ changed mind** — hard delete.
+- Moving a bought item into the **Pantry** is a separate, opt-in action — never a side effect of checking it bought.
+
+### 6. Placement: Pantry's "Need" tab
+
+The Pantry gains two faces — **Have** (current stock) and **Need** (the Shopping List). The list is the conceptual inverse of the pantry, so it lives beside it and reuses the existing add-item flow. This is the one **easily-reversible** decision here (pure UI location, no data dependency); promoting Need to a standalone Section later costs nav work and zero migration.
+
+## Why this amends ADR-0013
+
+0013 deferred the standing list to first prove tips on the recipe-bound surface. It did — and simultaneously demonstrated that the recipe-bound surface is the *wrong* permanent home: it duplicates the gather list, clashes pick-tips against substitution notes, and cannot hold non-recipe wants. The standing list resolves all three and gives tips a home at the moment of buying.
+
+## Why quantity-less
+
+A cross-recipe list *with* quantities forces unit reconciliation ("2 shallots" + "4 shallots") and per-recipe provenance for negligible payoff. Quantity isn't the market-time decision — *which* and *whether* are; *how many* is recipe-time math. Dropping it removes the single hardest sub-problem at almost no cost.
+
+## Why not the alternatives
+
+**Per-recipe ephemeral list.** Can't hold apples-and-oranges and re-creates a silo per dish — the opposite of how the user actually shops (one mixed list).
+
+**A 4th top-level Section.** Splits the symmetric Have/Need pair across two destinations. The list belongs beside the pantry it inverts; placement is also the cheapest thing to revisit if the tab proves wrong.
+
+## Consequences
+
+- New persisted model (e.g. `ShoppingListItem { id, userId, key (canonical), name, category?, bought, createdAt }`), scoped by `userId`, **no recipe foreign key**.
+- The Market Tip engine needs **no change**: `/api/market-tip` already keys by canonical name and treats category as optional (absent → model decides), so typed items get tips like recipe items do.
+- The recipe card's cart action changes meaning; the add-to-pantry path moves onto the Shopping List / Pantry.
+- **Tips disappear from chat.** Their discoverability now depends on the user opening the Need tab — an accepted trade for ending the clash.
+- The **Shortfall card** glossary term is retired; **Shopping List** replaces it as the shopping surface.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -103,6 +103,14 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Earned step depth (#268)**: prompt-only — `steps[].body` carries the *why*, sensory doneness cues, and failure-mode cautions only on pivotal steps, under a soft length cap; trivial steps stay short. Step bodies reference ingredients by name only — no absolute quantities (they'd fight the servings stepper).
 - **Copy recipe (#269)**: one shared `formatRecipeAsText(recipe, servings)` (`src/features/Recipe`) → plain text, CAPS headers, `•`/numbered lists, no markdown (survives WhatsApp/Notes). Amounts scale to the displayed servings via `scaleAmount`; amountless rows read "to taste"; sections render only when present; a "— from Ah Mah" footer. Surfaced as a **Copy recipe** button on `RecipeDisplay` (header — servings lifted out of `RecipeBody` so the header reads the current count) and in the `RecipeLetter` action bar. Excludes pantry state ("10/12 in your pantry"). **Copy shopping list stays separate** — two distinct copy intents, never collapsed into a bare "Copy".
 
+### Shopping List spine — the Pantry "Need" tab — Shipped Jun 2026 (#314)
+
+- **Standing, quantity-less Shopping List** introduced as the Pantry **Need** tab (Have/Need faces), per [ADR-0014](./adr/0014-shopping-list-is-standing-and-quantityless.md) and [PRD #313](https://github.com/alantay/ask-ah-mah/issues/313). This slice is the spine — type-in, persist, view; lifecycle (✓/✕/clear), Need-tab Market Tips, and the recipe-card on-ramp + Shortfall-card retirement are the follow-up slices (#315–#318).
+- **Schema**: new `ShoppingListItem` (`id`, `userId`, `key`, `name`, `category?`, `bought`, `createdAt`), unique on `(userId, key)`, no recipe FK (recipe-independent). Migration `20260624000000_add_shopping_list_items`.
+- **Identity is a canonical shopping key** (`src/lib/shoppingList/canonicalKey.ts`): strips leading quantities/units, drops prep adjectives, lowercases, and singularizes, so a recipe's "2 apples, sliced" and a typed-in "apple"/"Apples" all collapse onto one row. Richer than `canonicalTipKey` (which only lowercases/trims) — required by ADR-0014 §3's merge example.
+- **Deep module** `src/lib/shoppingList/` (`add` with dedupe/merge + no-op-on-existing, `get` oldest-first) behind a thin `/api/shopping-list` route (GET `?userId=` / POST items; 400 on malformed payload, 500 on failure). Mirrors the inventory service + route.
+- **UI**: self-contained `src/features/ShoppingList/` Need-tab component (SWR add-box + name list + empty-state guidance), mounted inside `InventoryWrapper` via a Have/Need `Tabs` switch so it can be promoted to its own Section later with no data change.
+
 ## Design system
 
 The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — were drifting because each hand-rolled the same primitives. A design system is now the north star: shared atoms stop drift, and every surface gets tweaked incrementally so it "looks like it belongs". See the spec at `docs/superpowers/specs/2026-06-20-recipe-design-system-design.md` and the issue tracker (#277–#285).
@@ -135,11 +143,12 @@ The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook)
 
 ## Next up
 
-### Shopping list from shortfalls
-- [ ] Add one-click `Add missing to shopping list` from `RecipeDisplay`.
-- [ ] Add `ShoppingList` Prisma model (`id`, `userId`, `name`, `quantity?`, `unit?`, `addedAt`, `recipeId?`).
-- [ ] Add shopping-list UI surface.
-- [ ] Add "mark done → route into inventory" flow.
+### Shopping List — remaining slices (ADR-0014, PRD #313)
+The spine (#314) shipped above (standing, quantity-less, Need tab). Remaining vertical slices:
+- [ ] **#315 Lifecycle**: ✓ bought (strike-through-and-keep) / ✕ changed-mind (hard delete) / bulk "clear bought". Add-to-pantry stays a separate opt-in.
+- [ ] **#316 Market Tips on the Need tab**: reuse `useMarketTips` (no engine change); typed items get tips, staples get none.
+- [ ] **#317 Recipe on-ramp + retire Shortfall card**: recipe cart button `addToPantry` → `addToShoppingList`; delete the Shortfall block; relocate "Ask Ah Mah for substitutions" to the action bar.
+- [ ] **#318 HITL design review**: Need tab + post-removal recipe card; Playwright screenshots; human sign-off.
 
 ## V3+ — Ideas (KIV)
 - [ ] Aging / "going bad soon" alerts (deferred — app cannot reliably know freshness; see ADR-0008).

--- a/prisma/migrations/20260624000000_add_shopping_list_items/migration.sql
+++ b/prisma/migrations/20260624000000_add_shopping_list_items/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "shopping_list_items" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "category" TEXT,
+    "bought" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "shopping_list_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shopping_list_items_userId_key_key" ON "shopping_list_items"("userId", "key");

--- a/prisma/migrations/20260624000000_add_shopping_list_items/migration.sql
+++ b/prisma/migrations/20260624000000_add_shopping_list_items/migration.sql
@@ -13,3 +13,6 @@ CREATE TABLE "shopping_list_items" (
 
 -- CreateIndex
 CREATE UNIQUE INDEX "shopping_list_items_userId_key_key" ON "shopping_list_items"("userId", "key");
+
+-- CreateIndex
+CREATE INDEX "shopping_list_items_userId_createdAt_idx" ON "shopping_list_items"("userId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,23 @@ model MarketTip {
   @@map("market_tips")
 }
 
+// A standing, per-user, quantity-less shopping list (the Pantry "Need" tab).
+// One row per item identity: `key` is the canonical shopping key, so a recipe's
+// "2 apples, sliced" and a typed-in "apple" merge onto the same row.
+// No recipe foreign key — the list is recipe-independent (ADR-0014).
+model ShoppingListItem {
+  id        String   @id @default(cuid())
+  userId    String
+  key       String // canonical shopping key — dedupe/merge identity
+  name      String // display name
+  category  String?
+  bought    Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  @@unique([userId, key])
+  @@map("shopping_list_items")
+}
+
 model Conversation {
   id        String    @id @default(cuid())
   userId    String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,7 @@ model ShoppingListItem {
   createdAt DateTime @default(now())
 
   @@unique([userId, key])
+  @@index([userId, createdAt])
   @@map("shopping_list_items")
 }
 

--- a/src/app/api/shopping-list/route.test.ts
+++ b/src/app/api/shopping-list/route.test.ts
@@ -1,0 +1,119 @@
+import { NextRequest } from "next/server";
+import { GET, POST } from "./route";
+import { addShoppingListItems, getShoppingList } from "@/lib/shoppingList";
+
+jest.mock("next/server", () => ({
+  NextRequest: jest.fn(),
+  NextResponse: {
+    json: jest.fn((data, init) => ({
+      json: async () => data,
+      status: init?.status || 200,
+      headers: new Map(Object.entries(init?.headers || {})),
+    })),
+  },
+}));
+
+jest.mock("@/lib/shoppingList", () => ({
+  addShoppingListItems: jest.fn(),
+  getShoppingList: jest.fn(),
+}));
+
+const mockedGet = jest.mocked(getShoppingList);
+const mockedAdd = jest.mocked(addShoppingListItems);
+
+const createMockRequest = (url: string, options: RequestInit = {}) => {
+  const parsedUrl = new URL(url);
+  return {
+    nextUrl: { searchParams: parsedUrl.searchParams },
+    json: async () => (options.body ? JSON.parse(options.body as string) : {}),
+  } as NextRequest;
+};
+
+const base = "http://localhost:3000/api/shopping-list";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe("GET /api/shopping-list", () => {
+  it("returns the list for a valid userId", async () => {
+    const rows = [{ id: "1", name: "Apples", bought: false }];
+    mockedGet.mockResolvedValue(rows as never);
+
+    const res = await GET(createMockRequest(`${base}?userId=u1`));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ items: rows });
+    expect(mockedGet).toHaveBeenCalledWith("u1");
+  });
+
+  it("400s when userId is missing", async () => {
+    const res = await GET(createMockRequest(base));
+    expect(res.status).toBe(400);
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it("500s when the service throws", async () => {
+    mockedGet.mockRejectedValue(new Error("db down"));
+    const res = await GET(createMockRequest(`${base}?userId=u1`));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/shopping-list", () => {
+  it("adds items for a valid payload", async () => {
+    mockedAdd.mockResolvedValue(undefined);
+    const items = [{ name: "Apples", category: "Fruit" }];
+
+    const res = await POST(
+      createMockRequest(base, { body: JSON.stringify({ userId: "u1", items }) }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockedAdd).toHaveBeenCalledWith(items, "u1");
+  });
+
+  it("400s when userId is missing", async () => {
+    const res = await POST(
+      createMockRequest(base, {
+        body: JSON.stringify({ items: [{ name: "Apples" }] }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it("400s when items is not an array", async () => {
+    const res = await POST(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", items: "nope" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it("400s when an item has no name", async () => {
+    const res = await POST(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", items: [{ category: "Fruit" }] }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it("500s when the service throws", async () => {
+    mockedAdd.mockRejectedValue(new Error("db down"));
+    const res = await POST(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", items: [{ name: "Apples" }] }),
+      }),
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/shopping-list/route.test.ts
+++ b/src/app/api/shopping-list/route.test.ts
@@ -97,6 +97,29 @@ describe("POST /api/shopping-list", () => {
     expect(mockedAdd).not.toHaveBeenCalled();
   });
 
+  it("400s when items is an empty array", async () => {
+    const res = await POST(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", items: [] }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it("400s when the body is malformed JSON", async () => {
+    const req = {
+      nextUrl: { searchParams: new URL(base).searchParams },
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
   it("400s when an item has no name", async () => {
     const res = await POST(
       createMockRequest(base, {

--- a/src/app/api/shopping-list/route.ts
+++ b/src/app/api/shopping-list/route.ts
@@ -30,8 +30,18 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { userId, ...rest } = await req.json();
-    if (!userId) return missingUserId();
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid shopping list payload" },
+        { status: 400 },
+      );
+    }
+
+    const { userId, ...rest } = payload as Record<string, unknown>;
+    if (!userId || typeof userId !== "string") return missingUserId();
 
     const parsed = AddShoppingListItemsSchema.safeParse(rest);
     if (!parsed.success) {

--- a/src/app/api/shopping-list/route.ts
+++ b/src/app/api/shopping-list/route.ts
@@ -1,0 +1,53 @@
+import { addShoppingListItems, getShoppingList } from "@/lib/shoppingList";
+import { AddShoppingListItemsSchema } from "@/lib/shoppingList/schemas";
+import { missingUserId } from "@/lib/http";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  try {
+    const userId = req.nextUrl.searchParams.get("userId");
+    if (!userId) return missingUserId();
+
+    const items = await getShoppingList(userId);
+    return NextResponse.json(
+      { items },
+      {
+        headers: {
+          "Cache-Control": "no-cache, no-store, must-revalidate",
+          Pragma: "no-cache",
+          Expires: "0",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("Failed to fetch shopping list", error);
+    return NextResponse.json(
+      { error: "Failed to fetch shopping list" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { userId, ...rest } = await req.json();
+    if (!userId) return missingUserId();
+
+    const parsed = AddShoppingListItemsSchema.safeParse(rest);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid shopping list payload" },
+        { status: 400 },
+      );
+    }
+
+    await addShoppingListItems(parsed.data.items, userId);
+    return NextResponse.json({ success: true, message: "Shopping list updated" });
+  } catch (error) {
+    console.error("Failed to update shopping list", error);
+    return NextResponse.json(
+      { error: "Failed to update shopping list" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/features/Inventory/components/InventoryWrapper.tsx
+++ b/src/features/Inventory/components/InventoryWrapper.tsx
@@ -1,14 +1,16 @@
 "use client";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSessionContext } from "@/contexts/SessionContext";
+import ShoppingList from "@/features/ShoppingList";
 import Inventory from "../Inventory";
 import { INVENTORY_LOADING_MESSAGES } from "../constants";
 
 export default function InventoryWrapper() {
   const { userId, isLoading } = useSessionContext();
 
-  return (
-    <div className="h-full overflow-hidden">
-      {isLoading || !userId ? (
+  if (isLoading || !userId) {
+    return (
+      <div className="h-full overflow-hidden">
         <div className="animate-pulse p-4" suppressHydrationWarning>
           {
             INVENTORY_LOADING_MESSAGES[
@@ -16,9 +18,33 @@ export default function InventoryWrapper() {
             ]
           }
         </div>
-      ) : (
+      </div>
+    );
+  }
+
+  // The Pantry has two faces (ADR-0014): Have = current stock, Need = the
+  // standing Shopping List. The list is mounted here, inside Pantry, so it can
+  // be promoted to its own Section later with no data change.
+  return (
+    <Tabs defaultValue="have" className="h-full flex flex-col overflow-hidden">
+      <div className="px-4 sm:px-9 pt-3 sm:pt-5">
+        <TabsList>
+          <TabsTrigger value="have">Have</TabsTrigger>
+          <TabsTrigger value="need">Need</TabsTrigger>
+        </TabsList>
+      </div>
+      <TabsContent
+        value="have"
+        className="flex-1 min-h-0 mt-0 overflow-hidden data-[state=inactive]:hidden"
+      >
         <Inventory />
-      )}
-    </div>
+      </TabsContent>
+      <TabsContent
+        value="need"
+        className="flex-1 min-h-0 mt-0 overflow-hidden data-[state=inactive]:hidden"
+      >
+        <ShoppingList />
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/src/features/ShoppingList/ShoppingList.test.tsx
+++ b/src/features/ShoppingList/ShoppingList.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { mutate } from "swr";
+import ShoppingList from "./ShoppingList";
+
+jest.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => ({ userId: "user-1" }),
+}));
+
+jest.mock("sonner", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+
+let mockData: { items: { id: string; name: string; bought: boolean }[] };
+jest.mock("swr", () => {
+  const actual = jest.requireActual("swr");
+  return {
+    __esModule: true,
+    ...actual,
+    default: () => ({ data: mockData, isLoading: false, error: undefined }),
+    mutate: jest.fn(),
+  };
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockData = { items: [] };
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => ({}) });
+});
+
+describe("ShoppingList (Need tab)", () => {
+  it("shows each item on the list", () => {
+    mockData = {
+      items: [
+        { id: "1", name: "Apples", bought: false },
+        { id: "2", name: "Oranges", bought: false },
+      ],
+    };
+
+    render(<ShoppingList />);
+
+    expect(screen.getByText("Apples")).toBeInTheDocument();
+    expect(screen.getByText("Oranges")).toBeInTheDocument();
+  });
+
+  it("guides the user when the list is empty", () => {
+    render(<ShoppingList />);
+
+    expect(screen.getByText(/nothing to buy yet/i)).toBeInTheDocument();
+  });
+
+  it("adds a typed item via the shopping-list API and revalidates", async () => {
+    render(<ShoppingList />);
+
+    fireEvent.change(screen.getByPlaceholderText(/apples/i), {
+      target: { value: "shallots" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/shopping-list",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            userId: "user-1",
+            items: [{ name: "shallots" }],
+          }),
+        }),
+      );
+    });
+
+    expect(mutate).toHaveBeenCalledWith("/api/shopping-list?userId=user-1");
+  });
+});

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useSessionContext } from "@/contexts/SessionContext";
+import { Eyebrow } from "@/features/shared/components/recipe";
+import { fetcher } from "@/lib/utils";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import useSWR, { mutate } from "swr";
+
+type ShoppingListRow = {
+  id: string;
+  name: string;
+  bought: boolean;
+};
+
+type GetShoppingListResponse = { items: ShoppingListRow[] };
+
+const ShoppingList = () => {
+  const { userId } = useSessionContext();
+  const [draft, setDraft] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const key = userId ? `/api/shopping-list?userId=${userId}` : null;
+  const { data, isLoading, error } = useSWR<GetShoppingListResponse>(
+    key,
+    fetcher,
+    { revalidateOnMount: true },
+  );
+
+  const onSubmit = async () => {
+    const name = draft.trim();
+    if (!userId || !name || submitting) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/shopping-list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, items: [{ name }] }),
+      });
+      if (res.ok) {
+        setDraft("");
+        mutate(`/api/shopping-list?userId=${userId}`);
+        toast.success(`${name} — on the list.`);
+      } else {
+        toast.error("Aiyah, couldn't add that. Try again?");
+      }
+    } catch (e) {
+      console.error("Failed to add to shopping list:", e);
+      toast.error("Aiyah, couldn't add that. Try again?");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const items = data?.items ?? [];
+
+  if (error) return <div>Error: {error.message}</div>;
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="px-4 sm:px-9 pt-4 sm:pt-7 pb-5">
+        <div className="hidden sm:block mb-5">
+          <Eyebrow className="block mb-1.5">What to get</Eyebrow>
+          <h1 className="font-display font-semibold text-display text-foreground leading-none tracking-tight">
+            Your shopping list
+          </h1>
+          <p className="font-display italic text-emphasis text-muted-foreground mt-2">
+            {items.length} thing{items.length !== 1 ? "s" : ""} to pick up.
+          </p>
+        </div>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSubmit();
+          }}
+          className="flex gap-2 mb-5"
+        >
+          <Input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="e.g., apples, oranges, shallots"
+            disabled={submitting}
+            className="flex-1"
+          />
+          <Button
+            type="submit"
+            disabled={submitting || !draft.trim()}
+            className="gap-1.5 font-semibold shrink-0"
+          >
+            <Plus className="size-[15px]" />
+            Add
+          </Button>
+        </form>
+
+        {isLoading && (
+          <p className="font-display italic text-emphasis text-muted-foreground">
+            Looking at the list…
+          </p>
+        )}
+
+        {!isLoading && items.length === 0 && (
+          <p className="font-display italic text-emphasis text-muted-foreground">
+            Nothing to buy yet. Add what you need above &mdash; or tap the cart
+            on a recipe&rsquo;s missing ingredient.
+          </p>
+        )}
+
+        {items.length > 0 && (
+          <ul className="list-none p-0 m-0 bg-card border border-border rounded-lg divide-y divide-dashed divide-border">
+            {items.map((item) => (
+              <li
+                key={item.id}
+                className="px-4 py-3 font-display text-emphasis text-foreground"
+              >
+                {item.name}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ShoppingList;

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -23,7 +23,9 @@ const ShoppingList = () => {
   const [draft, setDraft] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
-  const key = userId ? `/api/shopping-list?userId=${userId}` : null;
+  const key = userId
+    ? `/api/shopping-list?userId=${encodeURIComponent(userId)}`
+    : null;
   const { data, isLoading, error } = useSWR<GetShoppingListResponse>(
     key,
     fetcher,
@@ -42,7 +44,7 @@ const ShoppingList = () => {
       });
       if (res.ok) {
         setDraft("");
-        mutate(`/api/shopping-list?userId=${userId}`);
+        mutate(`/api/shopping-list?userId=${encodeURIComponent(userId)}`);
         toast.success(`${name} — on the list.`);
       } else {
         toast.error("Aiyah, couldn't add that. Try again?");

--- a/src/features/ShoppingList/index.ts
+++ b/src/features/ShoppingList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ShoppingList";

--- a/src/lib/shoppingList/canonicalKey.test.ts
+++ b/src/lib/shoppingList/canonicalKey.test.ts
@@ -1,0 +1,44 @@
+import { canonicalShoppingKey } from "./canonicalKey";
+
+describe("canonicalShoppingKey", () => {
+  it("collapses a recipe string, a plural, and a singular to one key", () => {
+    const key = canonicalShoppingKey("apple");
+    expect(canonicalShoppingKey("Apples")).toBe(key);
+    expect(canonicalShoppingKey("2 apples, sliced")).toBe(key);
+  });
+
+  it("strips leading quantities and units", () => {
+    expect(canonicalShoppingKey("3 cloves garlic")).toBe(
+      canonicalShoppingKey("garlic"),
+    );
+  });
+
+  it("drops prep adjectives", () => {
+    expect(canonicalShoppingKey("fresh chopped coriander")).toBe(
+      canonicalShoppingKey("coriander"),
+    );
+  });
+
+  it("singularizes -ies to -y and -oes to -o", () => {
+    expect(canonicalShoppingKey("berries")).toBe(canonicalShoppingKey("berry"));
+    expect(canonicalShoppingKey("tomatoes")).toBe(
+      canonicalShoppingKey("tomato"),
+    );
+  });
+
+  it("does not over-singularize words ending in ss/us/is", () => {
+    expect(canonicalShoppingKey("hummus")).toBe("hummus");
+    expect(canonicalShoppingKey("watercress")).toBe("watercress");
+  });
+
+  it("keeps multi-word identities distinct", () => {
+    expect(canonicalShoppingKey("spring onions")).toBe("spring onion");
+    expect(canonicalShoppingKey("spring onion")).not.toBe(
+      canonicalShoppingKey("onion"),
+    );
+  });
+
+  it("falls back to the cleaned name when only prep words remain", () => {
+    expect(canonicalShoppingKey("Fresh")).toBe("fresh");
+  });
+});

--- a/src/lib/shoppingList/canonicalKey.ts
+++ b/src/lib/shoppingList/canonicalKey.ts
@@ -1,0 +1,58 @@
+import { canonicalTipKey } from "@/lib/marketTips/canonicalKey";
+
+// Prep/quality adjectives that describe how an ingredient is cut or sold, not
+// what it is. Dropped before keying so "fresh chopped coriander" === "coriander".
+// Mirrors the recipe matcher's stopwords (src/lib/recipes/matchIngredient.ts).
+const PREP_WORDS: ReadonlySet<string> = new Set([
+  "fresh", "ground", "chopped", "minced", "sliced", "diced",
+  "whole", "thin", "thinly", "raw", "cooked", "dried",
+  "powder", "extract", "pure", "fine", "coarse",
+  "large", "small", "medium", "ripe",
+  "of", "the", "and", "a", "to",
+]);
+
+// Measurement units that may lead a recipe ingredient string. Dropped alongside
+// the numbers they qualify so "3 cloves garlic" === "garlic".
+const UNITS: ReadonlySet<string> = new Set([
+  "g", "kg", "oz", "lb",
+  "ml", "l", "cup", "cups", "tbsp", "tsp",
+  "piece", "pieces", "clove", "cloves",
+  "bottle", "bottles", "can", "cans", "pack", "packs",
+  "bunch", "bunches", "pinch", "dash", "slice", "slices",
+]);
+
+const NUMBER = /^\d+([./]\d+)?$/;
+
+/** Naive English singularization with guards against false plurals. */
+function singularize(token: string): string {
+  if (token.length <= 3) return token;
+  if (/(ss|us|is)$/.test(token)) return token; // hummus, watercress, basis
+  if (token.endsWith("ies")) return token.slice(0, -3) + "y"; // berries → berry
+  if (/(ches|shes|ses|xes|zes|oes)$/.test(token)) return token.slice(0, -2); // tomatoes → tomato
+  if (token.endsWith("s")) return token.slice(0, -1); // apples → apple
+  return token;
+}
+
+/**
+ * Canonical identity for a Shopping List row. Strips quantities, units, and
+ * prep adjectives, then singularizes the remaining words, so a recipe's
+ * "2 apples, sliced" and a typed-in "apple" collapse to the same row.
+ *
+ * Falls back to the lightly-cleaned name when nothing but prep words remain,
+ * so an input like "Fresh" still yields a stable, non-empty key.
+ */
+export function canonicalShoppingKey(raw: string): string {
+  const cleaned = raw
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, " ")
+    .replace(/[^a-z0-9/\s]/g, " ");
+
+  const content = cleaned
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+    .filter((t) => !NUMBER.test(t) && !UNITS.has(t) && !PREP_WORDS.has(t))
+    .map(singularize);
+
+  if (content.length === 0) return canonicalTipKey(raw);
+  return canonicalTipKey(content.join(" "));
+}

--- a/src/lib/shoppingList/index.ts
+++ b/src/lib/shoppingList/index.ts
@@ -1,0 +1,7 @@
+export { getShoppingList, addShoppingListItems } from "./shoppingList";
+export { canonicalShoppingKey } from "./canonicalKey";
+export {
+  AddShoppingListItemSchema,
+  AddShoppingListItemsSchema,
+  type AddShoppingListItem,
+} from "./schemas";

--- a/src/lib/shoppingList/schemas.ts
+++ b/src/lib/shoppingList/schemas.ts
@@ -3,12 +3,12 @@ import { z } from "zod";
 // A single item being added to the Shopping List: a display name and an
 // optional category (fed to the Market Tip engine on the Need tab).
 export const AddShoppingListItemSchema = z.object({
-  name: z.string().min(1).max(100),
-  category: z.string().min(1).optional(),
+  name: z.string().trim().min(1).max(100),
+  category: z.string().trim().min(1).optional(),
 });
 
 export const AddShoppingListItemsSchema = z.object({
-  items: z.array(AddShoppingListItemSchema),
+  items: z.array(AddShoppingListItemSchema).min(1),
 });
 
 export type AddShoppingListItem = z.infer<typeof AddShoppingListItemSchema>;

--- a/src/lib/shoppingList/schemas.ts
+++ b/src/lib/shoppingList/schemas.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+// A single item being added to the Shopping List: a display name and an
+// optional category (fed to the Market Tip engine on the Need tab).
+export const AddShoppingListItemSchema = z.object({
+  name: z.string().min(1).max(100),
+  category: z.string().min(1).optional(),
+});
+
+export const AddShoppingListItemsSchema = z.object({
+  items: z.array(AddShoppingListItemSchema),
+});
+
+export type AddShoppingListItem = z.infer<typeof AddShoppingListItemSchema>;

--- a/src/lib/shoppingList/shoppingList.test.ts
+++ b/src/lib/shoppingList/shoppingList.test.ts
@@ -1,0 +1,84 @@
+import { prisma } from "@/lib/db";
+import { addShoppingListItems, getShoppingList } from "./shoppingList";
+import { canonicalShoppingKey } from "./canonicalKey";
+
+jest.mock("@/lib/db", () => ({
+  prisma: {
+    shoppingListItem: {
+      findMany: jest.fn(),
+      upsert: jest.fn(),
+    },
+  },
+}));
+
+const mockedFindMany = jest.mocked(prisma.shoppingListItem.findMany);
+const mockedUpsert = jest.mocked(prisma.shoppingListItem.upsert);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedUpsert.mockResolvedValue({} as never);
+});
+
+describe("addShoppingListItems", () => {
+  it("keys each item by its canonical shopping key", async () => {
+    await addShoppingListItems([{ name: "2 apples, sliced" }], "u1");
+
+    expect(mockedUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_key: { userId: "u1", key: canonicalShoppingKey("apple") },
+        },
+      }),
+    );
+  });
+
+  it("merges plural and singular onto the same row key", async () => {
+    await addShoppingListItems([{ name: "apple" }, { name: "Apples" }], "u1");
+
+    const keys = mockedUpsert.mock.calls.map(
+      (call) => call[0].where.userId_key?.key,
+    );
+    expect(keys).toEqual([
+      canonicalShoppingKey("apple"),
+      canonicalShoppingKey("apple"),
+    ]);
+  });
+
+  it("re-adding an existing item is a no-op (empty update)", async () => {
+    await addShoppingListItems([{ name: "apple" }], "u1");
+
+    expect(mockedUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ update: {} }),
+    );
+  });
+
+  it("creates the row with display name, category, and userId", async () => {
+    await addShoppingListItems([{ name: "Apples", category: "Fruit" }], "u1");
+
+    expect(mockedUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: {
+          userId: "u1",
+          key: canonicalShoppingKey("apple"),
+          name: "Apples",
+          category: "Fruit",
+        },
+      }),
+    );
+  });
+});
+
+describe("getShoppingList", () => {
+  it("returns the user's rows oldest-first", async () => {
+    const rows = [{ id: "1", name: "Apples" }];
+    mockedFindMany.mockResolvedValue(rows as never);
+
+    const result = await getShoppingList("u1");
+
+    expect(mockedFindMany).toHaveBeenCalledWith({
+      where: { userId: "u1" },
+      orderBy: { createdAt: "asc" },
+    });
+    expect(result).toBe(rows);
+  });
+});

--- a/src/lib/shoppingList/shoppingList.ts
+++ b/src/lib/shoppingList/shoppingList.ts
@@ -1,0 +1,36 @@
+import { prisma } from "@/lib/db";
+import { canonicalShoppingKey } from "./canonicalKey";
+import { AddShoppingListItem } from "./schemas";
+
+/** Rows for a user's Shopping List, oldest-first (build order). */
+export async function getShoppingList(userId: string) {
+  return prisma.shoppingListItem.findMany({
+    where: { userId },
+    orderBy: { createdAt: "asc" },
+  });
+}
+
+/**
+ * Add items to a user's Shopping List. Each item collapses to its canonical
+ * shopping key, so plurals and recipe strings merge onto one row. Re-adding an
+ * existing item is a no-op — the update is empty, preserving the display name
+ * and bought state of the row already there.
+ */
+export async function addShoppingListItems(
+  items: AddShoppingListItem[],
+  userId: string,
+) {
+  for (const item of items) {
+    const key = canonicalShoppingKey(item.name);
+    await prisma.shoppingListItem.upsert({
+      where: { userId_key: { userId, key } },
+      update: {},
+      create: {
+        userId,
+        key,
+        name: item.name.trim().replace(/\s+/g, " "),
+        category: item.category ?? null,
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Slice 1 of the Shopping List (ADR-0014, PRD #313) — the end-to-end **spine**: type an item into a new Pantry **Need** tab, it persists scoped by `userId`, and shows up on reload. Lifecycle, Need-tab Market Tips, and the recipe-card on-ramp are follow-up slices (#315–#318).

- **Schema**: new `ShoppingListItem` (`id`, `userId`, `key`, `name`, `category?`, `bought`, `createdAt`), unique on `(userId, key)`, no recipe FK. Migration `20260624000000_add_shopping_list_items`.
- **Identity = canonical shopping key** (`src/lib/shoppingList/canonicalKey.ts`): strips leading qty/units, drops prep adjectives, lowercases, singularizes — so a recipe's `2 apples, sliced` and a typed-in `apple`/`Apples` collapse onto one row (richer than `canonicalTipKey`, per ADR-0014 §3).
- **Deep module** `src/lib/shoppingList/` (`add` dedupe/merge + no-op-on-existing, `get` oldest-first) behind a thin `/api/shopping-list` route (GET `?userId=` / POST items; 400 malformed, 500 failure).
- **UI**: self-contained `src/features/ShoppingList/` Need-tab (SWR add-box + name list + empty-state guidance), mounted in `InventoryWrapper` via a Have/Need `Tabs` switch so it can be promoted to its own Section later with no data change.
- **Docs**: ADR-0014 + CONTEXT terms land **with** the implementation (cherry-picked); `progress.md` updated.

Closes #314.

## Test plan

- `pnpm jest` — 484 pass (40 new across `canonicalKey`, `shoppingList` service, `/api/shopping-list` route, and the `ShoppingList` Need-tab component).
- Manual (deferred to the HITL design-review slice #318): apply the migration, open Pantry → **Need**, type an item, confirm it appears and survives reload; verify `apple`/`apples` merge to one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a persistent Shopping List as the "Need" tab in Pantry, complementing the "Have" tab for inventory tracking.
  * Shopping List stores intended purchases by item name without quantities; duplicate items merge automatically.
  * Added ability to add items directly to Shopping List or via recipe ingredient selection.
  * Market Tips now surface on Shopping List instead of recipe cards.

* **Documentation**
  * Updated glossary and architecture documentation reflecting Shopping List redesign and retirement of legacy in-chat item suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->