### PR TITLE
feat(pantry): default Cook With selection to whole pantry

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,6 +110,8 @@ Related: [ADR-0006](docs/adr/0006-cook-with-what-you-have-is-a-conversation.md),
 
 The set of pantry items the user has marked to *star* in a Cook With What You Have submission. Items can be ingredients or kitchenware. The selection is **emphasis, not constraint** — non-selected pantry items remain fair game for the model to use silently; selected items must appear or be addressed.
 
+A genuine Featured Selection is a **proper subset** of the pantry. Selecting the *entire* pantry is equivalent to selecting *nothing*: both send the relaxed whole-pantry request (*"no featured ingredients"*), never a kitchen-sink list of every item. The selection UI defaults to **all items checked** — the user *deselects* what they don't feel like cooking with — so "all checked" must collapse to the relaxed request, otherwise the common case would over-constrain the model.
+
 Related: [ADR-0007](docs/adr/0007-pantry-selection-is-feature-emphasis.md)
 
 ---

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -60,6 +60,7 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **More ideas button**: shown below Cook-With response pairs; sends "More ideas — different from these" in same Conversation.
 - **Chat staging chip**: "🥬 Cook with what I have →" routes to Pantry and auto-enters selection mode via `?selectionMode=1` URL param.
 - Key decisions: ADR-0006 (reuses `/api/chat`, not a dedicated route), ADR-0007 (selection = emphasis not constraint).
+- **Selection defaults to all-checked** (Jun 2026): "Cook with what you have" now enters selection mode with the **whole pantry pre-checked**; the user *deselects* what they'd rather skip. A `Clear all` / `Select all` toggle sits in the selection banner (desktop) and mobile header. Submitting with everything still checked collapses to the relaxed whole-pantry request (`buildCookWithMessage([], [])`, "no featured ingredients") — a Featured Selection only forms for a proper subset, preserving ADR-0007. CTA reads "Cook with everything" when all are checked. Replaces the abandoned split-pill / tap-to-feature affordance exploration. CONTEXT.md "Featured Selection" sharpened with the all==none equivalence.
 
 ### Recipe Tweak UI (Direction C) — Shipped May 2026
 - **5-state interactive flow** inside `RecipeDisplay`: resting → open → streaming → preview → saved.

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -228,6 +228,9 @@ const Inventory = () => {
   const exitSelectionMode = () => {
     setSelectionMode(false);
     setSelectedIds(new Set());
+    // Cancel any pending deferred seed so it can't repopulate selection after
+    // SWR data lands once we've already left selection mode.
+    setSeedAllOnLoad(false);
   };
 
   const selectAll = () => setSelectedIds(new Set(allItemIds()));

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -106,21 +106,14 @@ const Inventory = () => {
 
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Set when we enter selection mode before inventory data is in hand (e.g.
+  // routed from the Chat chip) — seeds "all selected" once the data lands.
+  const [seedAllOnLoad, setSeedAllOnLoad] = useState(false);
 
   const { userId } = useSessionContext();
   const { queueCookWithMessage, startNewConversation } = useConversationContext();
   const router = useRouter();
   const searchParams = useSearchParams();
-
-  // Auto-enter selection mode when routed from Chat chip (?selectionMode=1)
-  useEffect(() => {
-    if (searchParams.get("selectionMode") === "1") {
-      setSelectionMode(true);
-      setSelectedIds(new Set());
-      // Clear the param without re-rendering the parent
-      router.replace("/?tab=pantry", { scroll: false });
-    }
-  }, [searchParams, router]);
 
   const { data, error, isLoading } = useSWR<GetInventoryResponse>(
     userId ? `/api/inventory?userId=${userId}` : null,
@@ -130,6 +123,27 @@ const Inventory = () => {
       revalidateOnMount: true,
     },
   );
+
+  // Auto-enter selection mode when routed from Chat chip (?selectionMode=1).
+  // Data may not be loaded yet, so defer the all-select seed to the effect below.
+  useEffect(() => {
+    if (searchParams.get("selectionMode") === "1") {
+      setSelectionMode(true);
+      setSeedAllOnLoad(true);
+      // Clear the param without re-rendering the parent
+      router.replace("/?tab=pantry", { scroll: false });
+    }
+  }, [searchParams, router]);
+
+  // Once data is available, seed the deferred "all selected" set exactly once.
+  useEffect(() => {
+    if (!seedAllOnLoad || !data) return;
+    const ids = [...data.ingredientInventory, ...data.kitchenwareInventory].map(
+      (i) => i.id,
+    );
+    setSelectedIds(new Set(ids));
+    setSeedAllOnLoad(false);
+  }, [seedAllOnLoad, data]);
 
   const onSubmit = async () => {
     if (!userId || !draft.trim() || submitting) return;
@@ -198,15 +212,26 @@ const Inventory = () => {
     });
   };
 
+  const allItemIds = () =>
+    [
+      ...(data?.ingredientInventory ?? []),
+      ...(data?.kitchenwareInventory ?? []),
+    ].map((i) => i.id);
+
+  // Selection starts with the whole pantry checked; the user deselects what
+  // they don't feel like cooking with tonight.
   const enterSelectionMode = () => {
     setSelectionMode(true);
-    setSelectedIds(new Set());
+    setSelectedIds(new Set(allItemIds()));
   };
 
   const exitSelectionMode = () => {
     setSelectionMode(false);
     setSelectedIds(new Set());
   };
+
+  const selectAll = () => setSelectedIds(new Set(allItemIds()));
+  const clearAll = () => setSelectedIds(new Set());
 
   const handleCookWithSubmit = () => {
     const allItems = [
@@ -222,7 +247,13 @@ const Inventory = () => {
 
     if (selectedIngredients.length === 0 && selectedEquipment.length === 0) return;
 
-    const message = buildCookWithMessage(selectedIngredients, selectedEquipment);
+    // The whole pantry checked == nothing featured: both send the relaxed
+    // "cook from everything" request, never a kitchen-sink list of every item.
+    // A genuine Featured Selection only exists for a proper subset. (ADR-0007)
+    const isWholePantry = selectedIds.size === allItems.length;
+    const message = isWholePantry
+      ? buildCookWithMessage([], [])
+      : buildCookWithMessage(selectedIngredients, selectedEquipment);
 
     // Reset selection — Conversation owns context from here
     exitSelectionMode();
@@ -254,8 +285,10 @@ const Inventory = () => {
   );
   const totalSelected = selectedIds.size;
 
+  const allSelected = totalCount > 0 && totalSelected === totalCount;
   const ctaLabel = (() => {
     if (totalSelected === 0) return "Select items to cook";
+    if (allSelected) return "Cook with everything";
     if (selectedIngredients.length === 0 && selectedEquipment.length > 0) {
       const names = selectedEquipment.map((i) => i.name).join(" & ");
       return `Surprise me with ${names}`;
@@ -341,33 +374,52 @@ const Inventory = () => {
               )}
             </>
           ) : (
-            <div className="flex items-center justify-between w-full">
+            <div className="flex items-center justify-between w-full gap-2">
               <span className="font-display italic text-emphasis text-muted-foreground">
-                {totalSelected > 0 ? `${totalSelected} selected` : "Tap items to select"}
+                {totalSelected > 0
+                  ? `${totalSelected} of ${totalCount} selected`
+                  : "Nothing selected"}
               </span>
-              <Button
-                variant="outline"
-                onClick={exitSelectionMode}
-                className="gap-1.5 min-h-11 px-3 py-1.5 text-xs font-semibold text-muted-foreground"
-              >
-                <X className="size-[14px]" />
-                Cancel
-              </Button>
+              <div className="flex items-center gap-1.5 shrink-0">
+                <Button
+                  variant="ghost"
+                  onClick={totalSelected > 0 ? clearAll : selectAll}
+                  className="min-h-11 px-2.5 py-1.5 text-xs font-semibold text-primary-deep"
+                >
+                  {totalSelected > 0 ? "Clear all" : "Select all"}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={exitSelectionMode}
+                  className="gap-1.5 min-h-11 px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+                >
+                  <X className="size-[14px]" />
+                  Cancel
+                </Button>
+              </div>
             </div>
           )}
         </div>
 
         {/* Selection mode banner — desktop */}
-        {selectionMode && (
+        {selectionMode && totalCount > 0 && (
           <div className="hidden sm:flex items-center justify-between gap-2 mb-4 px-3 py-2.5 bg-primary/5 border border-dashed border-primary/30 rounded-lg">
             <div className="flex items-center gap-2">
               <Check className="size-[13px] text-primary shrink-0" />
               <span className="font-display italic text-dense text-muted-foreground">
                 {totalSelected === 0
-                  ? "Tap items to feature them — Ah Mah will build recipes around your picks."
-                  : `${totalSelected} item${totalSelected !== 1 ? "s" : ""} selected`}
+                  ? "Nothing selected — tick what you'd like to cook with."
+                  : allSelected
+                    ? "Cooking with everything. Untick anything you'd rather skip."
+                    : `${totalSelected} of ${totalCount} selected`}
               </span>
             </div>
+            <button
+              onClick={totalSelected > 0 ? clearAll : selectAll}
+              className="font-sans text-dense font-semibold text-primary-deep hover:text-primary cursor-pointer shrink-0"
+            >
+              {totalSelected > 0 ? "Clear all" : "Select all"}
+            </button>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Clicking **Cook with what you have** now enters selection mode with the **whole pantry pre-checked**; the user *deselects* what they'd rather skip (was: empty selection, tap to add).
- Adds a **Clear all / Select all** toggle in the desktop selection banner and the mobile header; submit CTA reads "Cook with everything" when all are checked, and stays disabled at zero selected.
- Submitting with everything still checked **collapses to the relaxed whole-pantry request** (`buildCookWithMessage([], [])`, "no featured ingredients") instead of a kitchen-sink list of every item. A genuine **Featured Selection** only forms for a *proper subset* — preserving **ADR-0007** (selection = emphasis, not constraint).
- Reverts the abandoned split-pill / tap-to-feature exploration; `InventoryItemRow.tsx` is back to `main`.
- `CONTEXT.md` "Featured Selection" sharpened with the all==none equivalence; `docs/progress.md` updated.

## Test plan
- Desktop & mobile: click "Cook with what you have" → all items checked.
- Deselect a couple → CTA shows "Suggest recipe (N selected)"; Clear all empties (CTA disables, flips to "Select all"); Select all re-checks.
- Submit with everything checked → chat receives "Suggest recipes using: no featured ingredients".
- Submit with a subset → chat receives the featured list.
- Chat staging chip ("Cook with what I have →") routes to Pantry with all items pre-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer pantry selection controls, including **Select all** and **Clear all** options.
  * The main action label now updates to better match whether everything, some items, or nothing is selected.

* **Bug Fixes**
  * Fixed selection mode so it correctly starts with the pantry pre-selected when data loads later.
  * Submitting with every item selected now behaves like a whole-pantry request instead of creating a featured subset.

* **Documentation**
  * Clarified the selection behavior and glossary wording for featured selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->