### PR TITLE
feat(auth): anonymous-session identity foundation (#340)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -24,7 +24,7 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **`proposeRecipe` tool**: replaces `gate` fenced-block convention; model must call `proposeRecipe` or emit ` ```recipe ` — never ask "do you have X?" in prose.
 - **Organised Pantry**: `category` enum (`Protein | Carbs | Vegetable | Condiments | Misc | Spice`) on `InventoryItem` and `RecipeIngredient`; pantry grouped under category headings; token-overlap `ingredientMatches` fixes false-NEED bugs (doubanjiang class).
 - **NEED pill → clickable add**: clicking a NEED pill POSTs to `/api/inventory`, revalidates SWR, shows toast.
-- **Better Auth**: Google OAuth + email magic link (Resend); `useSession` bridges auth session with localStorage guest fallback; guests unchanged.
+- **Better Auth**: Google OAuth + anonymous sessions (`anonymous()` plugin); `useSession` always resolves `userId` from the session — guests get an anonymous session, no localStorage id. See "Anonymous-session identity foundation" (#340).
 
 ## V2 — Polish (May 2026)
 
@@ -162,6 +162,13 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Public route `/r/[token]`** is a server component outside the app shell, resolving the recipe by **token alone — never `userId`** (`getRecipeByShareToken`), so it's readable by anyone yet only ever exposes that one recipe. Unknown token → `notFound()`. `generateMetadata` emits OG/Twitter tags (name, description, image) for rich link unfurls.
 - **Read-only reuse**: `RecipeDisplay` gained a `readOnly` prop that hides every owner action (Share, Tweak, the Tweak bench, Start cooking, Back) but keeps **Copy recipe** — useful for whoever opens the link. The public page wraps it (`PublicRecipeView`) with a slim "Ask Ah Mah" brand bar linking home.
 - **App-shell extraction**: the sidebar + mobile top bar moved from the root layout into a new `(app)` route group (`src/app/(app)/layout.tsx`); the root layout is now just fonts + providers + `Toaster`. Existing routes (`/`, `/recipe/[id]`) moved into the group — URLs unchanged. This is what lets `/r/[token]` render clean, without the app's nav leaking into a public link.
+
+### Anonymous-session identity foundation — In progress (#340)
+
+- **Every visitor now has a real session.** The client-generated `localStorage["ask-ah-mah-session"]` id is gone. The better-auth `anonymous()` plugin mints an unforgeable anonymous session on first load (`useSession` calls `signIn.anonymous()` when there's no session); signed-in users still use their Google session. `userId` is always `session.user.id`, and `isAuthenticated` now means non-anonymous (`!user.isAnonymous`).
+- **Server is the source of truth for identity.** New helper `getSessionUserId(req)` (`src/lib/session.ts`) resolves the caller from the verified session cookie via `auth.api.getSession`, returning the id or `null` (routes map that to a 401 via `unauthorized()`). This is the primitive the route-lockdown slices (#341–#345) build on — routes stop trusting a `userId` from the request.
+- **Schema**: `User.isAnonymous Boolean?` (additive migration `20260629000000_add_user_is_anonymous`). New anonymous users get their starter pantry seeded.
+- **Not yet wired**: data routes still read `userId` from the request (#341–#345), and guest→Google data migration on link is #346.
 
 ## Design system
 

--- a/prisma/migrations/20260629000000_add_user_is_anonymous/migration.sql
+++ b/prisma/migrations/20260629000000_add_user_is_anonymous/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN "isAnonymous" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,6 +121,7 @@ model User {
   email         String    @unique
   emailVerified Boolean
   image         String?
+  isAnonymous   Boolean?
   createdAt     DateTime
   updatedAt     DateTime
   sessions      Session[]

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,37 +1,48 @@
 "use client";
 import { authClient } from "@/lib/auth-client";
-import { generateShortId } from "@/lib/utils";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
+/**
+ * Resolves the current user from the better-auth session — the single source of
+ * identity. Every visitor has a real session: signed-in users via Google, and
+ * everyone else via an anonymous session minted on first load. `userId` always
+ * comes from that session (never a client-generated localStorage id), so the
+ * server can trust the session cookie over any userId in a request.
+ */
 export default function useSession() {
-  const { data: session, isPending: authPending } = authClient.useSession();
-  const [guestId, setGuestId] = useState<string | null>(null);
-  const [guestLoading, setGuestLoading] = useState(!session?.user);
+  const { data: session, isPending } = authClient.useSession();
+  // True only while we're minting the first anonymous session, so consumers keep
+  // showing "loading" rather than briefly seeing a null userId.
+  const [creatingGuest, setCreatingGuest] = useState(false);
+  const attemptedRef = useRef(false);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (isPending) return; // wait for the session check to settle
+    if (session?.user) return; // already have a session (anonymous or real)
+    if (attemptedRef.current) return; // only ever mint once per mount
+    attemptedRef.current = true;
 
-    let sessionId = localStorage.getItem("ask-ah-mah-session");
-    const isNew = !sessionId;
-    if (!sessionId) {
-      sessionId = generateShortId();
-      localStorage.setItem("ask-ah-mah-session", sessionId);
-    }
-    setGuestId(sessionId);
-    setGuestLoading(false);
+    setCreatingGuest(true);
+    authClient.signIn
+      .anonymous()
+      .then((res) => {
+        // A brand-new anonymous user owns nothing yet — seed their starter pantry.
+        const newUserId = res?.data?.user?.id;
+        if (newUserId) {
+          fetch("/api/inventory/seed", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ userId: newUserId }),
+          });
+        }
+      })
+      .finally(() => setCreatingGuest(false));
+  }, [isPending, session]);
 
-    if (isNew) {
-      fetch("/api/inventory/seed", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: sessionId }),
-      });
-    }
-  }, []);
-
-  const isAuthenticated = !!session?.user;
-  const userId = isAuthenticated ? session!.user.id : guestId;
-  const isLoading = authPending || guestLoading;
+  const userId = session?.user?.id ?? null;
+  // "Authenticated" means a real account, not an anonymous guest session.
+  const isAuthenticated = !!session?.user && !session.user.isAnonymous;
+  const isLoading = isPending || creatingGuest;
   const user = session?.user ?? null;
 
   return { userId, isLoading, isAuthenticated, user };

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,3 +1,6 @@
 import { createAuthClient } from "better-auth/react";
+import { anonymousClient } from "better-auth/client/plugins";
 
-export const authClient = createAuthClient();
+export const authClient = createAuthClient({
+  plugins: [anonymousClient()],
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
+import { anonymous } from "better-auth/plugins";
 import { prisma } from "@/lib/db";
 
 export const auth = betterAuth({
@@ -14,4 +15,10 @@ export const auth = betterAuth({
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
     },
   },
+  // Every visitor — signed-in or not — gets a real, unforgeable session.
+  // Guests are issued an anonymous session so routes can derive identity from
+  // the session cookie instead of a client-supplied userId. Migrating an
+  // anonymous user's data to their account on sign-in (onLinkAccount) is
+  // handled separately in #346.
+  plugins: [anonymous()],
 });

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -3,3 +3,7 @@ import { NextResponse } from "next/server";
 export function missingUserId() {
   return NextResponse.json({ error: "userId is required" }, { status: 400 });
 }
+
+export function unauthorized() {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1,0 +1,39 @@
+import { getSessionUserId } from "./session";
+import { auth } from "@/lib/auth";
+
+jest.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: jest.fn() } },
+}));
+
+const getSession = auth.api.getSession as unknown as jest.Mock;
+
+// The helper only reads `req.headers`, so a minimal stub stands in for a real
+// Request (which isn't a global in the jsdom test environment).
+function fakeRequest(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+describe("getSessionUserId", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("returns the verified user id from the session", async () => {
+    getSession.mockResolvedValue({ user: { id: "user-123" } });
+
+    await expect(getSessionUserId(fakeRequest())).resolves.toBe("user-123");
+  });
+
+  it("returns null when there is no session", async () => {
+    getSession.mockResolvedValue(null);
+
+    await expect(getSessionUserId(fakeRequest())).resolves.toBeNull();
+  });
+
+  it("passes the request headers through to better-auth", async () => {
+    getSession.mockResolvedValue({ user: { id: "user-123" } });
+    const req = fakeRequest({ cookie: "better-auth.session_token=abc" });
+
+    await getSessionUserId(req);
+
+    expect(getSession).toHaveBeenCalledWith({ headers: req.headers });
+  });
+});

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,16 @@
+import { auth } from "@/lib/auth";
+
+/**
+ * The single source of truth for "who is making this request" on the server.
+ *
+ * Resolves the caller's id from the verified better-auth session cookie —
+ * anonymous or signed-in alike. Routes MUST use this instead of trusting a
+ * `userId` from the query string or body, which is attacker-controlled.
+ *
+ * Returns the verified user id, or `null` when there is no valid session
+ * (callers map that to a 401 via `unauthorized()`).
+ */
+export async function getSessionUserId(req: Request): Promise<string | null> {
+  const session = await auth.api.getSession({ headers: req.headers });
+  return session?.user?.id ?? null;
+}


### PR DESCRIPTION
Closes #340

## Summary
Foundation for session-scoped access control. Every visitor now has a real, unforgeable better-auth session — guests via the `anonymous()` plugin, signed-in users via Google — so the server can derive identity from the session cookie instead of a client-supplied `userId`.

- **auth** (`src/lib/auth.ts`): enable `anonymous()` plugin; **auth-client**: add `anonymousClient()`.
- **`useSession`**: mints an anonymous session on first load (`signIn.anonymous()`) when there's no session; **drops the `localStorage` guest id**. `userId` is always `session.user.id`; `isAuthenticated` now means non-anonymous (`!user.isAnonymous`); new anonymous users get their starter pantry seeded.
- **`src/lib/session.ts`**: `getSessionUserId(req)` resolves the verified caller id (or `null`) from `auth.api.getSession` — the primitive #341–#345 build on. Added `unauthorized()` to `src/lib/http.ts`.
- **schema**: `User.isAnonymous Boolean?` — additive migration `20260629000000_add_user_is_anonymous`.

Routes still read `userId` from the request until the lockdown slices (#341–#345) land; guest→Google data migration is #346.

## ⚠️ Requires a DB migration before it works
This adds the `user.isAnonymous` column. **Run `npx prisma migrate deploy` against the database before/at deploy** — without it, anonymous sign-in will 500 (same failure mode as the earlier `shareToken` issue).

## Test plan
- [ ] Migration applied (`npx prisma migrate deploy`)
- [ ] **New visitor** (incognito, no cookie): an anonymous session is minted, the starter pantry seeds, and cookbook/pantry/shopping-list work
- [ ] **Reload**: same anonymous session persists (no duplicate users/seeds)
- [ ] **Google sign-in** still works; `isAuthenticated` flips true
- [ ] `getSessionUserId` unit tests pass (`src/lib/session.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)