### PR TITLE
feat(inventory-api): lock down pantry routes to the session user (#342)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -168,7 +168,7 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Every visitor now has a real session.** The client-generated `localStorage["ask-ah-mah-session"]` id is gone. The better-auth `anonymous()` plugin mints an unforgeable anonymous session on first load (`useSession` calls `signIn.anonymous()` when there's no session); signed-in users still use their Google session. `userId` is always `session.user.id`, and `isAuthenticated` now means non-anonymous (`!user.isAnonymous`).
 - **Server is the source of truth for identity.** New helper `getSessionUserId(req)` (`src/lib/session.ts`) resolves the caller from the verified session cookie via `auth.api.getSession`, returning the id or `null` (routes map that to a 401 via `unauthorized()`). This is the primitive the route-lockdown slices (#341–#345) build on — routes stop trusting a `userId` from the request.
 - **Schema**: `User.isAnonymous Boolean?` (additive migration `20260629000000_add_user_is_anonymous`). New anonymous users get their starter pantry seeded.
-- **Not yet wired**: pantry/shopping-list/conversation routes still read `userId` from the request (#342–#344), share-token mint trust is #345, and guest→Google data migration on link is #346.
+- **Not yet wired**: shopping-list/conversation routes still read `userId` from the request (#343–#344), share-token mint trust is #345, and guest→Google data migration on link is #346.
 
 ### Recipe routes locked down — Shipped (#341)
 
@@ -176,6 +176,12 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Clients stopped sending `userId` in request bodies** (RecipeList delete, AddRecipeModal save, MessageList save, RecipeDisplay save, TweakBench tweak). SWR GET keys keep `?userId=` purely as a client-side cache key / fetch gate; the server disregards it. The now-unused `userId` prop was dropped from `TweakBench`.
 - **Tests** cover cross-user access being denied (query/body-supplied foreign id resolves to the session user) and 401s for unauthenticated callers, mocking `getSessionUserId`.
 - **Out of scope here**: `POST /api/recipe/[id]/share` still trusts a body `userId` — hardened separately in #345.
+
+### Pantry (inventory) routes locked down — Shipped (#342)
+
+- **Inventory routes derive identity from the session.** `GET/POST/DELETE /api/inventory`, `POST /api/inventory/parse`, and `POST /api/inventory/seed` call `getSessionUserId(req)` and return `unauthorized()` (401) when there's no valid session. A `userId` in the query/body is ignored, so a caller can't read or mutate another user's pantry by supplying a foreign id.
+- **Clients stopped sending `userId` in request bodies** (Inventory add/parse + remove). SWR GET keys keep `?userId=` only as a client-side cache key. The new-anonymous-user pantry seed (`useSession`) now posts to `/api/inventory/seed` with no body — the session cookie set by `signIn.anonymous()` is the identity.
+- **Tests** cover cross-user access denial (query/body foreign id resolves to the session user) and 401s for unauthenticated callers, mocking `getSessionUserId`.
 
 ## Design system
 

--- a/src/app/api/inventory/parse/route.ts
+++ b/src/app/api/inventory/parse/route.ts
@@ -1,6 +1,7 @@
 import { addInventoryItem } from "@/lib/inventory/Inventory";
 import { AddInventoryItemSchema } from "@/lib/inventory/schemas";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
@@ -13,9 +14,10 @@ const ParseSchema = z.object({
 
 export async function POST(req: NextRequest) {
   try {
-    const { text, userId } = await req.json();
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
 
-    if (!userId) return missingUserId();
+    const { text } = await req.json();
     if (!text || typeof text !== "string" || text.trim().length === 0) {
       return NextResponse.json({ error: "text is required" }, { status: 400 });
     }

--- a/src/app/api/inventory/route.test.ts
+++ b/src/app/api/inventory/route.test.ts
@@ -3,6 +3,7 @@ import {
   getInventory,
   removeInventoryItem,
 } from "@/lib/inventory/Inventory";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
 import { DELETE, GET, POST } from "./route";
 
@@ -18,6 +19,12 @@ jest.mock("next/server", () => ({
   },
 }));
 
+// Identity comes from the verified session, never the request — mock it so we
+// can drive "who is calling" independently of any userId in the query/body.
+jest.mock("@/lib/session", () => ({
+  getSessionUserId: jest.fn(),
+}));
+
 // Mock the inventory functions
 jest.mock("@/lib/inventory/Inventory", () => ({
   addInventoryItem: jest.fn(),
@@ -28,6 +35,7 @@ jest.mock("@/lib/inventory/Inventory", () => ({
 const mockedAddInventoryItem = jest.mocked(addInventoryItem);
 const mockedGetInventory = jest.mocked(getInventory);
 const mockedRemoveInventoryItem = jest.mocked(removeInventoryItem);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 // Helper to create mock NextRequest
 const createMockRequest = (url: string, options: RequestInit = {}) => {
@@ -48,6 +56,9 @@ const createMockRequest = (url: string, options: RequestInit = {}) => {
 describe("Inventory API Routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: an authenticated session for "user-123". Individual tests
+    // override this (e.g. resolve null to simulate an unauthenticated caller).
+    mockedGetSessionUserId.mockResolvedValue("user-123");
     // Mock console.error to avoid noise in tests
     jest.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -118,26 +129,33 @@ describe("Inventory API Routes", () => {
       expect(response.headers.get("Expires")).toBe("0");
     });
 
-    it("should return 400 when userId is missing", async () => {
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+
       const request = createMockRequest("http://localhost:3000/api/inventory");
       const response = await GET(request);
       const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
+      expect(response.status).toBe(401);
+      expect(data).toEqual({ error: "Unauthorized" });
       expect(mockedGetInventory).not.toHaveBeenCalled();
     });
 
-    it("should return 400 when userId is empty string", async () => {
-      const request = createMockRequest(
-        "http://localhost:3000/api/inventory?userId="
-      );
-      const response = await GET(request);
-      const data = await response.json();
+    it("ignores a userId in the query and reads only the session user's pantry", async () => {
+      mockedGetInventory.mockResolvedValue({
+        kitchenwareInventory: [],
+        ingredientInventory: [],
+      });
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
-      expect(mockedGetInventory).not.toHaveBeenCalled();
+      // Attacker tries to read someone else's pantry by passing their id.
+      const request = createMockRequest(
+        "http://localhost:3000/api/inventory?userId=victim-999"
+      );
+      await GET(request);
+
+      expect(mockedGetInventory).toHaveBeenCalledTimes(1);
+      expect(mockedGetInventory).toHaveBeenCalledWith("user-123");
+      expect(mockedGetInventory).not.toHaveBeenCalledWith("victim-999");
     });
 
     it("should return 500 when getInventory throws error", async () => {
@@ -213,7 +231,9 @@ describe("Inventory API Routes", () => {
       expect(mockedAddInventoryItem).toHaveBeenCalledTimes(1);
     });
 
-    it("should return 400 when userId is missing", async () => {
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+
       const requestBody = {
         items: [{ name: "eggs", type: "ingredient" }],
       };
@@ -227,29 +247,26 @@ describe("Inventory API Routes", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
+      expect(response.status).toBe(401);
+      expect(data).toEqual({ error: "Unauthorized" });
       expect(mockedAddInventoryItem).not.toHaveBeenCalled();
     });
 
-    it("should return 400 when userId is empty string", async () => {
-      const requestBody = {
-        userId: "",
-        items: [{ name: "eggs", type: "ingredient" }],
-      };
+    it("adds under the session user, ignoring any userId in the body", async () => {
+      mockedAddInventoryItem.mockResolvedValue(undefined);
 
+      const items = [{ name: "eggs", type: "ingredient" }];
+      // Attacker tries to write into someone else's pantry via the body.
       const request = createMockRequest("http://localhost:3000/api/inventory", {
         method: "POST",
-        body: JSON.stringify(requestBody),
+        body: JSON.stringify({ userId: "victim-999", items }),
         headers: { "Content-Type": "application/json" },
       });
 
-      const response = await POST(request);
-      const data = await response.json();
+      await POST(request);
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
-      expect(mockedAddInventoryItem).not.toHaveBeenCalled();
+      expect(mockedAddInventoryItem).toHaveBeenCalledTimes(1);
+      expect(mockedAddInventoryItem).toHaveBeenCalledWith(items, "user-123");
     });
 
     it("should handle empty items array", async () => {
@@ -342,7 +359,9 @@ describe("Inventory API Routes", () => {
       expect(mockedRemoveInventoryItem).toHaveBeenCalledTimes(1);
     });
 
-    it("should return 400 when userId is missing", async () => {
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+
       const requestBody = {
         itemNames: ["eggs"],
       };
@@ -356,29 +375,26 @@ describe("Inventory API Routes", () => {
       const response = await DELETE(request);
       const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
+      expect(response.status).toBe(401);
+      expect(data).toEqual({ error: "Unauthorized" });
       expect(mockedRemoveInventoryItem).not.toHaveBeenCalled();
     });
 
-    it("should return 400 when userId is empty string", async () => {
-      const requestBody = {
-        userId: "",
-        itemNames: ["eggs"],
-      };
+    it("removes against the session user, ignoring any userId in the body", async () => {
+      mockedRemoveInventoryItem.mockResolvedValue(undefined);
 
+      // Attacker passes a victim id; the route must scope the delete to the
+      // authenticated caller so it can never touch another user's pantry.
       const request = createMockRequest("http://localhost:3000/api/inventory", {
         method: "DELETE",
-        body: JSON.stringify(requestBody),
+        body: JSON.stringify({ userId: "victim-999", itemNames: ["eggs"] }),
         headers: { "Content-Type": "application/json" },
       });
 
-      const response = await DELETE(request);
-      const data = await response.json();
+      await DELETE(request);
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
-      expect(mockedRemoveInventoryItem).not.toHaveBeenCalled();
+      expect(mockedRemoveInventoryItem).toHaveBeenCalledTimes(1);
+      expect(mockedRemoveInventoryItem).toHaveBeenCalledWith(["eggs"], "user-123");
     });
 
     it("should handle empty itemNames array", async () => {

--- a/src/app/api/inventory/route.ts
+++ b/src/app/api/inventory/route.ts
@@ -3,14 +3,15 @@ import {
   getInventory,
   removeInventoryItem,
 } from "@/lib/inventory/Inventory";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
   try {
-    const userId = req.nextUrl.searchParams.get("userId");
+    const userId = await getSessionUserId(req);
 
-    if (!userId) return missingUserId();
+    if (!userId) return unauthorized();
 
     const inventory = await getInventory(userId);
     return NextResponse.json(inventory, {
@@ -31,9 +32,10 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { items, userId } = await req.json();
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
 
-    if (!userId) return missingUserId();
+    const { items } = await req.json();
 
     await addInventoryItem(items, userId);
     return NextResponse.json({ success: true, message: "Inventory updated" });
@@ -48,8 +50,9 @@ export async function POST(req: NextRequest) {
 
 export async function DELETE(req: NextRequest) {
   try {
-    const { itemNames, userId } = await req.json();
-    if (!userId) return missingUserId();
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
+    const { itemNames } = await req.json();
     await removeInventoryItem(itemNames, userId);
     return NextResponse.json({ success: true, message: "Inventory updated" });
   } catch (error) {

--- a/src/app/api/inventory/seed/route.ts
+++ b/src/app/api/inventory/seed/route.ts
@@ -1,11 +1,12 @@
 import { seedDefaultInventory } from "@/lib/inventory/Inventory";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
   try {
-    const { userId } = await request.json();
-    if (!userId) return missingUserId();
+    const userId = await getSessionUserId(request);
+    if (!userId) return unauthorized();
 
     await seedDefaultInventory(userId);
     return NextResponse.json({ ok: true });

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -170,7 +170,7 @@ const Inventory = () => {
       const response = await fetch("/api/inventory/parse", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: draft, userId }),
+        body: JSON.stringify({ text: draft }),
       });
 
       if (response.ok) {
@@ -202,7 +202,7 @@ const Inventory = () => {
       const response = await fetch("/api/inventory", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ itemNames: [itemName], userId }),
+        body: JSON.stringify({ itemNames: [itemName] }),
       });
       if (response.ok) {
         mutate(`/api/inventory?userId=${userId}`);

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -27,13 +27,10 @@ export default function useSession() {
       .anonymous()
       .then((res) => {
         // A brand-new anonymous user owns nothing yet — seed their starter pantry.
-        const newUserId = res?.data?.user?.id;
-        if (newUserId) {
-          fetch("/api/inventory/seed", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ userId: newUserId }),
-          });
+        // The session cookie is set by signIn.anonymous(), so the seed route
+        // derives the userId from the session; no need to pass it in the body.
+        if (res?.data?.user?.id) {
+          fetch("/api/inventory/seed", { method: "POST" });
         }
       })
       .finally(() => setCreatingGuest(false));


### PR DESCRIPTION
## Summary

Inventory routes now derive identity from the verified better-auth session instead of trusting a client-supplied `userId`, closing the hole where anyone could read or mutate another user's pantry by passing a foreign id.

- `GET/POST/DELETE /api/inventory`, `POST /api/inventory/parse`, and `POST /api/inventory/seed` call `getSessionUserId(req)` and return `401` when there's no valid session.
- A `userId` in the query/body is ignored — the session owner is always used.
- Clients stop sending `userId` in request bodies (Inventory add/parse + remove). The new-anonymous-user pantry seed (`useSession`) now posts to `/api/inventory/seed` with no body; the session cookie set by `signIn.anonymous()` is the identity. SWR GET keys keep `?userId=` only as a client-side cache key.

## Test plan

- `pnpm jest src/app/api/inventory` — cross-user access denial (query/body foreign id resolves to the session user) + 401s for unauthenticated callers.
- Manual: signed in, pantry still loads/adds/parses/removes; a fresh visitor gets a seeded starter pantry; a request with someone else's `userId` only touches your own pantry.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)