### PR TITLE
fix(shopping-list): proper hover style on remove button

### DIFF
--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -252,7 +252,7 @@ const ShoppingList = () => {
                         type="button"
                         aria-label={`Remove ${item.name}`}
                         onClick={() => removeItem(item)}
-                        className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+                        className="shrink-0 -mr-1 flex size-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
                       >
                         <X className="size-4" />
                       </button>

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -206,7 +206,7 @@ const ShoppingList = () => {
               <TipsToggle
                 enabled={tipsOn}
                 onChange={setTipsOn}
-                label="Picking tips"
+                label="How to pick"
               />
             </div>
             {aisleGroups.map((group) => (

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -206,7 +206,7 @@ const ShoppingList = () => {
               <TipsToggle
                 enabled={tipsOn}
                 onChange={setTipsOn}
-                label="How to pick"
+                label="Picking tips"
               />
             </div>
             {aisleGroups.map((group) => (


### PR DESCRIPTION
## Summary

The shopping list's **X** remove button only changed text colour on hover — no hit-area affordance. It now gets a rounded `size-7` target with a `hover:bg-muted` background and pointer cursor, matching the pantry item remove button.

## Test plan

- Hover the X on a shopping-list row → rounded muted background appears, cursor is a pointer, icon darkens to foreground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)