### PR TITLE
feat(recipe-api): lock down recipe routes to the session user (#341)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -168,7 +168,14 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Every visitor now has a real session.** The client-generated `localStorage["ask-ah-mah-session"]` id is gone. The better-auth `anonymous()` plugin mints an unforgeable anonymous session on first load (`useSession` calls `signIn.anonymous()` when there's no session); signed-in users still use their Google session. `userId` is always `session.user.id`, and `isAuthenticated` now means non-anonymous (`!user.isAnonymous`).
 - **Server is the source of truth for identity.** New helper `getSessionUserId(req)` (`src/lib/session.ts`) resolves the caller from the verified session cookie via `auth.api.getSession`, returning the id or `null` (routes map that to a 401 via `unauthorized()`). This is the primitive the route-lockdown slices (#341–#345) build on — routes stop trusting a `userId` from the request.
 - **Schema**: `User.isAnonymous Boolean?` (additive migration `20260629000000_add_user_is_anonymous`). New anonymous users get their starter pantry seeded.
-- **Not yet wired**: data routes still read `userId` from the request (#341–#345), and guest→Google data migration on link is #346.
+- **Not yet wired**: pantry/shopping-list/conversation routes still read `userId` from the request (#342–#344), share-token mint trust is #345, and guest→Google data migration on link is #346.
+
+### Recipe routes locked down — Shipped (#341)
+
+- **Recipe routes derive identity from the session, never the request.** `GET/POST/DELETE /api/recipe`, `PATCH /api/recipe/[id]`, and `POST /api/recipe/[id]/tweak` now call `getSessionUserId(req)` and return `unauthorized()` (401) when there's no valid session. A `userId` in the query string or body is ignored entirely — an attacker can no longer read or mutate another user's cookbook by supplying a foreign id.
+- **Clients stopped sending `userId` in request bodies** (RecipeList delete, AddRecipeModal save, MessageList save, RecipeDisplay save, TweakBench tweak). SWR GET keys keep `?userId=` purely as a client-side cache key / fetch gate; the server disregards it. The now-unused `userId` prop was dropped from `TweakBench`.
+- **Tests** cover cross-user access being denied (query/body-supplied foreign id resolves to the session user) and 401s for unauthenticated callers, mocking `getSessionUserId`.
+- **Out of scope here**: `POST /api/recipe/[id]/share` still trusts a body `userId` — hardened separately in #345.
 
 ## Design system
 

--- a/src/app/api/recipe/[id]/route.ts
+++ b/src/app/api/recipe/[id]/route.ts
@@ -1,5 +1,6 @@
 import { updateRecipeForUser } from "@/lib/recipes";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { RecipeBlockSchema } from "@/lib/recipes/schemas";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -10,10 +11,11 @@ export async function PATCH(
   const { id } = await params;
 
   try {
-    const body = await req.json();
-    const { userId, recipe } = body;
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
 
-    if (!userId) return missingUserId();
+    const body = await req.json();
+    const { recipe } = body;
 
     const parsed = RecipeBlockSchema.safeParse(recipe);
     if (!parsed.success) {

--- a/src/app/api/recipe/[id]/tweak/route.test.ts
+++ b/src/app/api/recipe/[id]/tweak/route.test.ts
@@ -1,11 +1,15 @@
 import { openai } from "@ai-sdk/openai";
 import { generateText } from "ai";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
 import { POST } from "./route";
 
 jest.mock("@ai-sdk/openai", () => ({ openai: jest.fn() }));
 
 jest.mock("ai", () => ({ generateText: jest.fn() }));
+
+// Identity comes from the verified session, not the request body.
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
 
 jest.mock("next/server", () => {
   const NextResponse = jest.fn((body, init) => ({
@@ -25,6 +29,7 @@ jest.mock("next/server", () => {
 
 const mockedGenerateText = jest.mocked(generateText);
 const mockedOpenai = jest.mocked(openai);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 const validRecipeBlock = {
   id: "recipe-1",
@@ -45,7 +50,6 @@ const makeRequest = (body: unknown) => ({ json: async () => body }) as NextReque
 const params = Promise.resolve({ id: "recipe-1" });
 
 const baseBody = {
-  userId: "user-123",
   instruction: "less spicy",
   originalRecipe: validRecipeBlock,
 };
@@ -54,11 +58,22 @@ beforeEach(() => {
   jest.clearAllMocks();
   jest.spyOn(console, "error").mockImplementation(() => {});
   mockedOpenai.mockReturnValue("mock-model" as unknown as ReturnType<typeof openai>);
+  // Default: an authenticated caller. Tests override to simulate no session.
+  mockedGetSessionUserId.mockResolvedValue("user-123");
 });
 
 afterEach(() => jest.restoreAllMocks());
 
 describe("POST /api/recipe/[id]/tweak", () => {
+  it("returns 401 without ever calling the model when unauthenticated", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(baseBody), { params });
+
+    expect(res.status).toBe(401);
+    expect(mockedGenerateText).not.toHaveBeenCalled();
+  });
+
   it("requests a generous output token ceiling (not the old 2000 cap)", async () => {
     mockedGenerateText.mockResolvedValue({
       text: tweakJson,

--- a/src/app/api/recipe/[id]/tweak/route.test.ts
+++ b/src/app/api/recipe/[id]/tweak/route.test.ts
@@ -74,6 +74,22 @@ describe("POST /api/recipe/[id]/tweak", () => {
     expect(mockedGenerateText).not.toHaveBeenCalled();
   });
 
+  it("ignores any userId supplied in the body and proceeds as the session user", async () => {
+    mockedGenerateText.mockResolvedValue({
+      text: tweakJson,
+      finishReason: "stop",
+    } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+    const res = await POST(
+      makeRequest({ ...baseBody, userId: "victim-999" }),
+      { params },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockedGetSessionUserId).toHaveBeenCalledTimes(1);
+    expect(mockedGenerateText).toHaveBeenCalledTimes(1);
+  });
+
   it("requests a generous output token ceiling (not the old 2000 cap)", async () => {
     mockedGenerateText.mockResolvedValue({
       text: tweakJson,

--- a/src/app/api/recipe/[id]/tweak/route.ts
+++ b/src/app/api/recipe/[id]/tweak/route.ts
@@ -1,4 +1,5 @@
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { ChangeKindSchema, RecipeBlockSchema } from "@/lib/recipes/schemas";
 import { openai } from "@ai-sdk/openai";
 import { generateText } from "ai";
@@ -72,17 +73,18 @@ export async function POST(
   const { id } = await params;
 
   try {
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
+
     const body: {
-      userId?: string;
       instruction?: string;
       originalRecipe?: unknown;
       workingDraft?: unknown;
     } = await req.json();
 
-    const { userId, originalRecipe: originalRecipeRaw, workingDraft: workingDraftRaw } = body;
+    const { originalRecipe: originalRecipeRaw, workingDraft: workingDraftRaw } = body;
     let { instruction } = body;
 
-    if (!userId) return missingUserId();
     if (!instruction) {
       return NextResponse.json({ error: "instruction is required" }, { status: 400 });
     }

--- a/src/app/api/recipe/route.test.ts
+++ b/src/app/api/recipe/route.test.ts
@@ -507,6 +507,7 @@ describe("Recipe API Routes", () => {
 
       await POST(request);
 
+      expect(mockedSaveRecipeFromBlock).toHaveBeenCalledTimes(1);
       expect(mockedSaveRecipeFromBlock).toHaveBeenCalledWith(
         expect.any(Object),
         "user-123",
@@ -715,6 +716,7 @@ describe("Recipe API Routes", () => {
 
       await DELETE(request);
 
+      expect(mockedDeleteRecipeForUser).toHaveBeenCalledTimes(1);
       expect(mockedDeleteRecipeForUser).toHaveBeenCalledWith("recipe-123", "user-123");
     });
 

--- a/src/app/api/recipe/route.test.ts
+++ b/src/app/api/recipe/route.test.ts
@@ -1,4 +1,5 @@
 import { deleteRecipeForUser, getRecipes, saveRecipe, saveRecipeFromBlock } from "@/lib/recipes";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
 import { DELETE, GET, POST } from "./route";
 
@@ -12,6 +13,12 @@ jest.mock("next/server", () => ({
       headers: new Map(Object.entries(init?.headers || {})),
     })),
   },
+}));
+
+// Identity comes from the verified session, never the request — mock it so we
+// can drive "who is calling" independently of any userId in the query/body.
+jest.mock("@/lib/session", () => ({
+  getSessionUserId: jest.fn(),
 }));
 
 // Mock the recipe functions
@@ -39,6 +46,7 @@ const mockedSaveRecipe = jest.mocked(saveRecipe);
 const mockedSaveRecipeFromBlock = jest.mocked(saveRecipeFromBlock);
 const mockedProcessRecipe = jest.mocked(processRecipe);
 const mockedFetchRecipePhoto = jest.mocked(fetchRecipePhoto);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 const defaultProcessed = {
   tags: [] as string[],
@@ -75,6 +83,9 @@ const createMockRequest = (url: string, options: RequestInit = {}) => {
 describe("Recipe API Routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: an authenticated session for "user-123". Individual tests
+    // override this (e.g. resolve null to simulate an unauthenticated caller).
+    mockedGetSessionUserId.mockResolvedValue("user-123");
     // Mock console.error to avoid noise in tests
     jest.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -130,9 +141,7 @@ describe("Recipe API Routes", () => {
 
       mockedGetRecipes.mockResolvedValue(mockRecipes);
 
-      const request = createMockRequest(
-        "http://localhost:3000/api/recipe?userId=user-123"
-      );
+      const request = createMockRequest("http://localhost:3000/api/recipe");
       const response = await GET(request);
       const data = await response.json();
 
@@ -145,37 +154,39 @@ describe("Recipe API Routes", () => {
     it("should return empty array when no recipes found", async () => {
       mockedGetRecipes.mockResolvedValue([]);
 
-      const request = createMockRequest(
-        "http://localhost:3000/api/recipe?userId=user-456"
-      );
+      const request = createMockRequest("http://localhost:3000/api/recipe");
       const response = await GET(request);
       const data = await response.json();
 
       expect(response.status).toBe(200);
       expect(data).toEqual([]);
-      expect(mockedGetRecipes).toHaveBeenCalledWith("user-456");
+      expect(mockedGetRecipes).toHaveBeenCalledWith("user-123");
     });
 
-    it("should return 400 when userId is missing", async () => {
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+
       const request = createMockRequest("http://localhost:3000/api/recipe");
       const response = await GET(request);
       const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
+      expect(response.status).toBe(401);
+      expect(data).toEqual({ error: "Unauthorized" });
       expect(mockedGetRecipes).not.toHaveBeenCalled();
     });
 
-    it("should return 400 when userId is empty string", async () => {
-      const request = createMockRequest(
-        "http://localhost:3000/api/recipe?userId="
-      );
-      const response = await GET(request);
-      const data = await response.json();
+    it("ignores a userId in the query and reads only the session user's recipes", async () => {
+      mockedGetRecipes.mockResolvedValue([]);
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
-      expect(mockedGetRecipes).not.toHaveBeenCalled();
+      // Attacker tries to read someone else's cookbook by passing their id.
+      const request = createMockRequest(
+        "http://localhost:3000/api/recipe?userId=victim-999"
+      );
+      await GET(request);
+
+      // The session owner (user-123) is used, never the query-supplied id.
+      expect(mockedGetRecipes).toHaveBeenCalledWith("user-123");
+      expect(mockedGetRecipes).not.toHaveBeenCalledWith("victim-999");
     });
 
     it("should handle database errors gracefully", async () => {
@@ -440,7 +451,9 @@ describe("Recipe API Routes", () => {
       }, null);
     });
 
-    it("should return 400 when userId is missing", async () => {
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+
       const requestBody = {
         name: "Test Recipe",
         instructions: "Test instructions",
@@ -455,30 +468,50 @@ describe("Recipe API Routes", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
+      expect(response.status).toBe(401);
+      expect(data).toEqual({ error: "Unauthorized" });
       expect(mockedSaveRecipe).not.toHaveBeenCalled();
     });
 
-    it("should return 400 when userId is empty string", async () => {
-      const requestBody = {
-        userId: "",
-        name: "Test Recipe",
-        instructions: "Test instructions",
-      };
+    it("saves under the session user, ignoring any userId in the body", async () => {
+      mockedSaveRecipeFromBlock.mockResolvedValue({
+        id: "recipe-new",
+        userId: "user-123",
+        name: "Test",
+        instructions: "",
+        tags: [],
+        recipeId: null,
+        baseServings: 2,
+        ingredients: [],
+        prep: [],
+        notes: [],
+        steps: null,
+        description: null,
+        totalTimeMinutes: null,
+        createdAt: null,
+        imageUrl: null,
+        photographerName: null,
+        photographerUrl: null,
+        shareToken: null,
+      });
 
+      // Attacker tries to write into someone else's cookbook via the body.
       const request = createMockRequest("http://localhost:3000/api/recipe", {
         method: "POST",
-        body: JSON.stringify(requestBody),
+        body: JSON.stringify({
+          userId: "victim-999",
+          recipe: { title: "Test", ingredients: [], steps: [], tags: [], baseServings: 2 },
+        }),
         headers: { "Content-Type": "application/json" },
       });
 
-      const response = await POST(request);
-      const data = await response.json();
+      await POST(request);
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
-      expect(mockedSaveRecipe).not.toHaveBeenCalled();
+      expect(mockedSaveRecipeFromBlock).toHaveBeenCalledWith(
+        expect.any(Object),
+        "user-123",
+        undefined,
+      );
     });
 
     it("should handle long recipe content", async () => {
@@ -655,7 +688,9 @@ describe("Recipe API Routes", () => {
       expect(mockedDeleteRecipeForUser).toHaveBeenCalledWith("recipe-123", "user-123");
     });
 
-    it("should return 400 when userId is missing", async () => {
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+
       const request = createMockRequest("http://localhost:3000/api/recipe", {
         method: "DELETE",
         body: JSON.stringify({ recipeId: "recipe-123" }),
@@ -663,7 +698,24 @@ describe("Recipe API Routes", () => {
       });
 
       const response = await DELETE(request);
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(401);
+      expect(mockedDeleteRecipeForUser).not.toHaveBeenCalled();
+    });
+
+    it("deletes against the session user, ignoring any userId in the body", async () => {
+      mockedDeleteRecipeForUser.mockResolvedValue(undefined);
+
+      // Attacker passes a victim id; the route must scope the delete to the
+      // authenticated caller so it can never touch another user's recipe.
+      const request = createMockRequest("http://localhost:3000/api/recipe", {
+        method: "DELETE",
+        body: JSON.stringify({ recipeId: "recipe-123", userId: "victim-999" }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      await DELETE(request);
+
+      expect(mockedDeleteRecipeForUser).toHaveBeenCalledWith("recipe-123", "user-123");
     });
 
     it("should return 404 when recipe not found or not owned", async () => {

--- a/src/app/api/recipe/route.ts
+++ b/src/app/api/recipe/route.ts
@@ -2,21 +2,23 @@ import { deleteRecipeForUser, getRecipes, saveRecipe, saveRecipeFromBlock } from
 import { processRecipe } from "@/lib/recipes/recipeProcessor";
 import { normalizeTags } from "@/lib/recipes/normalizeTags";
 import { fetchRecipePhoto } from "@/lib/pexels/fetchPhoto";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
-  const userId = req.nextUrl.searchParams.get("userId");
-  if (!userId) return missingUserId();
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
   const recipes = await getRecipes(userId);
   return NextResponse.json(recipes);
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const { userId, recipeId } = body;
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
 
-  if (!userId) return missingUserId();
+  const body = await req.json();
+  const { recipeId } = body;
 
   if (body.recipe) {
     const recipe = await saveRecipeFromBlock(body.recipe, userId, recipeId ?? undefined);
@@ -56,8 +58,9 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  const { recipeId, userId } = await req.json();
-  if (!userId) return missingUserId();
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
+  const { recipeId } = await req.json();
   if (!recipeId) return NextResponse.json({ error: "recipeId is required" }, { status: 400 });
   try {
     await deleteRecipeForUser(recipeId, userId);

--- a/src/features/Chat/components/MessageList.test.tsx
+++ b/src/features/Chat/components/MessageList.test.tsx
@@ -24,14 +24,12 @@ jest.mock("swr/mutation", () => ({
     trigger: jest.fn(async (arg: {
       recipeStr: string;
       name: string;
-      userId: string;
       recipeId?: string;
     }) => {
       const res = await fetch("/api/recipe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          userId: arg.userId,
           name: arg.name,
           instructions: arg.recipeStr,
           recipeId: arg.recipeId,

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -82,14 +82,14 @@ const saveRecipeCall = async (
   {
     arg,
   }: {
-    arg: { recipeStr: string; name: string; userId: string; recipeId?: string };
+    arg: { recipeStr: string; name: string; recipeId?: string };
   },
 ) => {
-  const { recipeStr, name, userId, recipeId } = arg;
+  const { recipeStr, name, recipeId } = arg;
   const res = await fetch(key, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ userId, name, instructions: recipeStr, recipeId }),
+    body: JSON.stringify({ name, instructions: recipeStr, recipeId }),
   });
 
   if (!res.ok) throw new Error("Failed to save recipe");
@@ -219,7 +219,6 @@ export const MessageList = ({
       const saved = await trigger({
         recipeStr,
         name,
-        userId,
         recipeId: recipeKey,
       });
 
@@ -260,7 +259,6 @@ export const MessageList = ({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          userId,
           recipeId: recipeKey,
           recipe: recipeBlock,
         }),

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -506,7 +506,6 @@ export default function RecipeDisplay({
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          userId,
           recipe: recipeWithIdToBlock(workingDraft),
         }),
       });
@@ -685,7 +684,6 @@ export default function RecipeDisplay({
         {benchOpen && userId && !readOnly && (
           <TweakBench
             recipe={originalRecipeRef.current}
-            userId={userId}
             onWorkingDraftChange={handleWorkingDraftChange}
             onClose={handleBenchClose}
             onSave={handleSave}

--- a/src/features/RecipeDisplay/TweakBench.test.tsx
+++ b/src/features/RecipeDisplay/TweakBench.test.tsx
@@ -67,7 +67,6 @@ function renderBench(onWorkingDraftChange: jest.Mock = jest.fn()) {
     <StrictMode>
       <TweakBench
         recipe={recipe}
-        userId="user-123"
         onWorkingDraftChange={onWorkingDraftChange}
         onClose={jest.fn()}
         onSave={jest.fn()}

--- a/src/features/RecipeDisplay/TweakBench.tsx
+++ b/src/features/RecipeDisplay/TweakBench.tsx
@@ -31,7 +31,6 @@ type TurnEntry =
 
 interface TweakBenchProps {
   recipe: RecipeWithId;
-  userId: string;
   onWorkingDraftChange: (draft: RecipeWithId, changes: ChangeEntry[]) => void;
   onClose: () => void;
   onSave: () => Promise<void>;
@@ -76,7 +75,6 @@ const EMPTY_REFUSAL_FALLBACK =
 
 export function TweakBench({
   recipe,
-  userId,
   onWorkingDraftChange,
   onClose,
   onSave,
@@ -150,7 +148,6 @@ export function TweakBench({
           headers: { "Content-Type": "application/json" },
           signal: abortController.signal,
           body: JSON.stringify({
-            userId,
             instruction: text,
             originalRecipe: recipeWithIdToBlock(recipe),
             workingDraft: recipeWithIdToBlock(currentDraft),
@@ -257,7 +254,7 @@ export function TweakBench({
         }
       }
     },
-    [instruction, isStreaming, recipe, userId, onWorkingDraftChange],
+    [instruction, isStreaming, recipe, onWorkingDraftChange],
   );
 
   const handleTryAgain = useCallback(() => {

--- a/src/features/RecipeList/RecipeList.test.tsx
+++ b/src/features/RecipeList/RecipeList.test.tsx
@@ -48,7 +48,7 @@ describe("RecipeList — delete recipe", () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
   });
 
-  it("sends recipeId AND userId in the DELETE body", async () => {
+  it("sends only the recipeId in the DELETE body (identity comes from the session)", async () => {
     render(<RecipeList />);
 
     const deleteButton = screen.getByRole("button", { name: /Delete Test Recipe/i });
@@ -58,7 +58,7 @@ describe("RecipeList — delete recipe", () => {
       "/api/recipe",
       expect.objectContaining({
         method: "DELETE",
-        body: JSON.stringify({ recipeId: "r1", userId: "user-1" }),
+        body: JSON.stringify({ recipeId: "r1" }),
       }),
     );
   });

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -39,7 +39,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
       const res = await fetch(`/api/recipe`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ recipeId, userId }),
+        body: JSON.stringify({ recipeId }),
       });
       if (!res.ok) throw new Error("Delete failed");
       mutate(`/api/recipe?userId=${userId}`);

--- a/src/features/RecipeList/components/AddRecipeModal.tsx
+++ b/src/features/RecipeList/components/AddRecipeModal.tsx
@@ -210,7 +210,7 @@ export function AddRecipeModal({ open, onOpenChange }: AddRecipeModalProps) {
       const res = await fetch("/api/recipe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId, recipe: preview }),
+        body: JSON.stringify({ recipe: preview }),
       });
       if (!res.ok) throw new Error("Save failed");
       mutate(`/api/recipe?userId=${userId}`);


### PR DESCRIPTION
## Summary

Recipe routes now derive identity from the verified better-auth session instead of trusting a client-supplied `userId`. This closes the hole where anyone could read or mutate another user's cookbook by passing a foreign id.

- `GET/POST/DELETE /api/recipe`, `PATCH /api/recipe/[id]`, and `POST /api/recipe/[id]/tweak` call `getSessionUserId(req)` and return `401` when there's no valid session.
- A `userId` in the query string or body is ignored entirely — the session owner is always used.
- Clients stop sending `userId` in request bodies (RecipeList delete, AddRecipeModal save, MessageList save, RecipeDisplay save, TweakBench tweak). SWR GET keys keep `?userId=` only as a client-side cache key / fetch gate. Dropped the now-unused `userId` prop from `TweakBench`.

## Out of scope

`POST /api/recipe/[id]/share` still trusts a body `userId` — hardened separately in #345.

## Test plan

- `pnpm jest src/app/api/recipe` — cross-user access denial (query/body foreign id resolves to the session user) + 401s for unauthenticated callers.
- Manual: load the cookbook signed in (recipes still list, save, edit, delete, tweak), and confirm a request with someone else's `userId` returns only your own data.

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recipe actions now use the signed-in session for access control, preventing cross-user changes and honoring unauthorized requests.
  * Recipe create, edit (PATCH), delete, and tweak endpoints no longer accept an account ID from the client; requests without a valid session return unauthorized.
* **Tests**
  * Updated and added tests to verify unauthenticated access is rejected and cross-user access is denied.
* **Documentation**
  * Updated progress documentation to reflect that recipe route access lockdown has shipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->