### PR TITLE
feat(shopping-list): promote to its own Section; retire Have/Need tabs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,9 +16,9 @@ Related: [ADR-0002](docs/adr/0002-conversation-requires-at-least-one-message.md)
 
 ## Section
 
-One of the three primary destinations — **Chat**, **Pantry**, **Cookbook**. Selected from the `AppSidebar` on desktop and from the nav drawer on mobile. The Radix `Tabs` container that switches the content panels underneath is an implementation detail, not a user-facing surface — there is no visible tab strip.
+One of the four primary destinations — **Chat**, **Pantry**, **Shopping List**, **Cookbook**. Selected from the `AppSidebar` on desktop and from the nav drawer on mobile. The Radix `Tabs` container that switches the content panels underneath is an implementation detail, not a user-facing surface — there is no visible tab strip.
 
-The **Pantry** Section has two faces: **Have** (current stock) and **Need** (the **Shopping List**). See [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md).
+The **Pantry** (current stock) and the **Shopping List** (what to buy) are conceptual inverses, kept **adjacent in the nav** rather than nested under one surface. They were briefly co-located as a Have/Need tab strip inside the Pantry; that strip was the app's only visible tabs and read as foreign to the "destinations come from the nav" rule, so the Shopping List was promoted to its own Section. See [ADR-0015](docs/adr/0015-shopping-list-is-its-own-section.md) (amends [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md)).
 
 ---
 
@@ -40,7 +40,7 @@ When the stream finishes (`onFinish`), `commitConversation(id)` flips `pendingCo
 
 ## Nav Selection
 
-"You are in this **Section**." Shown on the primary navigation items in `AppSidebar` and the mobile nav drawer (Chat / Pantry / Cookbook). Visual treatment: `bg-card` background, `text-foreground` label, terracotta (`text-primary`) icon outline (stroke color only — no fill swap).
+"You are in this **Section**." Shown on the primary navigation items in `AppSidebar` and the mobile nav drawer (Chat / Pantry / Shopping List / Cookbook). Visual treatment: `bg-card` background, `text-foreground` label, terracotta (`text-primary`) icon outline (stroke color only — no fill swap).
 
 The Chat nav item is highlighted only in **Staging State** (`activeConversationId === null && pendingConversationId === null`). Once a conversation becomes pending or committed, the Chat nav unhighlights and **Thread Selection** takes over.
 
@@ -146,7 +146,7 @@ Formerly: the in-chat block that listed a recipe's missing items (the **Addition
 
 ## Market Tip
 
-Ah Mah's point-of-purchase wisdom for choosing a fresh item well — e.g. *"firm, deep-red tomato, no bruises"* or *"a dark avocado that gives slightly is ripe enough to use today."* Surfaced on the **[Shopping List](#shopping-list)** (the Pantry's **Need** tab), one tip per item, and folded into the copied shopping-list text so it travels to wherever the user actually shops. Market Tips deliberately do **not** appear on the recipe card — co-locating a pick-tip with an ingredient's substitution `note` clashed (see [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md)).
+Ah Mah's point-of-purchase wisdom for choosing a fresh item well — e.g. *"firm, deep-red tomato, no bruises"* or *"a dark avocado that gives slightly is ripe enough to use today."* Surfaced on the **[Shopping List](#shopping-list)** Section, one tip per item, and folded into the copied shopping-list text so it travels to wherever the user actually shops. Market Tips deliberately do **not** appear on the recipe card — co-locating a pick-tip with an ingredient's substitution `note` clashed (see [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md)).
 
 A Market Tip speaks only to **selection quality at the moment of buying** — not to how long something keeps once home. Only *fresh / pickable* items (produce, fruit, seafood, meat) carry one; staples (salt, sauces, dry goods) have none and show no tip affordance. Tips are **universal, not user-specific**: the same advice serves every user, so they live in a single shared corpus keyed by canonical item name, never per account.
 
@@ -158,7 +158,7 @@ Related: [ADR-0013](docs/adr/0013-market-tips-are-llm-generated-and-shared.md), 
 
 ## Shopping List
 
-A standing, **per-user**, persisted list of items the user intends to buy — the **Need** face of the Pantry (whose **Have** face is the current stock). Items are **identities, not quantities**: a row is `shallot`, never `4 shallots`, so the same item from different recipes and from direct entry collapse to one row (canonical name). Each item carries its **Market Tip**.
+A standing, **per-user**, persisted list of items the user intends to buy — its own top-level **Section**, the conceptual inverse of the **Pantry** (current stock) and kept adjacent to it in the nav. Items are **identities, not quantities**: a row is `shallot`, never `4 shallots`, so the same item from different recipes and from direct entry collapse to one row (canonical name). Each item carries its **Market Tip**.
 
 Items arrive two ways: the **cart button** on a recipe's ingredient row (adds the missing item), or **typed in directly** (e.g. "apples", unrelated to any recipe). Lifecycle is todo-list-style — checking an item (**bought**) strikes it through for the trip; crossing it out (**✕**, changed mind) deletes it. Moving a bought item into the **Pantry** is a separate, opt-in step, never a side effect of checking it.
 

--- a/docs/adr/0015-shopping-list-is-its-own-section.md
+++ b/docs/adr/0015-shopping-list-is-its-own-section.md
@@ -1,0 +1,36 @@
+# ADR-0015 — The Shopping List is its own top-level Section, not a tab inside the Pantry
+
+**Status:** Accepted — amends [ADR-0014](0014-shopping-list-is-standing-and-quantityless.md) §2 and §6
+
+## Context
+
+[ADR-0014](0014-shopping-list-is-standing-and-quantityless.md) placed the standing **Shopping List** on a **Need** tab inside the Pantry, opposite a **Have** tab (current stock). Its §2 ("Why not the alternatives") explicitly *rejected* a standalone Section — "splits the symmetric Have/Need pair across two destinations; the list belongs beside the pantry it inverts" — and §6 called the tab placement "the one **easily-reversible** decision here (pure UI location, no data dependency)."
+
+In use, the Have/Need tab strip was wrong on its own terms:
+
+1. **It contradicted the app's navigation model.** Per [the `Section` glossary entry](../../CONTEXT.md), destinations are chosen from the `AppSidebar` / mobile drawer, and "the Radix `Tabs` container … is an implementation detail … there is no visible tab strip." The Have/Need strip was the **only visible tab strip in the entire app** — a control whose signified meaning ("navigate to another tab") collided with the established rule that you change destinations from the nav, never from tabs.
+2. **The styling had nowhere to belong.** The shared `TabsTrigger` is a folder tab whose active state merges into the **Chat** surface (`bg-chat` / `border-b-chat`), but the Pantry panel is `bg-muted paper`. The tab's colour never matched the surface under it, so it read as orphaned.
+
+These are the symptoms ADR-0014 §6 invited us to revisit: placement was the cheap thing to change, and it proved wrong.
+
+## Decision
+
+Promote the **Shopping List** to its own top-level **Section**, peer to Chat / Pantry / Cookbook.
+
+- **Nav** becomes **Chat · Pantry · Shopping List · Cookbook**. Shopping List sits immediately after Pantry so the inverse-pair stays adjacent — the co-location ADR-0014 valued is preserved as *nav adjacency* instead of *nested tabs*.
+- **The Have/Need tab strip is deleted.** `InventoryWrapper` no longer wraps content in `Tabs`; the Pantry renders `<Inventory />` directly and once again means **stock only**. The Shopping List renders in its own content panel, switched by the same `?tab=` nav mechanism as every other Section (`?tab=shopping`).
+- **"Have" and "Need" are retired as user-facing terms.** They existed only as the two faces of one tabbed surface; with the surface gone, the Pantry is just the Pantry and the Shopping List is just the Shopping List. The nav label is **Shopping List** (self-evident to a first-time user in a way "Need" never was).
+
+No data changes — exactly as ADR-0014 §6 predicted. The `ShoppingListItem` model, its routes, and the Market Tip engine are untouched; this is nav + routing only.
+
+## Why this amends ADR-0014
+
+0014 §2 rejected a standalone Section to keep the Have/Need pair from being "split across two destinations." That cost is real but mild, and it is fully paid down by **nav adjacency**: the two destinations sit side by side, visibly an inverse pair, without forcing a foreign tab control onto one of them. 0014 §6 already flagged its own placement as the reversible bet; this ADR collects on it.
+
+## Consequences
+
+- One visible "Have/Need" affordance disappears; the Shopping List gains nav-level discoverability it lacked behind a tab (it no longer hides one click deep inside the Pantry).
+- `SidebarContent` and `MobileTopBar` each gain a fourth nav item (`ShoppingBasket` icon); `page.tsx` gains a fourth content panel; `useActiveTab` accepts `shopping`.
+- The glossary's `Section` entry now lists four destinations; `Have`/`Need` are removed as named faces.
+- Cross-references that described the Shopping List as "the Pantry's Need tab" are reworded to "its own Section, the inverse of the Pantry."
+- Reversibility is unchanged: collapsing it back into the Pantry (or elsewhere) remains pure UI/nav work with zero migration.

--- a/docs/adr/0015-shopping-list-is-its-own-section.md
+++ b/docs/adr/0015-shopping-list-is-its-own-section.md
@@ -30,7 +30,7 @@ No data changes — exactly as ADR-0014 §6 predicted. The `ShoppingListItem` mo
 ## Consequences
 
 - One visible "Have/Need" affordance disappears; the Shopping List gains nav-level discoverability it lacked behind a tab (it no longer hides one click deep inside the Pantry).
-- `SidebarContent` and `MobileTopBar` each gain a fourth nav item (`ShoppingBasket` icon); `page.tsx` gains a fourth content panel; `useActiveTab` accepts `shopping`.
+- `SidebarContent` gains a fourth nav item with a hand-drawn basket `ShoppingListIcon`; `MobileTopBar` (which reuses `SidebarContent` for its drawer) gains the `Shopping List` section label; `page.tsx` gains a fourth content panel; `useActiveTab` accepts `shopping`.
 - The glossary's `Section` entry now lists four destinations; `Have`/`Need` are removed as named faces.
 - Cross-references that described the Shopping List as "the Pantry's Need tab" are reworded to "its own Section, the inverse of the Pantry."
 - Reversibility is unchanged: collapsing it back into the Pantry (or elsewhere) remains pure UI/nav work with zero migration.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -103,6 +103,12 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Earned step depth (#268)**: prompt-only — `steps[].body` carries the *why*, sensory doneness cues, and failure-mode cautions only on pivotal steps, under a soft length cap; trivial steps stay short. Step bodies reference ingredients by name only — no absolute quantities (they'd fight the servings stepper).
 - **Copy recipe (#269)**: one shared `formatRecipeAsText(recipe, servings)` (`src/features/Recipe`) → plain text, CAPS headers, `•`/numbered lists, no markdown (survives WhatsApp/Notes). Amounts scale to the displayed servings via `scaleAmount`; amountless rows read "to taste"; sections render only when present; a "— from Ah Mah" footer. Surfaced as a **Copy recipe** button on `RecipeDisplay` (header — servings lifted out of `RecipeBody` so the header reads the current count) and in the `RecipeLetter` action bar. Excludes pantry state ("10/12 in your pantry"). **Copy shopping list stays separate** — two distinct copy intents, never collapsed into a bare "Copy".
 
+### Shopping List promoted to its own Section — Shipped Jun 2026
+
+- **The Have/Need tab strip is gone.** The standing Shopping List, briefly the Pantry's **Need** tab, is now its own top-level **Section** in the nav: **Chat · Pantry · Shopping List · Cookbook** (basket icon, sat next to Pantry so the inverse-pair stays adjacent). Pantry reverts to meaning **stock only**. See [ADR-0015](./adr/0015-shopping-list-is-its-own-section.md) (amends ADR-0014 §2/§6).
+- **Why**: the Have/Need strip was the app's *only* visible tab strip, contradicting the "destinations come from the nav, never from tabs" rule (`CONTEXT.md` → Section), and its folder-tab styling (`bg-chat`) never matched the Pantry surface (`bg-muted`) — so it read as orphaned. The fix was conceptual, not cosmetic: promote, don't restyle.
+- **Changes**: 4th `NAV_ITEMS` entry + `ShoppingListIcon` in `SidebarContent`; `SECTION_LABELS.shopping` in `MobileTopBar`; `"shopping"` added to `useActiveTab`; 4th `TabsContent` (`?tab=shopping`) renders `<ShoppingList />` in `page.tsx`; `InventoryWrapper` strips its `Tabs` and renders `<Inventory />` directly. **Zero data change** — exactly as ADR-0014 §6 predicted. `Have`/`Need` retired as user-facing terms.
+
 ### Shopping List spine — the Pantry "Need" tab — Shipped Jun 2026 (#314)
 
 - **Standing, quantity-less Shopping List** introduced as the Pantry **Need** tab (Have/Need faces), per [ADR-0014](./adr/0014-shopping-list-is-standing-and-quantityless.md) and [PRD #313](https://github.com/alantay/ask-ah-mah/issues/313). This slice is the spine — type-in, persist, view; lifecycle (✓/✕/clear), Need-tab Market Tips, and the recipe-card on-ramp + Shortfall-card retirement are the follow-up slices (#315–#318).
@@ -163,8 +169,8 @@ The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook)
 ## Next up
 
 ### Shopping List — remaining slices (ADR-0014, PRD #313)
-The spine (#314), lifecycle (#315), Market Tips (#316), and the recipe on-ramp + Shortfall retirement (#317) shipped above. Remaining vertical slice:
-- [ ] **#318 HITL design review**: Need tab + post-removal recipe card; Playwright screenshots; human sign-off.
+The spine (#314), lifecycle (#315), Market Tips (#316), and the recipe on-ramp + Shortfall retirement (#317) shipped above.
+- [x] **#318 HITL design review**: Playwright screenshots of the list states + post-removal recipe card surfaced that the **Have/Need tab strip itself** was the wrong pattern (the app's only visible tab strip). Resolved by promoting the Shopping List to its own Section — [ADR-0015](./adr/0015-shopping-list-is-its-own-section.md), shipped above.
 
 ## V3+ — Ideas (KIV)
 - [ ] Aging / "going bad soon" alerts (deferred — app cannot reliably know freshness; see ADR-0008).

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { Tabs, TabsContent } from "@/components/ui/tabs";
 import ChatWrapper from "@/features/Chat/components/ChatWrapper";
 import InventoryWrapper from "@/features/Inventory/components/InventoryWrapper";
 import RecipeList from "@/features/RecipeList/RecipeList";
+import ShoppingList from "@/features/ShoppingList";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { useRouter } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
@@ -54,6 +55,15 @@ function HomeContent() {
             className="flex-1 min-h-0 mt-0 overflow-hidden border border-border rounded-lg bg-muted paper data-[state=inactive]:hidden"
           >
             <InventoryWrapper />
+          </TabsContent>
+
+          {/* ── Shopping List tab ── */}
+          <TabsContent
+            value="shopping"
+            forceMount
+            className="flex-1 min-h-0 mt-0 overflow-hidden border border-border rounded-lg bg-muted paper data-[state=inactive]:hidden"
+          >
+            <ShoppingList />
           </TabsContent>
 
           {/* ── Cookbook tab ── */}

--- a/src/features/Inventory/components/InventoryWrapper.tsx
+++ b/src/features/Inventory/components/InventoryWrapper.tsx
@@ -1,7 +1,5 @@
 "use client";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSessionContext } from "@/contexts/SessionContext";
-import ShoppingList from "@/features/ShoppingList";
 import Inventory from "../Inventory";
 import { INVENTORY_LOADING_MESSAGES } from "../constants";
 
@@ -22,29 +20,8 @@ export default function InventoryWrapper() {
     );
   }
 
-  // The Pantry has two faces (ADR-0014): Have = current stock, Need = the
-  // standing Shopping List. The list is mounted here, inside Pantry, so it can
-  // be promoted to its own Section later with no data change.
-  return (
-    <Tabs defaultValue="have" className="h-full flex flex-col overflow-hidden">
-      <div className="px-4 sm:px-9 pt-3 sm:pt-5">
-        <TabsList>
-          <TabsTrigger value="have">Have</TabsTrigger>
-          <TabsTrigger value="need">Need</TabsTrigger>
-        </TabsList>
-      </div>
-      <TabsContent
-        value="have"
-        className="flex-1 min-h-0 mt-0 overflow-hidden data-[state=inactive]:hidden"
-      >
-        <Inventory />
-      </TabsContent>
-      <TabsContent
-        value="need"
-        className="flex-1 min-h-0 mt-0 overflow-hidden data-[state=inactive]:hidden"
-      >
-        <ShoppingList />
-      </TabsContent>
-    </Tabs>
-  );
+  // The Pantry is current stock only. The standing Shopping List — once the
+  // Pantry's "Need" tab — is now its own top-level Section (ADR-0015), so this
+  // surface renders the inventory directly with no tab strip.
+  return <Inventory />;
 }

--- a/src/features/shared/components/MobileTopBar.tsx
+++ b/src/features/shared/components/MobileTopBar.tsx
@@ -7,8 +7,9 @@ import { useActiveTab } from "@/hooks/useActiveTab";
 import { useRef, useState } from "react";
 import { SidebarContent } from "./SidebarContent";
 
-const SECTION_LABELS: Record<"pantry" | "cookbook", string> = {
+const SECTION_LABELS: Record<"pantry" | "shopping" | "cookbook", string> = {
   pantry: "Pantry",
+  shopping: "Shopping List",
   cookbook: "Cookbook",
 };
 

--- a/src/features/shared/components/SidebarContent.tsx
+++ b/src/features/shared/components/SidebarContent.tsx
@@ -29,10 +29,22 @@ const CookbookIcon = () => (
   </svg>
 );
 
+const ShoppingListIcon = () => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="m5 11 4-7" />
+    <path d="m19 11-4-7" />
+    <path d="M2 11h20" />
+    <path d="m3.5 11 1.6 7.4a2 2 0 0 0 2 1.6h9.8a2 2 0 0 0 2-1.6l1.7-7.4" />
+    <path d="m9 11 1 9" />
+    <path d="m15 11-1 9" />
+  </svg>
+);
+
 const NAV_ITEMS = [
-  { id: "chat",     label: "New Chat",  Icon: ChatIcon     },
-  { id: "pantry",   label: "Pantry",    Icon: PantryIcon   },
-  { id: "cookbook", label: "Cookbook",  Icon: CookbookIcon },
+  { id: "chat",     label: "New Chat",      Icon: ChatIcon         },
+  { id: "pantry",   label: "Pantry",        Icon: PantryIcon       },
+  { id: "shopping", label: "Shopping List", Icon: ShoppingListIcon },
+  { id: "cookbook", label: "Cookbook",      Icon: CookbookIcon     },
 ] as const;
 
 interface SidebarContentProps {

--- a/src/hooks/useActiveTab.ts
+++ b/src/hooks/useActiveTab.ts
@@ -2,9 +2,9 @@
 
 import { usePathname, useSearchParams } from "next/navigation";
 
-export type ActiveTab = "chat" | "pantry" | "cookbook";
+export type ActiveTab = "chat" | "pantry" | "shopping" | "cookbook";
 
-const VALID_TABS = ["chat", "pantry", "cookbook"] as const satisfies readonly ActiveTab[];
+const VALID_TABS = ["chat", "pantry", "shopping", "cookbook"] as const satisfies readonly ActiveTab[];
 
 /**
  * Single source of truth for which top-level tab is currently active.


### PR DESCRIPTION
## Summary

The Have/Need tab strip inside the Pantry was the app's **only** visible tab strip — contradicting the established rule that destinations come from the nav, never from tabs (`CONTEXT.md` → Section) — and its folder-tab styling (`bg-chat`) never matched the Pantry surface (`bg-muted`), so it read as orphaned. The fix is conceptual, not cosmetic: **promote the standing Shopping List to its own top-level Section.**

- **Nav** becomes **Chat · Pantry · Shopping List · Cookbook** (basket icon; sits next to Pantry so the inverse-pair stays adjacent).
- **Pantry reverts to stock only**; the Have/Need tab strip is deleted; `Have`/`Need` retired as user-facing terms.
- **Zero data change** — `ShoppingListItem`, routes, and the Market Tip engine are untouched. This is nav + routing only, exactly as ADR-0014 §6 predicted.

### Changes
- `SidebarContent` — 4th `NAV_ITEMS` entry + `ShoppingListIcon`
- `MobileTopBar` — `SECTION_LABELS.shopping`
- `useActiveTab` — accepts `"shopping"`
- `page.tsx` — 4th `TabsContent` (`?tab=shopping`) renders `<ShoppingList />`
- `InventoryWrapper` — strips its `Tabs`, renders `<Inventory />` directly
- Docs: **ADR-0015** (amends ADR-0014 §2/§6), `CONTEXT.md` (Section now 4 destinations; Have/Need removed), `progress.md`

This came out of the #318 HITL design review, which surfaced that the tab pattern itself — not the layout — was the problem.

## Test plan
- Nav (desktop sidebar + mobile drawer) shows **Chat · Pantry · Shopping List · Cookbook**; Shopping List highlights when active.
- `?tab=shopping` deep-links to the Shopping List; Market Tips, bought strike-through, and Clear bought all work.
- Pantry shows stock only, no tab strip.
- `jest src/features/ShoppingList src/features/Inventory` → 15 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Shopping List** as a top-level navigation option alongside Chat, Pantry, and Cookbook.
  * Shopping List now opens in its own section on desktop and mobile, with its own label and tab state.

* **Bug Fixes**
  * Simplified Pantry to show inventory directly, removing the old Have/Need split.
  * Updated navigation and URL tab handling so the Shopping List view opens reliably.

* **Documentation**
  * Refreshed glossary and progress notes to reflect Shopping List as a first-class destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->