### PR TITLE
fix(tips): pantry tips persist across list changes + lift item cap + restore key fix

### DIFF
--- a/src/app/api/market-tip/route.ts
+++ b/src/app/api/market-tip/route.ts
@@ -16,7 +16,7 @@ const RequestSchema = z.object({
       }),
     )
     .min(1)
-    .max(30),
+    .max(200),
 });
 
 const TipGenSchema = z.object({

--- a/src/app/api/storage-tip/route.test.ts
+++ b/src/app/api/storage-tip/route.test.ts
@@ -110,6 +110,34 @@ describe("POST /api/storage-tip", () => {
     expect(mockedCreate).not.toHaveBeenCalled();
   });
 
+  it("passes a name-only key to the model (kind kept out of the key)", async () => {
+    // Regression: the kind label must not leak into the prompt's key, or the
+    // model echoes "potato (ingredient)" and it never matches the cache key.
+    mockedFindMany.mockResolvedValue([] as never);
+    mockedGenerate.mockResolvedValue({
+      object: { tips: [{ key: "potato", tip: "cool, dark place" }] },
+    } as never);
+
+    await POST(reqWith({ items: [{ name: "Potato", type: "ingredient" }] }));
+
+    const prompt = mockedGenerate.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain("potato = ingredient");
+    expect(prompt).not.toContain("potato (ingredient)");
+  });
+
+  it("accepts a large pantry payload (more than 30 items)", async () => {
+    mockedFindMany.mockResolvedValue([] as never);
+    mockedGenerate.mockResolvedValue({ object: { tips: [] } } as never);
+
+    const items = Array.from({ length: 40 }, (_, i) => ({
+      name: `item ${i}`,
+      type: "ingredient",
+    }));
+    const res = await POST(reqWith({ items }));
+
+    expect(res.status).toBe(200);
+  });
+
   it("400s when items is missing", async () => {
     const res = await POST(reqWith({}));
     expect(res.status).toBe(400);

--- a/src/app/api/storage-tip/route.ts
+++ b/src/app/api/storage-tip/route.ts
@@ -16,7 +16,7 @@ const RequestSchema = z.object({
       }),
     )
     .min(1)
-    .max(30),
+    .max(200),
 });
 
 const TipGenSchema = z.object({
@@ -68,7 +68,7 @@ export async function POST(req: NextRequest) {
       // kitchen-domain relevance gate runs at the model so non-kitchen items
       // resolve to "" and get negative-cached.
       const list = misses
-        .map((k) => `- ${k} (${wanted.get(k)!.type})`)
+        .map((k) => `${k} = ${wanted.get(k)!.type}`)
         .join("\n");
       const { object } = await generateObject({
         model: openai("gpt-5-mini"),
@@ -76,10 +76,12 @@ export async function POST(req: NextRequest) {
         temperature: 0.4,
         prompt: `You are Ah Mah, a warm Singaporean grandmother. For each kitchen item, give ONE short tip on how to KEEP it well at home — for food, how to store it so it lasts (where, how, what to avoid); for equipment, how to care for it so it lasts.
 
+Each item below is written as "name = kind".
+
 RULES:
-- Return exactly one entry per item, using the EXACT given item text as "key".
+- Return exactly one entry per item. Set "key" to the NAME only — the text to the LEFT of " = " — copied EXACTLY. Never include the kind in the key.
+- Use the kind (right of " = "): "ingredient" means food, "kitchenware" means equipment — advise accordingly.
 - "tip": max 12 words, plain imperative. NO "to store X" preamble. e.g. "cool, dark place — never the fridge".
-- The label in parentheses tells you if it is an ingredient (food) or kitchenware (equipment); advise accordingly.
 - ${KITCHEN_DOMAIN_RULE}
 - If there is no meaningful way to keep it better (it just sits in the cupboard), return tip as an empty string "".
 - Warm and practical, but keep it SHORT.

--- a/src/hooks/useMarketTips.ts
+++ b/src/hooks/useMarketTips.ts
@@ -42,7 +42,13 @@ export function useMarketTips(
       if (!res.ok) throw new Error("market-tip fetch failed");
       return res.json();
     },
-    { revalidateOnFocus: false, dedupingInterval: 1000 * 60 * 60 },
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 1000 * 60 * 60,
+      // Adding/removing a list item changes the key; keep the prior tips on
+      // screen while the new request resolves instead of blanking every row.
+      keepPreviousData: true,
+    },
   );
 
   return data?.tips ?? {};

--- a/src/hooks/useStorageTips.ts
+++ b/src/hooks/useStorageTips.ts
@@ -39,7 +39,13 @@ export function useStorageTips(
       if (!res.ok) throw new Error("storage-tip fetch failed");
       return res.json();
     },
-    { revalidateOnFocus: false, dedupingInterval: 1000 * 60 * 60 },
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 1000 * 60 * 60,
+      // Adding/removing an item changes the key; keep the prior tips on screen
+      // while the new request resolves instead of blanking every row.
+      keepPreviousData: true,
+    },
   );
 
   return data?.tips ?? {};


### PR DESCRIPTION
## Summary

Fixes three issues that broke pantry Storage Tips after #329/#333:

- **Tips disappeared after adding an item.** Adding/removing a pantry item changes the `useStorageTips` SWR key; SWR dropped `data` to `undefined` while the new key refetched, blanking every row. Added `keepPreviousData: true` (also on `useMarketTips`, same flaw on the shopping list) so prior tips stay on screen during the refetch.
- **400 on real pantries.** The request schema capped `items` at **30**; a 32-item pantry 400'd, so *no* tips loaded. Raised the cap to **200** on both `/api/storage-tip` and `/api/market-tip`.
- **Restored a lost fix.** The `name = kind` cache-key fix (so the model doesn't echo `"potato (ingredient)"` and miss the `potato` key) never reached main — #333 squash-merged before that commit landed. Re-applied, with its regression test, plus a new test asserting a 40-item payload is accepted.

## Test plan

- [x] `storage-tip` / `market-tip` route suites green (13 tests), incl. key-format + large-payload regressions.
- [x] Verified live: 8-item mixed payload returns real tips for every kitchen item and `""` for a mountain bike (relevance gate); no 400.
- [ ] Manual: with Keeping tips on, add a pantry item → existing tips stay put, the new item's tip fills in; works past 30 items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Larger item lists are now supported for tip requests, so bulk inputs are less likely to be rejected.
  * Tip results stay visible while updated suggestions load, reducing flicker when item lists change.

* **Bug Fixes**
  * Improved how item names are handled in storage tips so labels are cleaner and more consistent.
  * Added coverage for larger requests and key handling to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->