### PR TITLE
feat(shopping-list): lifecycle — bought / remove / clear bought (#315)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -151,7 +151,6 @@ The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook)
 
 ### Shopping List — remaining slices (ADR-0014, PRD #313)
 The spine (#314) and lifecycle (#315) shipped above. Remaining vertical slices:
-- [x] **#315 Lifecycle**: ✓ bought (strike-through-and-keep) / ✕ changed-mind (hard delete) / bulk "clear bought". Add-to-pantry stays a separate opt-in.
 - [ ] **#316 Market Tips on the Need tab**: reuse `useMarketTips` (no engine change); typed items get tips, staples get none.
 - [ ] **#317 Recipe on-ramp + retire Shortfall card**: recipe cart button `addToPantry` → `addToShoppingList`; delete the Shortfall block; relocate "Ask Ah Mah for substitutions" to the action bar.
 - [ ] **#318 HITL design review**: Need tab + post-removal recipe card; Playwright screenshots; human sign-off.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -111,6 +111,12 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Deep module** `src/lib/shoppingList/` (`add` with dedupe/merge + no-op-on-existing, `get` oldest-first) behind a thin `/api/shopping-list` route (GET `?userId=` / POST items; 400 on malformed payload, 500 on failure). Mirrors the inventory service + route.
 - **UI**: self-contained `src/features/ShoppingList/` Need-tab component (SWR add-box + name list + empty-state guidance), mounted inside `InventoryWrapper` via a Have/Need `Tabs` switch so it can be promoted to its own Section later with no data change.
 
+### Shopping List lifecycle — ✓ / ✕ / clear bought — Shipped Jun 2026 (#315)
+
+- **Three lifecycle actions** on each Need-tab row, per ADR-0014: **✓ bought** (toggle — strike-through-and-keep, never removed), **✕ changed-mind** (hard delete), and a bulk **Clear bought** button that appears only while at least one row is bought.
+- **Service** (`src/lib/shoppingList/`): `setBought` / `removeShoppingListItem` / `clearBoughtItems`, all `userId`-scoped via `updateMany`/`deleteMany` so a row can only be touched by its owner. **Route** grows `PATCH` (`{id, bought}` → setBought) and `DELETE` (`{id}` → remove, or `{clearBought:true}` → clear), both 400 on a missing `userId` or an absent target.
+- **Bought is not add-to-pantry** — checking a row only flips its `bought` flag; moving an item into the pantry stays a separate, explicit opt-in (no inventory write on the bought path).
+
 ## Design system
 
 The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — were drifting because each hand-rolled the same primitives. A design system is now the north star: shared atoms stop drift, and every surface gets tweaked incrementally so it "looks like it belongs". See the spec at `docs/superpowers/specs/2026-06-20-recipe-design-system-design.md` and the issue tracker (#277–#285).
@@ -144,8 +150,8 @@ The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook)
 ## Next up
 
 ### Shopping List — remaining slices (ADR-0014, PRD #313)
-The spine (#314) shipped above (standing, quantity-less, Need tab). Remaining vertical slices:
-- [ ] **#315 Lifecycle**: ✓ bought (strike-through-and-keep) / ✕ changed-mind (hard delete) / bulk "clear bought". Add-to-pantry stays a separate opt-in.
+The spine (#314) and lifecycle (#315) shipped above. Remaining vertical slices:
+- [x] **#315 Lifecycle**: ✓ bought (strike-through-and-keep) / ✕ changed-mind (hard delete) / bulk "clear bought". Add-to-pantry stays a separate opt-in.
 - [ ] **#316 Market Tips on the Need tab**: reuse `useMarketTips` (no engine change); typed items get tips, staples get none.
 - [ ] **#317 Recipe on-ramp + retire Shortfall card**: recipe cart button `addToPantry` → `addToShoppingList`; delete the Shortfall block; relocate "Ask Ah Mah for substitutions" to the action bar.
 - [ ] **#318 HITL design review**: Need tab + post-removal recipe card; Playwright screenshots; human sign-off.

--- a/src/app/api/shopping-list/route.test.ts
+++ b/src/app/api/shopping-list/route.test.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from "next/server";
-import { GET, POST } from "./route";
-import { addShoppingListItems, getShoppingList } from "@/lib/shoppingList";
+import { DELETE, GET, PATCH, POST } from "./route";
+import {
+  addShoppingListItems,
+  clearBoughtItems,
+  getShoppingList,
+  removeShoppingListItem,
+  setBought,
+} from "@/lib/shoppingList";
 
 jest.mock("next/server", () => ({
   NextRequest: jest.fn(),
@@ -16,10 +22,16 @@ jest.mock("next/server", () => ({
 jest.mock("@/lib/shoppingList", () => ({
   addShoppingListItems: jest.fn(),
   getShoppingList: jest.fn(),
+  setBought: jest.fn(),
+  removeShoppingListItem: jest.fn(),
+  clearBoughtItems: jest.fn(),
 }));
 
 const mockedGet = jest.mocked(getShoppingList);
 const mockedAdd = jest.mocked(addShoppingListItems);
+const mockedSetBought = jest.mocked(setBought);
+const mockedRemove = jest.mocked(removeShoppingListItem);
+const mockedClearBought = jest.mocked(clearBoughtItems);
 
 const createMockRequest = (url: string, options: RequestInit = {}) => {
   const parsedUrl = new URL(url);
@@ -138,5 +150,87 @@ describe("POST /api/shopping-list", () => {
       }),
     );
     expect(res.status).toBe(500);
+  });
+});
+
+describe("PATCH /api/shopping-list", () => {
+  it("sets an item bought for a valid payload", async () => {
+    mockedSetBought.mockResolvedValue(undefined);
+
+    const res = await PATCH(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", id: "row-1", bought: true }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockedSetBought).toHaveBeenCalledWith("u1", "row-1", true);
+  });
+
+  it("400s when userId is missing", async () => {
+    const res = await PATCH(
+      createMockRequest(base, {
+        body: JSON.stringify({ id: "row-1", bought: true }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedSetBought).not.toHaveBeenCalled();
+  });
+
+  it("400s when id is missing or bought is not a boolean", async () => {
+    const res = await PATCH(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", bought: "yes" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedSetBought).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/shopping-list", () => {
+  it("removes one item when given an id", async () => {
+    mockedRemove.mockResolvedValue(undefined);
+
+    const res = await DELETE(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", id: "row-1" }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockedRemove).toHaveBeenCalledWith("u1", "row-1");
+    expect(mockedClearBought).not.toHaveBeenCalled();
+  });
+
+  it("clears bought items when clearBought is true", async () => {
+    mockedClearBought.mockResolvedValue(undefined);
+
+    const res = await DELETE(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", clearBought: true }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockedClearBought).toHaveBeenCalledWith("u1");
+    expect(mockedRemove).not.toHaveBeenCalled();
+  });
+
+  it("400s when userId is missing", async () => {
+    const res = await DELETE(
+      createMockRequest(base, { body: JSON.stringify({ id: "row-1" }) }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedRemove).not.toHaveBeenCalled();
+  });
+
+  it("400s when neither id nor clearBought is provided", async () => {
+    const res = await DELETE(
+      createMockRequest(base, { body: JSON.stringify({ userId: "u1" }) }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedRemove).not.toHaveBeenCalled();
+    expect(mockedClearBought).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/shopping-list/route.test.ts
+++ b/src/app/api/shopping-list/route.test.ts
@@ -186,6 +186,29 @@ describe("PATCH /api/shopping-list", () => {
     expect(res.status).toBe(400);
     expect(mockedSetBought).not.toHaveBeenCalled();
   });
+
+  it("400s when the body is malformed JSON", async () => {
+    const req = {
+      nextUrl: { searchParams: new URL(base).searchParams },
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    } as unknown as NextRequest;
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    expect(mockedSetBought).not.toHaveBeenCalled();
+  });
+
+  it("500s when the service throws", async () => {
+    mockedSetBought.mockRejectedValue(new Error("db down"));
+    const res = await PATCH(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", id: "row-1", bought: true }),
+      }),
+    );
+    expect(res.status).toBe(500);
+  });
 });
 
 describe("DELETE /api/shopping-list", () => {
@@ -232,5 +255,29 @@ describe("DELETE /api/shopping-list", () => {
     expect(res.status).toBe(400);
     expect(mockedRemove).not.toHaveBeenCalled();
     expect(mockedClearBought).not.toHaveBeenCalled();
+  });
+
+  it("400s when the body is malformed JSON", async () => {
+    const req = {
+      nextUrl: { searchParams: new URL(base).searchParams },
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    } as unknown as NextRequest;
+
+    const res = await DELETE(req);
+    expect(res.status).toBe(400);
+    expect(mockedRemove).not.toHaveBeenCalled();
+    expect(mockedClearBought).not.toHaveBeenCalled();
+  });
+
+  it("500s when the service throws", async () => {
+    mockedRemove.mockRejectedValue(new Error("db down"));
+    const res = await DELETE(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "u1", id: "row-1" }),
+      }),
+    );
+    expect(res.status).toBe(500);
   });
 });

--- a/src/app/api/shopping-list/route.ts
+++ b/src/app/api/shopping-list/route.ts
@@ -1,7 +1,25 @@
-import { addShoppingListItems, getShoppingList } from "@/lib/shoppingList";
+import {
+  addShoppingListItems,
+  clearBoughtItems,
+  getShoppingList,
+  removeShoppingListItem,
+  setBought,
+} from "@/lib/shoppingList";
 import { AddShoppingListItemsSchema } from "@/lib/shoppingList/schemas";
 import { missingUserId } from "@/lib/http";
 import { NextRequest, NextResponse } from "next/server";
+
+async function readJson(req: NextRequest): Promise<Record<string, unknown> | null> {
+  try {
+    return (await req.json()) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
 
 export async function GET(req: NextRequest) {
   try {
@@ -30,28 +48,64 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    let payload: unknown;
-    try {
-      payload = await req.json();
-    } catch {
-      return NextResponse.json(
-        { error: "Invalid shopping list payload" },
-        { status: 400 },
-      );
-    }
+    const payload = await readJson(req);
+    if (!payload) return badRequest("Invalid shopping list payload");
 
-    const { userId, ...rest } = payload as Record<string, unknown>;
+    const { userId, ...rest } = payload;
     if (!userId || typeof userId !== "string") return missingUserId();
 
     const parsed = AddShoppingListItemsSchema.safeParse(rest);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: "Invalid shopping list payload" },
-        { status: 400 },
-      );
-    }
+    if (!parsed.success) return badRequest("Invalid shopping list payload");
 
     await addShoppingListItems(parsed.data.items, userId);
+    return NextResponse.json({ success: true, message: "Shopping list updated" });
+  } catch (error) {
+    console.error("Failed to update shopping list", error);
+    return NextResponse.json(
+      { error: "Failed to update shopping list" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  try {
+    const payload = await readJson(req);
+    if (!payload) return badRequest("Invalid shopping list payload");
+
+    const { userId, id, bought } = payload;
+    if (!userId || typeof userId !== "string") return missingUserId();
+    if (typeof id !== "string" || typeof bought !== "boolean") {
+      return badRequest("id (string) and bought (boolean) are required");
+    }
+
+    await setBought(userId, id, bought);
+    return NextResponse.json({ success: true, message: "Shopping list updated" });
+  } catch (error) {
+    console.error("Failed to update shopping list", error);
+    return NextResponse.json(
+      { error: "Failed to update shopping list" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const payload = await readJson(req);
+    if (!payload) return badRequest("Invalid shopping list payload");
+
+    const { userId, id, clearBought } = payload;
+    if (!userId || typeof userId !== "string") return missingUserId();
+
+    if (typeof id === "string") {
+      await removeShoppingListItem(userId, id);
+    } else if (clearBought === true) {
+      await clearBoughtItems(userId);
+    } else {
+      return badRequest("Provide an item id or clearBought: true");
+    }
+
     return NextResponse.json({ success: true, message: "Shopping list updated" });
   } catch (error) {
     console.error("Failed to update shopping list", error);

--- a/src/app/api/shopping-list/route.ts
+++ b/src/app/api/shopping-list/route.ts
@@ -68,6 +68,14 @@ export async function POST(req: NextRequest) {
   }
 }
 
+/**
+ * Toggle a Need-tab row's bought flag.
+ *
+ * Body: `{ userId: string, id: string, bought: boolean }`. Returns
+ * `{ success: true, message }` on success. 400s on malformed JSON, a missing
+ * `userId`, a non-string `id`, or a non-boolean `bought`; 500s if the service
+ * throws. Flips the flag only — never adds the item to the pantry.
+ */
 export async function PATCH(req: NextRequest) {
   try {
     const payload = await readJson(req);
@@ -90,6 +98,15 @@ export async function PATCH(req: NextRequest) {
   }
 }
 
+/**
+ * Remove from the Need tab — one row, or all bought rows.
+ *
+ * Body: `{ userId: string, id: string }` deletes a single row;
+ * `{ userId: string, clearBought: true }` bulk-deletes the user's bought rows.
+ * Returns `{ success: true, message }` on success. 400s on malformed JSON, a
+ * missing `userId`, or when neither `id` nor `clearBought: true` is given;
+ * 500s if the service throws.
+ */
 export async function DELETE(req: NextRequest) {
   try {
     const payload = await readJson(req);

--- a/src/features/ShoppingList/ShoppingList.test.tsx
+++ b/src/features/ShoppingList/ShoppingList.test.tsx
@@ -71,4 +71,101 @@ describe("ShoppingList (Need tab)", () => {
 
     expect(mutate).toHaveBeenCalledWith("/api/shopping-list?userId=user-1");
   });
+
+  it("marks an item bought via PATCH when its checkbox is toggled", async () => {
+    mockData = { items: [{ id: "row-1", name: "Apples", bought: false }] };
+
+    render(<ShoppingList />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /apples/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/shopping-list",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ userId: "user-1", id: "row-1", bought: true }),
+        }),
+      );
+    });
+
+    expect(mutate).toHaveBeenCalledWith("/api/shopping-list?userId=user-1");
+  });
+
+  it("un-marks a bought item via PATCH when toggled back", async () => {
+    mockData = { items: [{ id: "row-1", name: "Apples", bought: true }] };
+
+    render(<ShoppingList />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /apples/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/shopping-list",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({
+            userId: "user-1",
+            id: "row-1",
+            bought: false,
+          }),
+        }),
+      );
+    });
+  });
+
+  it("removes an item via DELETE when its remove control is clicked", async () => {
+    mockData = { items: [{ id: "row-1", name: "Apples", bought: false }] };
+
+    render(<ShoppingList />);
+
+    fireEvent.click(screen.getByRole("button", { name: /remove apples/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/shopping-list",
+        expect.objectContaining({
+          method: "DELETE",
+          body: JSON.stringify({ userId: "user-1", id: "row-1" }),
+        }),
+      );
+    });
+
+    expect(mutate).toHaveBeenCalledWith("/api/shopping-list?userId=user-1");
+  });
+
+  it("clears bought items via DELETE when 'clear bought' is clicked", async () => {
+    mockData = {
+      items: [
+        { id: "row-1", name: "Apples", bought: true },
+        { id: "row-2", name: "Oranges", bought: false },
+      ],
+    };
+
+    render(<ShoppingList />);
+
+    fireEvent.click(screen.getByRole("button", { name: /clear bought/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/shopping-list",
+        expect.objectContaining({
+          method: "DELETE",
+          body: JSON.stringify({ userId: "user-1", clearBought: true }),
+        }),
+      );
+    });
+
+    expect(mutate).toHaveBeenCalledWith("/api/shopping-list?userId=user-1");
+  });
+
+  it("does not offer 'clear bought' when nothing is bought", () => {
+    mockData = { items: [{ id: "row-1", name: "Apples", bought: false }] };
+
+    render(<ShoppingList />);
+
+    expect(
+      screen.queryByRole("button", { name: /clear bought/i }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -4,8 +4,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { Eyebrow } from "@/features/shared/components/recipe";
-import { fetcher } from "@/lib/utils";
-import { Plus } from "lucide-react";
+import { cn, fetcher } from "@/lib/utils";
+import { Check, Plus, X } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
@@ -57,7 +57,44 @@ const ShoppingList = () => {
     }
   };
 
+  const revalidate = () => {
+    if (userId) {
+      mutate(`/api/shopping-list?userId=${encodeURIComponent(userId)}`);
+    }
+  };
+
+  const mutateList = async (
+    method: "PATCH" | "DELETE",
+    body: Record<string, unknown>,
+  ) => {
+    if (!userId) return;
+    try {
+      const res = await fetch("/api/shopping-list", {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, ...body }),
+      });
+      if (res.ok) {
+        revalidate();
+      } else {
+        toast.error("Aiyah, that didn't work. Try again?");
+      }
+    } catch (e) {
+      console.error("Failed to update shopping list:", e);
+      toast.error("Aiyah, that didn't work. Try again?");
+    }
+  };
+
+  const toggleBought = (item: ShoppingListRow) =>
+    mutateList("PATCH", { id: item.id, bought: !item.bought });
+
+  const removeItem = (item: ShoppingListRow) =>
+    mutateList("DELETE", { id: item.id });
+
+  const clearBought = () => mutateList("DELETE", { clearBought: true });
+
   const items = data?.items ?? [];
+  const hasBought = items.some((item) => item.bought);
 
   if (error) return <div>Error: {error.message}</div>;
 
@@ -116,12 +153,57 @@ const ShoppingList = () => {
             {items.map((item) => (
               <li
                 key={item.id}
-                className="px-4 py-3 font-display text-emphasis text-foreground"
+                className="flex items-center gap-3 px-4 py-3 font-display text-emphasis"
               >
-                {item.name}
+                <button
+                  type="button"
+                  role="checkbox"
+                  aria-checked={item.bought}
+                  aria-label={item.name}
+                  onClick={() => toggleBought(item)}
+                  className={cn(
+                    "flex size-5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                    item.bought
+                      ? "bg-primary border-primary text-primary-foreground"
+                      : "border-border text-transparent hover:border-primary",
+                  )}
+                >
+                  <Check className="size-3" strokeWidth={3} />
+                </button>
+                <span
+                  className={cn(
+                    "flex-1",
+                    item.bought
+                      ? "line-through text-muted-foreground"
+                      : "text-foreground",
+                  )}
+                >
+                  {item.name}
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Remove ${item.name}`}
+                  onClick={() => removeItem(item)}
+                  className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <X className="size-4" />
+                </button>
               </li>
             ))}
           </ul>
+        )}
+
+        {hasBought && (
+          <div className="mt-4 flex justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={clearBought}
+              className="font-display text-muted-foreground hover:text-foreground"
+            >
+              Clear bought
+            </Button>
+          </div>
         )}
       </div>
     </div>

--- a/src/lib/shoppingList/index.ts
+++ b/src/lib/shoppingList/index.ts
@@ -1,4 +1,10 @@
-export { getShoppingList, addShoppingListItems } from "./shoppingList";
+export {
+  getShoppingList,
+  addShoppingListItems,
+  setBought,
+  removeShoppingListItem,
+  clearBoughtItems,
+} from "./shoppingList";
 export { canonicalShoppingKey } from "./canonicalKey";
 export {
   AddShoppingListItemSchema,

--- a/src/lib/shoppingList/shoppingList.test.ts
+++ b/src/lib/shoppingList/shoppingList.test.ts
@@ -1,5 +1,11 @@
 import { prisma } from "@/lib/db";
-import { addShoppingListItems, getShoppingList } from "./shoppingList";
+import {
+  addShoppingListItems,
+  clearBoughtItems,
+  getShoppingList,
+  removeShoppingListItem,
+  setBought,
+} from "./shoppingList";
 import { canonicalShoppingKey } from "./canonicalKey";
 
 jest.mock("@/lib/db", () => ({
@@ -7,16 +13,22 @@ jest.mock("@/lib/db", () => ({
     shoppingListItem: {
       findMany: jest.fn(),
       upsert: jest.fn(),
+      updateMany: jest.fn(),
+      deleteMany: jest.fn(),
     },
   },
 }));
 
 const mockedFindMany = jest.mocked(prisma.shoppingListItem.findMany);
 const mockedUpsert = jest.mocked(prisma.shoppingListItem.upsert);
+const mockedUpdateMany = jest.mocked(prisma.shoppingListItem.updateMany);
+const mockedDeleteMany = jest.mocked(prisma.shoppingListItem.deleteMany);
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockedUpsert.mockResolvedValue({} as never);
+  mockedUpdateMany.mockResolvedValue({ count: 1 } as never);
+  mockedDeleteMany.mockResolvedValue({ count: 1 } as never);
 });
 
 describe("addShoppingListItems", () => {
@@ -65,6 +77,47 @@ describe("addShoppingListItems", () => {
         },
       }),
     );
+  });
+});
+
+describe("setBought", () => {
+  it("sets the bought flag on the user's row", async () => {
+    await setBought("u1", "row-1", true);
+
+    expect(mockedUpdateMany).toHaveBeenCalledWith({
+      where: { id: "row-1", userId: "u1" },
+      data: { bought: true },
+    });
+  });
+
+  it("scopes the update by userId so another user's row is untouched", async () => {
+    await setBought("u1", "row-1", false);
+
+    expect(mockedUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: "u1" }),
+      }),
+    );
+  });
+});
+
+describe("removeShoppingListItem", () => {
+  it("deletes exactly the one user-scoped row", async () => {
+    await removeShoppingListItem("u1", "row-1");
+
+    expect(mockedDeleteMany).toHaveBeenCalledWith({
+      where: { id: "row-1", userId: "u1" },
+    });
+  });
+});
+
+describe("clearBoughtItems", () => {
+  it("deletes only the user's bought rows", async () => {
+    await clearBoughtItems("u1");
+
+    expect(mockedDeleteMany).toHaveBeenCalledWith({
+      where: { userId: "u1", bought: true },
+    });
   });
 });
 

--- a/src/lib/shoppingList/shoppingList.ts
+++ b/src/lib/shoppingList/shoppingList.ts
@@ -34,3 +34,24 @@ export async function addShoppingListItems(
     });
   }
 }
+
+/**
+ * Mark a row bought (✓ strike-through) or unbought. Scoped by `userId` via
+ * `updateMany` so a row can only be toggled by its owner.
+ */
+export async function setBought(userId: string, id: string, bought: boolean) {
+  await prisma.shoppingListItem.updateMany({
+    where: { id, userId },
+    data: { bought },
+  });
+}
+
+/** Hard-delete a single row (✕ changed mind). Scoped by `userId`. */
+export async function removeShoppingListItem(userId: string, id: string) {
+  await prisma.shoppingListItem.deleteMany({ where: { id, userId } });
+}
+
+/** Bulk "clear bought" — remove only the user's bought rows, keep the rest. */
+export async function clearBoughtItems(userId: string) {
+  await prisma.shoppingListItem.deleteMany({ where: { userId, bought: true } });
+}


### PR DESCRIPTION
## Summary
Slice 2 of the Shopping List (PRD #313, ADR-0014). Adds the three Need-tab lifecycle actions to the standing list:

- **✓ bought** — a per-row toggle that strikes the row through and *keeps* it (never auto-removes)
- **✕ changed-mind** — hard-deletes a single row
- **Clear bought** — bulk-removes bought rows; the button only appears while at least one row is bought

### Layers
- **Service** (`src/lib/shoppingList/`): `setBought` / `removeShoppingListItem` / `clearBoughtItems`, all `userId`-scoped via `updateMany`/`deleteMany` so a row can only be touched by its owner.
- **Route** (`/api/shopping-list`): grows `PATCH` (`{id, bought}` → setBought) and `DELETE` (`{id}` → remove, or `{clearBought:true}` → clear). Both 400 on a missing `userId` or an absent target; malformed JSON 400s; service errors 500.
- **UI** (`src/features/ShoppingList/`): each row gets an accessible check control (strike-through when bought) and a remove control; a Clear-bought button sits below the list when relevant.

### Bought ≠ add-to-pantry
Checking a row only flips its `bought` flag — there is no inventory write on that path. Moving an item into the pantry stays a separate, explicit opt-in.

## Test plan
- `pnpm jest` — 502 passing (26 shopping-list service+route, 8 component).
- Manual (deferred to the HITL design slice #318): toggle a row bought → strike-through + Clear-bought appears; ✕ removes a row; Clear bought drops only bought rows.

Closes #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mark shopping list items as bought/unbought with improved checkbox controls
  * Delete individual items from your shopping list
  * Clear all bought items at once via a dedicated action button
  * Updated item row UI with accessible checkbox behavior and an explicit remove button
* **API & Behavior**
  * Added support for updating bought status and deleting/clearing items through new shopping-list endpoints, with consistent validation and error responses
* **Documentation**
  * Updated shopping list lifecycle documentation and remaining rollout checklist
* **Tests**
  * Expanded API, UI, and service-layer test coverage for these operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->