### PR TITLE
fix(shopping-list): derive userId from session, ignore request-supplied id

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -168,7 +168,7 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Every visitor now has a real session.** The client-generated `localStorage["ask-ah-mah-session"]` id is gone. The better-auth `anonymous()` plugin mints an unforgeable anonymous session on first load (`useSession` calls `signIn.anonymous()` when there's no session); signed-in users still use their Google session. `userId` is always `session.user.id`, and `isAuthenticated` now means non-anonymous (`!user.isAnonymous`).
 - **Server is the source of truth for identity.** New helper `getSessionUserId(req)` (`src/lib/session.ts`) resolves the caller from the verified session cookie via `auth.api.getSession`, returning the id or `null` (routes map that to a 401 via `unauthorized()`). This is the primitive the route-lockdown slices (#341–#345) build on — routes stop trusting a `userId` from the request.
 - **Schema**: `User.isAnonymous Boolean?` (additive migration `20260629000000_add_user_is_anonymous`). New anonymous users get their starter pantry seeded.
-- **Not yet wired**: shopping-list/conversation routes still read `userId` from the request (#343–#344), share-token mint trust is #345, and guest→Google data migration on link is #346.
+- **Not yet wired**: conversation routes still read `userId` from the request (#344), share-token mint trust is #345, and guest→Google data migration on link is #346.
 
 ### Recipe routes locked down — Shipped (#341)
 
@@ -182,6 +182,12 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Inventory routes derive identity from the session.** `GET/POST/DELETE /api/inventory`, `POST /api/inventory/parse`, and `POST /api/inventory/seed` call `getSessionUserId(req)` and return `unauthorized()` (401) when there's no valid session. A `userId` in the query/body is ignored, so a caller can't read or mutate another user's pantry by supplying a foreign id.
 - **Clients stopped sending `userId` in request bodies** (Inventory add/parse + remove). SWR GET keys keep `?userId=` only as a client-side cache key. The new-anonymous-user pantry seed (`useSession`) now posts to `/api/inventory/seed` with no body — the session cookie set by `signIn.anonymous()` is the identity.
 - **Tests** cover cross-user access denial (query/body foreign id resolves to the session user) and 401s for unauthenticated callers, mocking `getSessionUserId`.
+
+### Shopping-list routes locked down — Shipped (#343)
+
+- **Shopping-list routes derive identity from the session.** `GET/POST/PATCH/DELETE /api/shopping-list` and `POST /api/shopping-list/classify` call `getSessionUserId(req)` and return `unauthorized()` (401) when there's no valid session. A `userId` in the query/body is ignored (the POST passes the full payload through `AddShoppingListItemsSchema.safeParse`, and `z.object` strips unknown keys), so a caller can't read or mutate another user's list by supplying a foreign id.
+- **Clients stopped sending `userId` in request bodies** (`ShoppingList` add/toggle/remove/clear + classify; `RecipeLetter` cart add). SWR GET/mutate keys keep `?userId=` only as a client-side cache key. The classify fetch now sends no body — the session cookie is the identity.
+- **Tests** cover cross-user access denial (body foreign id resolves to the session user) and 401s for unauthenticated callers, mocking `getSessionUserId`.
 
 ## Design system
 

--- a/src/app/api/shopping-list/classify/route.test.ts
+++ b/src/app/api/shopping-list/classify/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { POST } from "./route";
 import { classifyPendingAisles } from "@/lib/shoppingList";
+import { getSessionUserId } from "@/lib/session";
 
 jest.mock("next/server", () => ({
   NextRequest: jest.fn(),
@@ -16,7 +17,10 @@ jest.mock("@/lib/shoppingList", () => ({
   classifyPendingAisles: jest.fn(),
 }));
 
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
+
 const mockedClassify = jest.mocked(classifyPendingAisles);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 const reqWith = (body: unknown) =>
   ({ json: async () => body } as unknown as NextRequest);
@@ -24,30 +28,39 @@ const reqWith = (body: unknown) =>
 beforeEach(() => {
   jest.clearAllMocks();
   jest.spyOn(console, "error").mockImplementation(() => {});
+  mockedGetSessionUserId.mockResolvedValue("user-123");
 });
 
 afterEach(() => jest.restoreAllMocks());
 
 describe("POST /api/shopping-list/classify", () => {
-  it("classifies the user's pending rows and reports success", async () => {
-    const res = await POST(reqWith({ userId: "u1" }));
+  it("classifies the session user's pending rows and reports success", async () => {
+    const res = await POST(reqWith({}));
     const body = await res.json();
 
-    expect(mockedClassify).toHaveBeenCalledWith("u1");
+    expect(mockedClassify).toHaveBeenCalledWith("user-123");
     expect(body).toEqual({ success: true });
   });
 
-  it("400s when userId is missing", async () => {
+  it("401s when unauthenticated", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
     const res = await POST(reqWith({}));
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
     expect(mockedClassify).not.toHaveBeenCalled();
+  });
+
+  it("ignores a userId in the body and classifies for the session user", async () => {
+    await POST(reqWith({ userId: "victim-999" }));
+
+    expect(mockedClassify).toHaveBeenCalledTimes(1);
+    expect(mockedClassify).toHaveBeenCalledWith("user-123");
   });
 
   it("500s when the service throws", async () => {
     mockedClassify.mockRejectedValue(new Error("model down"));
 
-    const res = await POST(reqWith({ userId: "u1" }));
+    const res = await POST(reqWith({}));
 
     expect(res.status).toBe(500);
   });

--- a/src/app/api/shopping-list/classify/route.ts
+++ b/src/app/api/shopping-list/classify/route.ts
@@ -1,26 +1,20 @@
 import { classifyPendingAisles } from "@/lib/shoppingList";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Assign a shopping Aisle to the user's not-yet-categorised rows and persist it.
  *
- * Body: `{ userId: string }`. Client-triggered after the list loads (mirroring
- * the Market Tip fetch) so a typed-in item lands in `Other` instantly and
- * shifts to its real aisle once this returns. A no-op when nothing is pending.
- * 400s on malformed JSON or a missing `userId`; 500s if the service throws.
+ * Client-triggered after the list loads (mirroring the Market Tip fetch) so a
+ * typed-in item lands in `Other` instantly and shifts to its real aisle once
+ * this returns. The caller is taken from the session — no body needed. A no-op
+ * when nothing is pending. 401s when unauthenticated; 500s if the service throws.
  */
 export async function POST(req: NextRequest) {
   try {
-    let payload: unknown;
-    try {
-      payload = await req.json();
-    } catch {
-      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-    }
-
-    const userId = (payload as { userId?: unknown })?.userId;
-    if (!userId || typeof userId !== "string") return missingUserId();
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
 
     await classifyPendingAisles(userId);
     return NextResponse.json({ success: true });

--- a/src/app/api/shopping-list/route.test.ts
+++ b/src/app/api/shopping-list/route.test.ts
@@ -7,6 +7,7 @@ import {
   removeShoppingListItem,
   setBought,
 } from "@/lib/shoppingList";
+import { getSessionUserId } from "@/lib/session";
 
 jest.mock("next/server", () => ({
   NextRequest: jest.fn(),
@@ -27,11 +28,14 @@ jest.mock("@/lib/shoppingList", () => ({
   clearBoughtItems: jest.fn(),
 }));
 
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
+
 const mockedGet = jest.mocked(getShoppingList);
 const mockedAdd = jest.mocked(addShoppingListItems);
 const mockedSetBought = jest.mocked(setBought);
 const mockedRemove = jest.mocked(removeShoppingListItem);
 const mockedClearBought = jest.mocked(clearBoughtItems);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 const createMockRequest = (url: string, options: RequestInit = {}) => {
   const parsedUrl = new URL(url);
@@ -46,32 +50,41 @@ const base = "http://localhost:3000/api/shopping-list";
 beforeEach(() => {
   jest.clearAllMocks();
   jest.spyOn(console, "error").mockImplementation(() => {});
+  mockedGetSessionUserId.mockResolvedValue("user-123");
 });
 
 afterEach(() => jest.restoreAllMocks());
 
 describe("GET /api/shopping-list", () => {
-  it("returns the list for a valid userId", async () => {
+  it("returns the list for the session user", async () => {
     const rows = [{ id: "1", name: "Apples", bought: false }];
     mockedGet.mockResolvedValue(rows as never);
 
-    const res = await GET(createMockRequest(`${base}?userId=u1`));
+    const res = await GET(createMockRequest(base));
     const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(body).toEqual({ items: rows });
-    expect(mockedGet).toHaveBeenCalledWith("u1");
+    expect(mockedGet).toHaveBeenCalledWith("user-123");
   });
 
-  it("400s when userId is missing", async () => {
+  it("401s when unauthenticated", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
     const res = await GET(createMockRequest(base));
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
     expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it("ignores a userId in the query and uses the session user", async () => {
+    mockedGet.mockResolvedValue([] as never);
+    await GET(createMockRequest(`${base}?userId=victim-999`));
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    expect(mockedGet).toHaveBeenCalledWith("user-123");
   });
 
   it("500s when the service throws", async () => {
     mockedGet.mockRejectedValue(new Error("db down"));
-    const res = await GET(createMockRequest(`${base}?userId=u1`));
+    const res = await GET(createMockRequest(base));
     expect(res.status).toBe(500);
   });
 });
@@ -82,27 +95,40 @@ describe("POST /api/shopping-list", () => {
     const items = [{ name: "Apples", category: "Fruit" }];
 
     const res = await POST(
-      createMockRequest(base, { body: JSON.stringify({ userId: "u1", items }) }),
+      createMockRequest(base, { body: JSON.stringify({ items }) }),
     );
 
     expect(res.status).toBe(200);
-    expect(mockedAdd).toHaveBeenCalledWith(items, "u1");
+    expect(mockedAdd).toHaveBeenCalledWith(items, "user-123");
   });
 
-  it("400s when userId is missing", async () => {
+  it("401s when unauthenticated", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
     const res = await POST(
       createMockRequest(base, {
         body: JSON.stringify({ items: [{ name: "Apples" }] }),
       }),
     );
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
     expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it("ignores a userId in the body and adds for the session user", async () => {
+    mockedAdd.mockResolvedValue(undefined);
+    const items = [{ name: "Apples" }];
+    await POST(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "victim-999", items }),
+      }),
+    );
+    expect(mockedAdd).toHaveBeenCalledTimes(1);
+    expect(mockedAdd).toHaveBeenCalledWith(items, "user-123");
   });
 
   it("400s when items is not an array", async () => {
     const res = await POST(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", items: "nope" }),
+        body: JSON.stringify({ items: "nope" }),
       }),
     );
     expect(res.status).toBe(400);
@@ -112,7 +138,7 @@ describe("POST /api/shopping-list", () => {
   it("400s when items is an empty array", async () => {
     const res = await POST(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", items: [] }),
+        body: JSON.stringify({ items: [] }),
       }),
     );
     expect(res.status).toBe(400);
@@ -135,7 +161,7 @@ describe("POST /api/shopping-list", () => {
   it("400s when an item has no name", async () => {
     const res = await POST(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", items: [{ category: "Fruit" }] }),
+        body: JSON.stringify({ items: [{ category: "Fruit" }] }),
       }),
     );
     expect(res.status).toBe(400);
@@ -146,7 +172,7 @@ describe("POST /api/shopping-list", () => {
     mockedAdd.mockRejectedValue(new Error("db down"));
     const res = await POST(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", items: [{ name: "Apples" }] }),
+        body: JSON.stringify({ items: [{ name: "Apples" }] }),
       }),
     );
     expect(res.status).toBe(500);
@@ -159,28 +185,40 @@ describe("PATCH /api/shopping-list", () => {
 
     const res = await PATCH(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", id: "row-1", bought: true }),
+        body: JSON.stringify({ id: "row-1", bought: true }),
       }),
     );
 
     expect(res.status).toBe(200);
-    expect(mockedSetBought).toHaveBeenCalledWith("u1", "row-1", true);
+    expect(mockedSetBought).toHaveBeenCalledWith("user-123", "row-1", true);
   });
 
-  it("400s when userId is missing", async () => {
+  it("401s when unauthenticated", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
     const res = await PATCH(
       createMockRequest(base, {
         body: JSON.stringify({ id: "row-1", bought: true }),
       }),
     );
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
     expect(mockedSetBought).not.toHaveBeenCalled();
+  });
+
+  it("ignores a userId in the body and uses the session user", async () => {
+    mockedSetBought.mockResolvedValue(undefined);
+    await PATCH(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "victim-999", id: "row-1", bought: true }),
+      }),
+    );
+    expect(mockedSetBought).toHaveBeenCalledTimes(1);
+    expect(mockedSetBought).toHaveBeenCalledWith("user-123", "row-1", true);
   });
 
   it("400s when id is missing or bought is not a boolean", async () => {
     const res = await PATCH(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", bought: "yes" }),
+        body: JSON.stringify({ bought: "yes" }),
       }),
     );
     expect(res.status).toBe(400);
@@ -204,7 +242,7 @@ describe("PATCH /api/shopping-list", () => {
     mockedSetBought.mockRejectedValue(new Error("db down"));
     const res = await PATCH(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", id: "row-1", bought: true }),
+        body: JSON.stringify({ id: "row-1", bought: true }),
       }),
     );
     expect(res.status).toBe(500);
@@ -217,12 +255,12 @@ describe("DELETE /api/shopping-list", () => {
 
     const res = await DELETE(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", id: "row-1" }),
+        body: JSON.stringify({ id: "row-1" }),
       }),
     );
 
     expect(res.status).toBe(200);
-    expect(mockedRemove).toHaveBeenCalledWith("u1", "row-1");
+    expect(mockedRemove).toHaveBeenCalledWith("user-123", "row-1");
     expect(mockedClearBought).not.toHaveBeenCalled();
   });
 
@@ -231,26 +269,38 @@ describe("DELETE /api/shopping-list", () => {
 
     const res = await DELETE(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", clearBought: true }),
+        body: JSON.stringify({ clearBought: true }),
       }),
     );
 
     expect(res.status).toBe(200);
-    expect(mockedClearBought).toHaveBeenCalledWith("u1");
+    expect(mockedClearBought).toHaveBeenCalledWith("user-123");
     expect(mockedRemove).not.toHaveBeenCalled();
   });
 
-  it("400s when userId is missing", async () => {
+  it("401s when unauthenticated", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
     const res = await DELETE(
       createMockRequest(base, { body: JSON.stringify({ id: "row-1" }) }),
     );
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
     expect(mockedRemove).not.toHaveBeenCalled();
+  });
+
+  it("ignores a userId in the body and uses the session user", async () => {
+    mockedRemove.mockResolvedValue(undefined);
+    await DELETE(
+      createMockRequest(base, {
+        body: JSON.stringify({ userId: "victim-999", id: "row-1" }),
+      }),
+    );
+    expect(mockedRemove).toHaveBeenCalledTimes(1);
+    expect(mockedRemove).toHaveBeenCalledWith("user-123", "row-1");
   });
 
   it("400s when neither id nor clearBought is provided", async () => {
     const res = await DELETE(
-      createMockRequest(base, { body: JSON.stringify({ userId: "u1" }) }),
+      createMockRequest(base, { body: JSON.stringify({}) }),
     );
     expect(res.status).toBe(400);
     expect(mockedRemove).not.toHaveBeenCalled();
@@ -275,7 +325,7 @@ describe("DELETE /api/shopping-list", () => {
     mockedRemove.mockRejectedValue(new Error("db down"));
     const res = await DELETE(
       createMockRequest(base, {
-        body: JSON.stringify({ userId: "u1", id: "row-1" }),
+        body: JSON.stringify({ id: "row-1" }),
       }),
     );
     expect(res.status).toBe(500);

--- a/src/app/api/shopping-list/route.ts
+++ b/src/app/api/shopping-list/route.ts
@@ -6,7 +6,8 @@ import {
   setBought,
 } from "@/lib/shoppingList";
 import { AddShoppingListItemsSchema } from "@/lib/shoppingList/schemas";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest, NextResponse } from "next/server";
 
 async function readJson(req: NextRequest): Promise<Record<string, unknown> | null> {
@@ -23,8 +24,8 @@ function badRequest(message: string) {
 
 export async function GET(req: NextRequest) {
   try {
-    const userId = req.nextUrl.searchParams.get("userId");
-    if (!userId) return missingUserId();
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
 
     const items = await getShoppingList(userId);
     return NextResponse.json(
@@ -48,13 +49,14 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
+
     const payload = await readJson(req);
     if (!payload) return badRequest("Invalid shopping list payload");
 
-    const { userId, ...rest } = payload;
-    if (!userId || typeof userId !== "string") return missingUserId();
-
-    const parsed = AddShoppingListItemsSchema.safeParse(rest);
+    // `userId` in the body (if any) is ignored — z.object strips unknown keys.
+    const parsed = AddShoppingListItemsSchema.safeParse(payload);
     if (!parsed.success) return badRequest("Invalid shopping list payload");
 
     await addShoppingListItems(parsed.data.items, userId);
@@ -71,18 +73,20 @@ export async function POST(req: NextRequest) {
 /**
  * Toggle a Need-tab row's bought flag.
  *
- * Body: `{ userId: string, id: string, bought: boolean }`. Returns
- * `{ success: true, message }` on success. 400s on malformed JSON, a missing
- * `userId`, a non-string `id`, or a non-boolean `bought`; 500s if the service
- * throws. Flips the flag only — never adds the item to the pantry.
+ * Caller is taken from the session. Body: `{ id: string, bought: boolean }`.
+ * Returns `{ success: true, message }` on success. 401s when unauthenticated;
+ * 400s on malformed JSON, a non-string `id`, or a non-boolean `bought`; 500s if
+ * the service throws. Flips the flag only — never adds the item to the pantry.
  */
 export async function PATCH(req: NextRequest) {
   try {
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
+
     const payload = await readJson(req);
     if (!payload) return badRequest("Invalid shopping list payload");
 
-    const { userId, id, bought } = payload;
-    if (!userId || typeof userId !== "string") return missingUserId();
+    const { id, bought } = payload;
     if (typeof id !== "string" || typeof bought !== "boolean") {
       return badRequest("id (string) and bought (boolean) are required");
     }
@@ -101,19 +105,21 @@ export async function PATCH(req: NextRequest) {
 /**
  * Remove from the Need tab — one row, or all bought rows.
  *
- * Body: `{ userId: string, id: string }` deletes a single row;
- * `{ userId: string, clearBought: true }` bulk-deletes the user's bought rows.
- * Returns `{ success: true, message }` on success. 400s on malformed JSON, a
- * missing `userId`, or when neither `id` nor `clearBought: true` is given;
- * 500s if the service throws.
+ * Caller is taken from the session. Body: `{ id: string }` deletes a single
+ * row; `{ clearBought: true }` bulk-deletes the user's bought rows. Returns
+ * `{ success: true, message }` on success. 401s when unauthenticated; 400s on
+ * malformed JSON, or when neither `id` nor `clearBought: true` is given; 500s
+ * if the service throws.
  */
 export async function DELETE(req: NextRequest) {
   try {
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
+
     const payload = await readJson(req);
     if (!payload) return badRequest("Invalid shopping list payload");
 
-    const { userId, id, clearBought } = payload;
-    if (!userId || typeof userId !== "string") return missingUserId();
+    const { id, clearBought } = payload;
 
     if (typeof id === "string") {
       await removeShoppingListItem(userId, id);

--- a/src/features/Chat/components/recipe/RecipeLetter.test.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.test.tsx
@@ -271,7 +271,6 @@ describe('Recipe cart adds to the shopping list', () => {
         method: 'POST',
         body: JSON.stringify({
           items: [{ name: 'bok choy', category: 'Vegetable' }],
-          userId: 'user-123',
         }),
       }),
     );

--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -110,7 +110,6 @@ export function RecipeLetter({
               ...(ing.category && { category: ing.category }),
             },
           ],
-          userId,
         }),
       });
       if (!res.ok) {

--- a/src/features/ShoppingList/ShoppingList.test.tsx
+++ b/src/features/ShoppingList/ShoppingList.test.tsx
@@ -83,7 +83,6 @@ describe("ShoppingList aisles", () => {
         "/api/shopping-list/classify",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ userId: "user-1" }),
         }),
       );
     });
@@ -138,7 +137,6 @@ describe("ShoppingList", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
-            userId: "user-1",
             items: [{ name: "shallots" }],
           }),
         }),
@@ -160,7 +158,7 @@ describe("ShoppingList", () => {
         "/api/shopping-list",
         expect.objectContaining({
           method: "PATCH",
-          body: JSON.stringify({ userId: "user-1", id: "row-1", bought: true }),
+          body: JSON.stringify({ id: "row-1", bought: true }),
         }),
       );
     });
@@ -181,7 +179,6 @@ describe("ShoppingList", () => {
         expect.objectContaining({
           method: "PATCH",
           body: JSON.stringify({
-            userId: "user-1",
             id: "row-1",
             bought: false,
           }),
@@ -202,7 +199,7 @@ describe("ShoppingList", () => {
         "/api/shopping-list",
         expect.objectContaining({
           method: "DELETE",
-          body: JSON.stringify({ userId: "user-1", id: "row-1" }),
+          body: JSON.stringify({ id: "row-1" }),
         }),
       );
     });
@@ -227,7 +224,7 @@ describe("ShoppingList", () => {
         "/api/shopping-list",
         expect.objectContaining({
           method: "DELETE",
-          body: JSON.stringify({ userId: "user-1", clearBought: true }),
+          body: JSON.stringify({ clearBought: true }),
         }),
       );
     });

--- a/src/features/ShoppingList/ShoppingList.test.tsx
+++ b/src/features/ShoppingList/ShoppingList.test.tsx
@@ -262,9 +262,10 @@ describe("ShoppingList", () => {
 
     render(<ShoppingList />);
 
-    expect(mockedUseMarketTips).toHaveBeenCalledWith([
-      { name: "Tomatoes", category: "Vegetable" },
-    ]);
+    expect(mockedUseMarketTips).toHaveBeenCalledWith(
+      [{ name: "Tomatoes", category: "Vegetable" }],
+      true,
+    );
   });
 
   it("shows no tip for a staple the engine returns nothing for", () => {

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -50,7 +50,7 @@ const ShoppingList = () => {
       const res = await fetch("/api/shopping-list", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId, items: [{ name }] }),
+        body: JSON.stringify({ items: [{ name }] }),
       });
       if (res.ok) {
         setDraft("");
@@ -82,7 +82,7 @@ const ShoppingList = () => {
       const res = await fetch("/api/shopping-list", {
         method,
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId, ...body }),
+        body: JSON.stringify(body),
       });
       if (res.ok) {
         revalidate();
@@ -121,7 +121,6 @@ const ShoppingList = () => {
     fetch("/api/shopping-list/classify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userId }),
     })
       .then((res) => {
         if (res.ok) revalidate();


### PR DESCRIPTION
## Summary
Locks down the shopping-list routes so identity comes from the verified better-auth session cookie, never a client-supplied `userId` — continuing the route-lockdown sequence (#341 recipe, #342 inventory).

- `GET/POST/PATCH/DELETE /api/shopping-list` and `POST /api/shopping-list/classify` now call `getSessionUserId(req)` and return `unauthorized()` (401) when there's no valid session.
- A `userId` in the query/body is ignored. The POST passes the full payload through `AddShoppingListItemsSchema.safeParse`, and `z.object` strips unknown keys — so a stray body `userId` is harmlessly dropped.
- Clients stop sending `userId` in request bodies (`ShoppingList` add/toggle/remove/clear + classify; `RecipeLetter` cart add). SWR GET/mutate keys keep `?userId=` only as a client-side cache key; the classify fetch now sends no body.
- Drive-by: fixed a stale `useMarketTips` assertion in `ShoppingList.test.tsx` (the component passes `(items, tipsOn)`; the test asserted a single arg).

## Test plan
- `pnpm jest src/app/api/shopping-list src/features/ShoppingList src/features/Chat/components/recipe`
- New tests cover cross-user denial (body foreign id resolves to the session user) and 401s for unauthenticated callers.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)