### PR TITLE
fix(conversation): lock down conversation/message/chat routes to the session user

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -168,7 +168,7 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Every visitor now has a real session.** The client-generated `localStorage["ask-ah-mah-session"]` id is gone. The better-auth `anonymous()` plugin mints an unforgeable anonymous session on first load (`useSession` calls `signIn.anonymous()` when there's no session); signed-in users still use their Google session. `userId` is always `session.user.id`, and `isAuthenticated` now means non-anonymous (`!user.isAnonymous`).
 - **Server is the source of truth for identity.** New helper `getSessionUserId(req)` (`src/lib/session.ts`) resolves the caller from the verified session cookie via `auth.api.getSession`, returning the id or `null` (routes map that to a 401 via `unauthorized()`). This is the primitive the route-lockdown slices (#341–#345) build on — routes stop trusting a `userId` from the request.
 - **Schema**: `User.isAnonymous Boolean?` (additive migration `20260629000000_add_user_is_anonymous`). New anonymous users get their starter pantry seeded.
-- **Not yet wired**: conversation routes still read `userId` from the request (#344), share-token mint trust is #345, and guest→Google data migration on link is #346.
+- **Not yet wired**: share-token mint trust is #345, and guest→Google data migration on link is #346.
 
 ### Recipe routes locked down — Shipped (#341)
 
@@ -188,6 +188,16 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Shopping-list routes derive identity from the session.** `GET/POST/PATCH/DELETE /api/shopping-list` and `POST /api/shopping-list/classify` call `getSessionUserId(req)` and return `unauthorized()` (401) when there's no valid session. A `userId` in the query/body is ignored (the POST passes the full payload through `AddShoppingListItemsSchema.safeParse`, and `z.object` strips unknown keys), so a caller can't read or mutate another user's list by supplying a foreign id.
 - **Clients stopped sending `userId` in request bodies** (`ShoppingList` add/toggle/remove/clear + classify; `RecipeLetter` cart add). SWR GET/mutate keys keep `?userId=` only as a client-side cache key. The classify fetch now sends no body — the session cookie is the identity.
 - **Tests** cover cross-user access denial (body foreign id resolves to the session user) and 401s for unauthenticated callers, mocking `getSessionUserId`.
+
+### Conversation/message/chat routes locked down — Shipped (#344)
+
+- **Conversation, message, and chat routes derive identity from the session.** `GET/POST /api/conversation`, `PATCH/DELETE /api/conversation/[id]`, `GET/POST /api/message`, and `POST /api/chat` call `getSessionUserId(req)` and return `unauthorized()` (401) when there's no valid session. A `userId` in the query/body is ignored, so a caller can't list, read, or mutate another user's conversations by supplying a foreign id.
+- **Ownership is enforced in the service layer, not just at the route** (the new part vs #341–#343): a valid session for user A still can't touch user B's conversation.
+  - `getMessages(conversationId, userId)` filters on the conversation relation's `userId`, so a foreign `conversationId` returns an empty history — chat-context loading (`loadConversationContext`) is scoped the same way.
+  - `createMessage` rejects (throws `Conversation not found`) when the target conversation exists but is owned by someone else, closing the `connectOrCreate` cross-user write.
+  - `renameConversation` / `autoTitleIfNull` scope their writes by `{ id, userId }` (`updateMany` / `findFirst`); a rename aimed at a foreign id matches zero rows and the route maps the thrown `Conversation not found` to a 404 (mirrors `deleteConversation`).
+- **Clients stopped sending `userId` in request bodies / query** (`useChatSession` chat transport + message POST + conversation create; `ConversationContext` deletes). SWR keys keep `?userId=` only as a client-side cache key.
+- **Tests** cover cross-user denial at both the route and service layers, plus 401s for unauthenticated callers, mocking `getSessionUserId`.
 
 ## Design system
 

--- a/src/app/api/chat/route.test.ts
+++ b/src/app/api/chat/route.test.ts
@@ -4,6 +4,7 @@ import {
   removeInventoryItem,
 } from "@/lib/inventory/Inventory";
 import { getMessages } from "@/lib/messages/messages";
+import { getSessionUserId } from "@/lib/session";
 import { openai } from "@ai-sdk/openai";
 import {
   convertToModelMessages,
@@ -24,6 +25,8 @@ jest.mock("@/lib/inventory/Inventory", () => ({
 jest.mock("@/lib/messages/messages", () => ({
   getMessages: jest.fn(),
 }));
+
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
 
 jest.mock("@ai-sdk/openai", () => ({
   openai: jest.fn(),
@@ -49,15 +52,24 @@ jest.mock("./constants", () => ({
   CHAT_SYSTEM_PROMPT: "Test system prompt",
 }));
 
-// Mock Next.js server components
+// Mock Next.js server components. NextResponse.json lets the auth/validation
+// guards (unauthorized, conversationId-missing) return real status objects;
+// thrown errors still fall through to chatErrorResponse's `new Response`.
 jest.mock("next/server", () => ({
   NextRequest: jest.fn(),
+  NextResponse: {
+    json: jest.fn((data, init) => ({
+      json: async () => data,
+      status: init?.status || 200,
+    })),
+  },
 }));
 
 const mockedAddInventoryItem = jest.mocked(addInventoryItem);
 const mockedGetInventory = jest.mocked(getInventory);
 const mockedRemoveInventoryItem = jest.mocked(removeInventoryItem);
 const mockedGetMessages = jest.mocked(getMessages);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 const mockedOpenai = jest.mocked(openai);
 const mockedConvertToModelMessages = jest.mocked(convertToModelMessages);
 const mockedStepCountIs = jest.mocked(stepCountIs);
@@ -76,6 +88,8 @@ describe("Chat API Route", () => {
     jest.clearAllMocks();
     // Mock console.error to avoid noise in tests
     jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockedGetSessionUserId.mockResolvedValue("user-123");
 
     // Setup default mocks
     mockedOpenai.mockReturnValue(
@@ -141,7 +155,7 @@ describe("Chat API Route", () => {
 
       expect(response).toBe("mock-stream-response");
       expect(mockedOpenai).toHaveBeenCalledWith("gpt-5-mini");
-      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123");
+      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123", "user-123");
       expect(mockedValidateUIMessages).toHaveBeenCalled();
       expect(mockedStreamText).toHaveBeenCalled();
     });
@@ -165,7 +179,7 @@ describe("Chat API Route", () => {
       const response = await POST(request);
 
       expect(response).toBe("mock-stream-response");
-      expect(mockedGetMessages).toHaveBeenCalledWith("conv-456");
+      expect(mockedGetMessages).toHaveBeenCalledWith("conv-456", "user-123");
       expect(mockedValidateUIMessages).toHaveBeenCalledWith({
         messages: requestBody.messages,
       });
@@ -325,7 +339,7 @@ describe("Chat API Route", () => {
 
       const response = await POST(request);
       expect(response.status).toBe(500);
-      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123");
+      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123", "user-123");
     });
 
     it("should handle validation errors", async () => {
@@ -351,10 +365,49 @@ describe("Chat API Route", () => {
     });
 
     it("should handle malformed request body", async () => {
-      const request = createMockRequest("invalid json");
+      // A body that fails to parse throws → chatErrorResponse → 500.
+      const request = {
+        json: async () => {
+          throw new SyntaxError("Unexpected token");
+        },
+      } as unknown as NextRequest;
 
       const response = await POST(request);
       expect(response.status).toBe(500);
+    });
+
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+
+      const request = createMockRequest({
+        conversationId: "conv-123",
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "Hi" }] },
+        ],
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      expect(mockedGetMessages).not.toHaveBeenCalled();
+      expect(mockedStreamText).not.toHaveBeenCalled();
+    });
+
+    it("loads history for the session user, ignoring any body userId", async () => {
+      mockedGetMessages.mockResolvedValue([]);
+
+      const request = createMockRequest({
+        userId: "victim-999",
+        conversationId: "conv-123",
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "Hi" }] },
+        ],
+      });
+
+      await POST(request);
+
+      expect(mockedGetMessages).toHaveBeenCalledTimes(1);
+      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123", "user-123");
     });
   });
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -3,7 +3,8 @@ import { loadConversationContext } from "@/lib/chat/context";
 import { chatErrorResponse } from "@/lib/chat/errors";
 import { latestUserText } from "@/lib/chat/messageText";
 import { buildChatTools } from "@/lib/chat/tools";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { openai } from "@ai-sdk/openai";
 import {
   convertToModelMessages,
@@ -18,13 +19,14 @@ import { CHAT_SYSTEM_PROMPT } from "./constants";
 
 export async function POST(req: NextRequest) {
   try {
-    const { messages, userId, conversationId }: {
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
+
+    const { messages, conversationId }: {
       messages: UIMessage[];
-      userId: string;
       conversationId: string;
     } = await req.json();
 
-    if (!userId) return missingUserId();
     if (!conversationId) return NextResponse.json({ error: "conversationId is required" }, { status: 400 });
 
     // Deterministically capture any pantry items the user mentions BEFORE the
@@ -33,7 +35,11 @@ export async function POST(req: NextRequest) {
     // for phrasings the gate misses. Failures here are swallowed (non-fatal).
     const captured = await captureMentionedInventory(latestUserText(messages), userId);
 
-    const validatedMessages = await loadConversationContext(conversationId, messages);
+    const validatedMessages = await loadConversationContext(
+      conversationId,
+      messages,
+      userId
+    );
 
     const stream = createUIMessageStream({
       execute: ({ writer }) => {

--- a/src/app/api/conversation/[id]/route.test.ts
+++ b/src/app/api/conversation/[id]/route.test.ts
@@ -4,6 +4,7 @@ import {
   deleteConversation,
   renameConversation,
 } from "@/lib/conversations";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
 
 jest.mock("next/server", () => ({
@@ -23,9 +24,12 @@ jest.mock("@/lib/conversations", () => ({
   deleteConversation: jest.fn(),
 }));
 
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
+
 const mockedRenameConversation = jest.mocked(renameConversation);
 const mockedAutoTitleIfNull = jest.mocked(autoTitleIfNull);
 const mockedDeleteConversation = jest.mocked(deleteConversation);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 global.Response = class {
   status: number;
@@ -51,10 +55,11 @@ const params = Promise.resolve({ id: "conv-1" });
 describe("Conversation by-id API routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedGetSessionUserId.mockResolvedValue("user-1");
   });
 
   describe("PATCH /api/conversation/[id]", () => {
-    it("renames a conversation", async () => {
+    it("renames a conversation scoped to the session user", async () => {
       const conversation = { id: "conv-1", title: "Weeknight noodles" };
       mockedRenameConversation.mockResolvedValue(conversation as never);
 
@@ -70,11 +75,12 @@ describe("Conversation by-id API routes", () => {
       expect(data).toEqual({ conversation });
       expect(mockedRenameConversation).toHaveBeenCalledWith(
         "conv-1",
-        "Weeknight noodles"
+        "Weeknight noodles",
+        "user-1"
       );
     });
 
-    it("keeps auto-title rename behaviour", async () => {
+    it("keeps auto-title rename behaviour, scoped to the session user", async () => {
       const conversation = { id: "conv-1", title: "Egg ideas" };
       mockedAutoTitleIfNull.mockResolvedValue(conversation as never);
 
@@ -88,7 +94,41 @@ describe("Conversation by-id API routes", () => {
 
       expect(response.status).toBe(200);
       expect(data).toEqual({ conversation });
-      expect(mockedAutoTitleIfNull).toHaveBeenCalledWith("conv-1", "Egg ideas");
+      expect(mockedAutoTitleIfNull).toHaveBeenCalledWith(
+        "conv-1",
+        "Egg ideas",
+        "user-1"
+      );
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+      const request = createMockRequest("http://localhost:3000/api/conversation/conv-1", {
+        method: "PATCH",
+        body: JSON.stringify({ title: "Weeknight noodles" }),
+      });
+
+      const response = await PATCH(request, { params });
+
+      expect(response.status).toBe(401);
+      expect(mockedRenameConversation).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when renaming a conversation the user does not own", async () => {
+      mockedRenameConversation.mockRejectedValue(
+        new Error("Conversation not found")
+      );
+
+      const request = createMockRequest("http://localhost:3000/api/conversation/conv-1", {
+        method: "PATCH",
+        body: JSON.stringify({ title: "Hijack" }),
+      });
+
+      const response = await PATCH(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data).toEqual({ error: "Conversation not found" });
     });
 
     it("returns 400 when title is missing", async () => {
@@ -106,11 +146,11 @@ describe("Conversation by-id API routes", () => {
   });
 
   describe("DELETE /api/conversation/[id]", () => {
-    it("returns 204 on success", async () => {
+    it("returns 204 on success, scoped to the session user", async () => {
       mockedDeleteConversation.mockResolvedValue(undefined);
 
       const request = createMockRequest(
-        "http://localhost:3000/api/conversation/conv-1?userId=user-1",
+        "http://localhost:3000/api/conversation/conv-1",
         { method: "DELETE" }
       );
 
@@ -120,11 +160,38 @@ describe("Conversation by-id API routes", () => {
       expect(mockedDeleteConversation).toHaveBeenCalledWith("conv-1", "user-1");
     });
 
+    it("returns 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+      const request = createMockRequest(
+        "http://localhost:3000/api/conversation/conv-1",
+        { method: "DELETE" }
+      );
+
+      const response = await DELETE(request, { params });
+
+      expect(response.status).toBe(401);
+      expect(mockedDeleteConversation).not.toHaveBeenCalled();
+    });
+
+    it("ignores a userId in the query and deletes as the session user", async () => {
+      mockedDeleteConversation.mockResolvedValue(undefined);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/conversation/conv-1?userId=victim-999",
+        { method: "DELETE" }
+      );
+
+      await DELETE(request, { params });
+
+      expect(mockedDeleteConversation).toHaveBeenCalledTimes(1);
+      expect(mockedDeleteConversation).toHaveBeenCalledWith("conv-1", "user-1");
+    });
+
     it("returns 404 when the conversation does not belong to the user", async () => {
       mockedDeleteConversation.mockRejectedValue(new Error("Conversation not found"));
 
       const request = createMockRequest(
-        "http://localhost:3000/api/conversation/conv-1?userId=user-1",
+        "http://localhost:3000/api/conversation/conv-1",
         { method: "DELETE" }
       );
 

--- a/src/app/api/conversation/[id]/route.ts
+++ b/src/app/api/conversation/[id]/route.ts
@@ -3,26 +3,43 @@ import {
   deleteConversation,
   renameConversation,
 } from "@/lib/conversations";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
+
   const { id } = await params;
   const { title, autoTitle } = await req.json();
 
   if (typeof title === "string") {
-    if (autoTitle) {
-      const conversation = await autoTitleIfNull(id, title);
-      if (!conversation) {
-        return new NextResponse(null, { status: 204 });
+    try {
+      if (autoTitle) {
+        const conversation = await autoTitleIfNull(id, title, userId);
+        if (!conversation) {
+          return new NextResponse(null, { status: 204 });
+        }
+        return NextResponse.json({ conversation });
       }
+      const conversation = await renameConversation(id, title, userId);
       return NextResponse.json({ conversation });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === "Conversation not found"
+      ) {
+        return NextResponse.json(
+          { error: "Conversation not found" },
+          { status: 404 }
+        );
+      }
+      throw error;
     }
-    const conversation = await renameConversation(id, title);
-    return NextResponse.json({ conversation });
   }
 
   return NextResponse.json(
@@ -35,10 +52,10 @@ export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await params;
-  const userId = req.nextUrl.searchParams.get("userId");
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
 
-  if (!userId) return missingUserId();
+  const { id } = await params;
 
   try {
     await deleteConversation(id, userId);

--- a/src/app/api/conversation/route.test.ts
+++ b/src/app/api/conversation/route.test.ts
@@ -3,6 +3,7 @@ import {
   getOrCreateEmptyConversation,
   listConversations,
 } from "@/lib/conversations";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
 import type { ConversationEntity } from "@/lib/conversations";
 
@@ -22,8 +23,11 @@ jest.mock("@/lib/conversations", () => ({
   getOrCreateEmptyConversation: jest.fn(),
 }));
 
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
+
 const mockedListConversations = jest.mocked(listConversations);
 const mockedGetOrCreateEmptyConversation = jest.mocked(getOrCreateEmptyConversation);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 const createMockRequest = (url: string, options: RequestInit = {}) => {
   const parsedUrl = new URL(url);
@@ -64,16 +68,15 @@ function makeConversation(overrides: Partial<{
 describe("Conversation API Routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedGetSessionUserId.mockResolvedValue("user-1");
   });
 
   describe("GET /api/conversation", () => {
-    it("should return flat conversations for valid userId", async () => {
+    it("should return flat conversations for the session user", async () => {
       const conv = makeConversation({ id: "conv-1" });
       mockedListConversations.mockResolvedValue([conv]);
 
-      const request = createMockRequest(
-        "http://localhost:3000/api/conversation?userId=user-1"
-      );
+      const request = createMockRequest("http://localhost:3000/api/conversation");
       const response = await GET(request);
       const data = await response.json();
 
@@ -82,24 +85,32 @@ describe("Conversation API Routes", () => {
       expect(mockedListConversations).toHaveBeenCalledWith("user-1");
     });
 
-    it("should return 400 when userId is missing", async () => {
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
       const request = createMockRequest(
         "http://localhost:3000/api/conversation"
       );
       const response = await GET(request);
-      const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
+      expect(response.status).toBe(401);
       expect(mockedListConversations).not.toHaveBeenCalled();
+    });
+
+    it("ignores a userId in the query and uses the session user", async () => {
+      mockedListConversations.mockResolvedValue(emptyList);
+      const request = createMockRequest(
+        "http://localhost:3000/api/conversation?userId=victim-999"
+      );
+      await GET(request);
+
+      expect(mockedListConversations).toHaveBeenCalledTimes(1);
+      expect(mockedListConversations).toHaveBeenCalledWith("user-1");
     });
 
     it("should return empty list when no conversations exist", async () => {
       mockedListConversations.mockResolvedValue(emptyList);
 
-      const request = createMockRequest(
-        "http://localhost:3000/api/conversation?userId=user-empty"
-      );
+      const request = createMockRequest("http://localhost:3000/api/conversation");
       const response = await GET(request);
       const data = await response.json();
 
@@ -109,7 +120,7 @@ describe("Conversation API Routes", () => {
   });
 
   describe("POST /api/conversation", () => {
-    it("should return the reusable empty conversation for valid userId", async () => {
+    it("should return the reusable empty conversation for the session user", async () => {
       const newConv = makeConversation({ id: "conv-new", userId: "user-1" });
       mockedGetOrCreateEmptyConversation.mockResolvedValue(newConv);
 
@@ -117,7 +128,6 @@ describe("Conversation API Routes", () => {
         "http://localhost:3000/api/conversation",
         {
           method: "POST",
-          body: JSON.stringify({ userId: "user-1" }),
           headers: { "Content-Type": "application/json" },
         }
       );
@@ -130,22 +140,38 @@ describe("Conversation API Routes", () => {
       expect(mockedGetOrCreateEmptyConversation).toHaveBeenCalledWith("user-1");
     });
 
-    it("should return 400 when userId is missing", async () => {
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
       const request = createMockRequest(
         "http://localhost:3000/api/conversation",
         {
           method: "POST",
-          body: JSON.stringify({}),
           headers: { "Content-Type": "application/json" },
         }
       );
 
       const response = await POST(request);
-      const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({ error: "userId is required" });
+      expect(response.status).toBe(401);
       expect(mockedGetOrCreateEmptyConversation).not.toHaveBeenCalled();
+    });
+
+    it("ignores a userId in the body and uses the session user", async () => {
+      const newConv = makeConversation({ id: "conv-new", userId: "user-1" });
+      mockedGetOrCreateEmptyConversation.mockResolvedValue(newConv);
+      const request = createMockRequest(
+        "http://localhost:3000/api/conversation",
+        {
+          method: "POST",
+          body: JSON.stringify({ userId: "victim-999" }),
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+
+      await POST(request);
+
+      expect(mockedGetOrCreateEmptyConversation).toHaveBeenCalledTimes(1);
+      expect(mockedGetOrCreateEmptyConversation).toHaveBeenCalledWith("user-1");
     });
 
     it("should handle database errors gracefully", async () => {
@@ -155,7 +181,6 @@ describe("Conversation API Routes", () => {
         "http://localhost:3000/api/conversation",
         {
           method: "POST",
-          body: JSON.stringify({ userId: "user-1" }),
           headers: { "Content-Type": "application/json" },
         }
       );

--- a/src/app/api/conversation/route.ts
+++ b/src/app/api/conversation/route.ts
@@ -2,20 +2,21 @@ import {
   getOrCreateEmptyConversation,
   listConversations,
 } from "@/lib/conversations";
-import { missingUserId } from "@/lib/http";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
-  const userId = req.nextUrl.searchParams.get("userId");
-  if (!userId) return missingUserId();
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
 
   const conversations = await listConversations(userId);
   return NextResponse.json({ conversations }); // flat array, ordered by updatedAt desc
 }
 
 export async function POST(req: NextRequest) {
-  const { userId } = await req.json();
-  if (!userId) return missingUserId();
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
   const conversation = await getOrCreateEmptyConversation(userId);
   return NextResponse.json({ conversation });
 }

--- a/src/app/api/message/route.test.ts
+++ b/src/app/api/message/route.test.ts
@@ -1,5 +1,6 @@
 import { GET, POST } from "./route";
 import { createMessage, getMessages } from "@/lib/messages";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
 
 // Mock Next.js server components
@@ -20,6 +21,8 @@ jest.mock("@/lib/messages", () => ({
   getMessages: jest.fn(),
 }));
 
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
+
 // Mock conversations lib (pulls in ai SDK which requires TransformStream)
 jest.mock("@/lib/conversations", () => ({
   autoTitleConversation: jest.fn().mockResolvedValue(undefined),
@@ -37,6 +40,7 @@ jest.mock("@/lib/db", () => ({
 
 const mockedCreateMessage = jest.mocked(createMessage);
 const mockedGetMessages = jest.mocked(getMessages);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 // Helper to create mock NextRequest
 const createMockRequest = (url: string, options: RequestInit = {}) => {
@@ -58,6 +62,7 @@ describe("Message API Routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, "error").mockImplementation(() => {});
+    mockedGetSessionUserId.mockResolvedValue("user-123");
   });
 
   afterEach(() => {
@@ -95,7 +100,7 @@ describe("Message API Routes", () => {
 
       expect(response.status).toBe(200);
       expect(data).toEqual(mockMessages);
-      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123");
+      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123", "user-123");
       expect(mockedGetMessages).toHaveBeenCalledTimes(1);
     });
 
@@ -110,7 +115,18 @@ describe("Message API Routes", () => {
 
       expect(response.status).toBe(200);
       expect(data).toEqual([]);
-      expect(mockedGetMessages).toHaveBeenCalledWith("conv-456");
+      expect(mockedGetMessages).toHaveBeenCalledWith("conv-456", "user-123");
+    });
+
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
+      const request = createMockRequest(
+        "http://localhost:3000/api/message?conversationId=conv-123"
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(401);
+      expect(mockedGetMessages).not.toHaveBeenCalled();
     });
 
     it("should return 400 when conversationId is missing", async () => {
@@ -143,7 +159,7 @@ describe("Message API Routes", () => {
       );
 
       await expect(GET(request)).rejects.toThrow("Database error");
-      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123");
+      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123", "user-123");
     });
 
     it("should handle multiple query parameters correctly", async () => {
@@ -168,7 +184,7 @@ describe("Message API Routes", () => {
 
       expect(response.status).toBe(200);
       expect(data).toEqual(mockMessages);
-      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123");
+      expect(mockedGetMessages).toHaveBeenCalledWith("conv-123", "user-123");
     });
   });
 
@@ -268,12 +284,13 @@ describe("Message API Routes", () => {
 
       expect(response.status).toBe(400);
       expect(data).toEqual({
-        error: "conversationId, userId, content, and role are required",
+        error: "conversationId, content, and role are required",
       });
       expect(mockedCreateMessage).not.toHaveBeenCalled();
     });
 
-    it("should return 400 when userId is missing", async () => {
+    it("should return 401 when unauthenticated", async () => {
+      mockedGetSessionUserId.mockResolvedValue(null);
       const requestBody = {
         conversationId: "conv-123",
         content: "Test message",
@@ -287,13 +304,64 @@ describe("Message API Routes", () => {
       });
 
       const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      expect(mockedCreateMessage).not.toHaveBeenCalled();
+    });
+
+    it("ignores a userId in the body and writes as the session user", async () => {
+      const newMessage = {
+        id: "msg-new",
+        conversationId: "conv-123",
+        userId: "user-123",
+        content: "Test message",
+        role: "user",
+        createdAt: new Date("2024-01-01T10:00:00.000Z"),
+      };
+      mockedCreateMessage.mockResolvedValue(newMessage);
+
+      const request = createMockRequest("http://localhost:3000/api/message", {
+        method: "POST",
+        body: JSON.stringify({
+          conversationId: "conv-123",
+          userId: "victim-999",
+          content: "Test message",
+          role: "user",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      await POST(request);
+
+      expect(mockedCreateMessage).toHaveBeenCalledTimes(1);
+      expect(mockedCreateMessage).toHaveBeenCalledWith(
+        "conv-123",
+        "user-123",
+        "Test message",
+        "user"
+      );
+    });
+
+    it("returns 404 when writing to a conversation the user does not own", async () => {
+      mockedCreateMessage.mockRejectedValue(
+        new Error("Conversation not found")
+      );
+
+      const request = createMockRequest("http://localhost:3000/api/message", {
+        method: "POST",
+        body: JSON.stringify({
+          conversationId: "conv-foreign",
+          content: "Hijack",
+          role: "user",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data).toEqual({
-        error: "conversationId, userId, content, and role are required",
-      });
-      expect(mockedCreateMessage).not.toHaveBeenCalled();
+      expect(response.status).toBe(404);
+      expect(data).toEqual({ error: "Conversation not found" });
     });
 
     it("should return 400 when content is missing", async () => {
@@ -314,7 +382,7 @@ describe("Message API Routes", () => {
 
       expect(response.status).toBe(400);
       expect(data).toEqual({
-        error: "conversationId, userId, content, and role are required",
+        error: "conversationId, content, and role are required",
       });
       expect(mockedCreateMessage).not.toHaveBeenCalled();
     });
@@ -337,7 +405,7 @@ describe("Message API Routes", () => {
 
       expect(response.status).toBe(400);
       expect(data).toEqual({
-        error: "conversationId, userId, content, and role are required",
+        error: "conversationId, content, and role are required",
       });
       expect(mockedCreateMessage).not.toHaveBeenCalled();
     });
@@ -361,7 +429,7 @@ describe("Message API Routes", () => {
 
       expect(response.status).toBe(400);
       expect(data).toEqual({
-        error: "conversationId, userId, content, and role are required",
+        error: "conversationId, content, and role are required",
       });
       expect(mockedCreateMessage).not.toHaveBeenCalled();
     });

--- a/src/app/api/message/route.ts
+++ b/src/app/api/message/route.ts
@@ -1,8 +1,13 @@
 import { maybeAutoTitleConversation } from "@/lib/conversations";
+import { unauthorized } from "@/lib/http";
 import { createMessage, getMessages } from "@/lib/messages";
+import { getSessionUserId } from "@/lib/session";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
+
   const conversationId = req.nextUrl.searchParams.get("conversationId");
   if (!conversationId) {
     return NextResponse.json(
@@ -10,23 +15,38 @@ export async function GET(req: NextRequest) {
       { status: 400 }
     );
   }
-  const messages = await getMessages(conversationId);
+  // getMessages is owner-scoped: a foreign conversationId returns no messages.
+  const messages = await getMessages(conversationId, userId);
   return NextResponse.json(messages);
 }
 
 export async function POST(req: NextRequest) {
-  const { conversationId, userId, content, role } = await req.json();
-  if (!conversationId || !userId || !content || !role) {
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
+
+  const { conversationId, content, role } = await req.json();
+  if (!conversationId || !content || !role) {
     return NextResponse.json(
-      { error: "conversationId, userId, content, and role are required" },
+      { error: "conversationId, content, and role are required" },
       { status: 400 }
     );
   }
-  const message = await createMessage(conversationId, userId, content, role);
 
-  if (role === "assistant") {
-    void maybeAutoTitleConversation(conversationId);
+  try {
+    const message = await createMessage(conversationId, userId, content, role);
+
+    if (role === "assistant") {
+      void maybeAutoTitleConversation(conversationId);
+    }
+
+    return NextResponse.json({ message });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Conversation not found") {
+      return NextResponse.json(
+        { error: "Conversation not found" },
+        { status: 404 }
+      );
+    }
+    throw error;
   }
-
-  return NextResponse.json({ message });
 }

--- a/src/contexts/ConversationContext.test.tsx
+++ b/src/contexts/ConversationContext.test.tsx
@@ -24,14 +24,21 @@ const mockMutate = jest.fn();
 
 jest.mock("swr", () => ({
   __esModule: true,
-  default: jest.fn((key: string | null) => ({
-    data: key ? swrData.get(key) : undefined,
-    isLoading: false,
-  })),
+  default: jest.fn((key: unknown) => {
+    // The list key is now a tuple ["/api/conversation", userId]; serialize it to
+    // a string for the fixture map (userId stays out of the request URL).
+    const k = Array.isArray(key) ? key.join("|") : (key as string | null);
+    return {
+      data: k ? swrData.get(k) : undefined,
+      isLoading: false,
+    };
+  }),
   mutate: (...args: unknown[]) => mockMutate(...args),
 }));
 
 const mockUserId = "user-test-123";
+const listKeyTuple = ["/api/conversation", mockUserId] as const;
+const listKey = listKeyTuple.join("|");
 
 jest.mock("@/contexts/SessionContext", () => ({
   useSessionContext: jest.fn(() => ({ userId: mockUserId, isLoading: false })),
@@ -102,7 +109,7 @@ describe("ConversationContext", () => {
   });
 
   it("starts in staging state (null) when localStorage is empty", () => {
-    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+    swrData.set(listKey, {
       conversations: [makeConversation("conv-from-api")],
     });
 
@@ -113,7 +120,7 @@ describe("ConversationContext", () => {
 
   it("uses the localStorage value instead of fetching an active conversation", () => {
     localStorageMock.getItem.mockReturnValueOnce("conv-from-storage");
-    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+    swrData.set(listKey, {
       conversations: [makeConversation("conv-from-storage")],
     });
 
@@ -128,7 +135,7 @@ describe("ConversationContext", () => {
       _count: { messages: 2 },
     });
     localStorageMock.getItem.mockReturnValueOnce("conv-current");
-    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+    swrData.set(listKey, {
       conversations: [current],
     });
 
@@ -145,7 +152,7 @@ describe("ConversationContext", () => {
   it("renameConversation PATCHes the given id", async () => {
     const conversation = makeConversation("conv-abc");
     localStorageMock.getItem.mockReturnValueOnce("conv-abc");
-    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+    swrData.set(listKey, {
       conversations: [conversation],
     });
     mockFetch.mockResolvedValueOnce({
@@ -176,7 +183,7 @@ describe("ConversationContext", () => {
       _count: { messages: 1 },
     });
     localStorageMock.getItem.mockReturnValueOnce("conv-delete");
-    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+    swrData.set(listKey, {
       conversations: [active, fallback],
     });
     mockFetch.mockResolvedValueOnce({ ok: true });
@@ -205,7 +212,7 @@ describe("ConversationContext", () => {
       _count: { messages: 1 },
     });
     localStorageMock.getItem.mockReturnValueOnce("conv-delete");
-    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+    swrData.set(listKey, {
       conversations: [active, fallback],
     });
     mockFetch.mockResolvedValueOnce({ ok: false });
@@ -232,7 +239,7 @@ describe("ConversationContext", () => {
       _count: { messages: 2 },
     });
     localStorageMock.getItem.mockReturnValueOnce("conv-only");
-    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+    swrData.set(listKey, {
       conversations: [active],
     });
 
@@ -251,7 +258,7 @@ describe("ConversationContext", () => {
     });
     // SWR cache rolled back — globalMutate called with previousConversations (the original list)
     expect(mockMutate).toHaveBeenCalledWith(
-      `/api/conversation?userId=${mockUserId}`,
+      listKeyTuple,
       { conversations: [active] },
       false
     );
@@ -270,7 +277,7 @@ describe("ConversationContext", () => {
       _count: { messages: 1 },
     });
     localStorageMock.getItem.mockReturnValueOnce("conv-active");
-    swrData.set(`/api/conversation?userId=${mockUserId}`, {
+    swrData.set(listKey, {
       conversations: [active, other],
     });
     mockFetch.mockResolvedValueOnce({ ok: true });

--- a/src/contexts/ConversationContext.test.tsx
+++ b/src/contexts/ConversationContext.test.tsx
@@ -189,7 +189,7 @@ describe("ConversationContext", () => {
 
     expect(result.current.activeConversationId).toBe("conv-fallback");
     expect(mockFetch).toHaveBeenCalledWith(
-      `/api/conversation/conv-delete?userId=${encodeURIComponent(mockUserId)}`,
+      `/api/conversation/conv-delete`,
       { method: "DELETE" }
     );
   });
@@ -283,7 +283,7 @@ describe("ConversationContext", () => {
 
     expect(result.current.activeConversationId).toBe("conv-active");
     expect(mockFetch).toHaveBeenCalledWith(
-      `/api/conversation/conv-other?userId=${encodeURIComponent(mockUserId)}`,
+      `/api/conversation/conv-other`,
       { method: "DELETE" }
     );
   });

--- a/src/contexts/ConversationContext.tsx
+++ b/src/contexts/ConversationContext.tsx
@@ -89,12 +89,18 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem(LOCAL_STORAGE_KEY);
   };
 
-  const revalidateConversationKeys = () =>
-    globalMutate(
+  const revalidateConversationKeys = () => {
+    if (!userId) return Promise.resolve();
+    // Only revalidate the current user's bucket. Matching every
+    // ["/api/conversation", *] tuple would refetch a prior user's cache under
+    // the new session after an account switch.
+    return globalMutate(
       (key: unknown) =>
-        (typeof key === "string" && key.includes("/api/conversation")) ||
-        (Array.isArray(key) && key[0] === "/api/conversation"),
+        Array.isArray(key) &&
+        key[0] === "/api/conversation" &&
+        key[1] === userId,
     );
+  };
 
   // Clear active conversation and enter staging state — no API call
   const startNewConversation = () => {

--- a/src/contexts/ConversationContext.tsx
+++ b/src/contexts/ConversationContext.tsx
@@ -188,7 +188,7 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
 
       try {
         const res = await fetch(
-          `/api/conversation/${previousActiveConversationId}?userId=${encodeURIComponent(userId)}`,
+          `/api/conversation/${previousActiveConversationId}`,
           { method: "DELETE" }
         );
 
@@ -219,10 +219,9 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
       }
 
       try {
-        const res = await fetch(
-          `/api/conversation/${id}?userId=${encodeURIComponent(userId)}`,
-          { method: "DELETE" }
-        );
+        const res = await fetch(`/api/conversation/${id}`, {
+          method: "DELETE",
+        });
 
         if (!res.ok) {
           throw new Error("Failed to delete conversation");

--- a/src/contexts/ConversationContext.tsx
+++ b/src/contexts/ConversationContext.tsx
@@ -55,12 +55,14 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
   const [pendingConversationId, setPendingConversationId] = useState<string | null>(null);
   const [pendingCookWithMessage, setPendingCookWithMessage] = useState<string | null>(null);
 
-  // Fetch the conversations list
-  const listKey = userId ? `/api/conversation?userId=${userId}` : null;
+  // Fetch the conversations list. userId lives in the SWR key only to partition
+  // the cache per user — it is NOT sent to the server (the session cookie is the
+  // identity). A tuple key keeps the fetch URL clean: /api/conversation, no query.
+  const listKey = userId ? (["/api/conversation", userId] as const) : null;
 
   const { data: listData, isLoading: listLoading } = useSWR<ConversationListResponse>(
     listKey,
-    async (url: string) => {
+    async ([url]: readonly [string, string]) => {
       const res = await fetch(url);
       if (!res.ok) throw new Error("Failed to fetch conversations");
       return res.json();
@@ -90,7 +92,8 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
   const revalidateConversationKeys = () =>
     globalMutate(
       (key: unknown) =>
-        typeof key === "string" && key.includes("/api/conversation"),
+        (typeof key === "string" && key.includes("/api/conversation")) ||
+        (Array.isArray(key) && key[0] === "/api/conversation"),
     );
 
   // Clear active conversation and enter staging state — no API call

--- a/src/features/Chat/hooks/useChatSession.ts
+++ b/src/features/Chat/hooks/useChatSession.ts
@@ -61,7 +61,6 @@ export function useChatSession() {
         body: {
           messages,
           ...body,
-          userId,
           conversationId: inFlightConvIdRef.current,
         },
       }),
@@ -183,7 +182,6 @@ export function useChatSession() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          userId,
           conversationId: targetConvId,
           role,
           content,
@@ -274,7 +272,6 @@ export function useChatSession() {
         const res = await fetch("/api/conversation", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ userId }),
         });
         if (!res.ok) {
           throw new Error(`Could not start conversation (${res.status})`);

--- a/src/lib/chat/context.test.ts
+++ b/src/lib/chat/context.test.ts
@@ -39,12 +39,20 @@ describe("loadConversationContext", () => {
     ]);
 
     const incoming = [makeUIMessage("m2", "assistant", "hi updated"), makeUIMessage("m3", "user", "new")];
-    const result = await loadConversationContext("conv-1", incoming);
+    const result = await loadConversationContext("conv-1", incoming, "user-1");
 
     expect(result).toHaveLength(3);
     expect(result[0]).toMatchObject({ id: "m1" });
     expect(result[1]).toMatchObject({ id: "m2", parts: [{ text: "hi updated" }] });
     expect(result[2]).toMatchObject({ id: "m3" });
+  });
+
+  it("scopes the history load to the session user", async () => {
+    (getMessages as jest.Mock).mockResolvedValue([]);
+    await loadConversationContext("conv-1", [makeUIMessage("m1", "user", "hi")], "user-1");
+
+    expect(getMessages).toHaveBeenCalledTimes(1);
+    expect(getMessages).toHaveBeenCalledWith("conv-1", "user-1");
   });
 
   it("caps db messages at the CONTEXT_WINDOW (15) before merging", async () => {
@@ -54,7 +62,7 @@ describe("loadConversationContext", () => {
     (getMessages as jest.Mock).mockResolvedValue(manyMessages);
 
     const incoming = [makeUIMessage("m19", "assistant", "last")];
-    const result = await loadConversationContext("conv-1", incoming);
+    const result = await loadConversationContext("conv-1", incoming, "user-1");
 
     // slice(-15) gives indices 5-19 (15 items), then drop last (index 19), giving 14 + 1 incoming = 15
     expect(result.length).toBeLessThanOrEqual(15);
@@ -63,7 +71,7 @@ describe("loadConversationContext", () => {
   it("handles empty db messages with only incoming", async () => {
     (getMessages as jest.Mock).mockResolvedValue([]);
     const incoming = [makeUIMessage("m1", "user", "first message")];
-    const result = await loadConversationContext("conv-1", incoming);
+    const result = await loadConversationContext("conv-1", incoming, "user-1");
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ id: "m1" });
   });
@@ -71,7 +79,7 @@ describe("loadConversationContext", () => {
   it("passes merged messages through validateUIMessages", async () => {
     (getMessages as jest.Mock).mockResolvedValue([makeDbMessage("m1", "user", "hello")]);
     const incoming = [makeUIMessage("m1", "user", "hello"), makeUIMessage("m2", "assistant", "hi")];
-    await loadConversationContext("conv-1", incoming);
+    await loadConversationContext("conv-1", incoming, "user-1");
     expect(validateUIMessages).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/chat/context.ts
+++ b/src/lib/chat/context.ts
@@ -5,9 +5,10 @@ const CONTEXT_WINDOW = 15;
 
 export async function loadConversationContext(
   conversationId: string,
-  incoming: UIMessage[]
+  incoming: UIMessage[],
+  userId: string
 ) {
-  const previousMessages = await getMessages(conversationId);
+  const previousMessages = await getMessages(conversationId, userId);
 
   const uiMessages = previousMessages.slice(-CONTEXT_WINDOW).map((msg) => ({
     id: msg.id,

--- a/src/lib/conversations/conversations.test.ts
+++ b/src/lib/conversations/conversations.test.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db";
 import {
   autoTitleConversation,
+  autoTitleIfNull,
   createConversation,
   deleteConversation,
   getOrCreateActiveConversation,
@@ -17,6 +18,7 @@ jest.mock("@/lib/db", () => ({
       findUnique: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn(),
       deleteMany: jest.fn(),
     },
     message: {
@@ -174,18 +176,74 @@ describe("Conversation Functions", () => {
   });
 
   describe("renameConversation", () => {
-    it("updates title and returns updated conversation", async () => {
+    it("updates title scoped to the owner and returns the updated conversation", async () => {
       const updated = makeConversation({ id: "conv-1", title: "My New Title" });
-      mockedPrisma.conversation.update.mockResolvedValue(updated);
+      mockedPrisma.conversation.updateMany.mockResolvedValue({ count: 1 });
+      mockedPrisma.conversation.findUnique.mockResolvedValue(updated);
 
-      const result = await renameConversation("conv-1", "My New Title");
+      const result = await renameConversation("conv-1", "My New Title", "user-1");
 
       expect(result.title).toBe("My New Title");
-      expect(mockedPrisma.conversation.update).toHaveBeenCalledWith({
-        where: { id: "conv-1" },
+      expect(mockedPrisma.conversation.updateMany).toHaveBeenCalledWith({
+        where: { id: "conv-1", userId: "user-1" },
         data: { title: "My New Title" },
+      });
+      expect(mockedPrisma.conversation.findUnique).toHaveBeenCalledWith({
+        where: { id: "conv-1" },
         include: { _count: { select: { messages: true } } },
       });
+    });
+
+    it("throws when the conversation is not owned by the user", async () => {
+      mockedPrisma.conversation.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        renameConversation("conv-1", "Hijack", "user-1")
+      ).rejects.toThrow("Conversation not found");
+
+      expect(mockedPrisma.conversation.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("autoTitleIfNull", () => {
+    it("titles the conversation only when owned and currently untitled", async () => {
+      mockedPrisma.conversation.findFirst.mockResolvedValue(
+        makeConversation({ id: "conv-1", title: null })
+      );
+      const titled = makeConversation({ id: "conv-1", title: "Egg ideas" });
+      mockedPrisma.conversation.update.mockResolvedValue(titled);
+
+      const result = await autoTitleIfNull("conv-1", "Egg ideas", "user-1");
+
+      expect(result?.title).toBe("Egg ideas");
+      expect(mockedPrisma.conversation.findFirst).toHaveBeenCalledWith({
+        where: { id: "conv-1", userId: "user-1" },
+      });
+      expect(mockedPrisma.conversation.update).toHaveBeenCalledWith({
+        where: { id: "conv-1" },
+        data: { title: "Egg ideas" },
+        include: { _count: { select: { messages: true } } },
+      });
+    });
+
+    it("returns null without writing when the conversation is not owned", async () => {
+      mockedPrisma.conversation.findFirst.mockResolvedValue(null);
+
+      const result = await autoTitleIfNull("conv-1", "Hijack", "user-1");
+
+      expect(result).toBeNull();
+      expect(mockedPrisma.conversation.update).not.toHaveBeenCalled();
+    });
+
+    it("returns null without writing when a title already exists", async () => {
+      mockedPrisma.conversation.findFirst.mockResolvedValue(
+        makeConversation({ id: "conv-1", title: "Existing" })
+      );
+
+      const result = await autoTitleIfNull("conv-1", "New", "user-1");
+
+      expect(result).toBeNull();
+      expect(mockedPrisma.conversation.update).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/conversations/conversations.test.ts
+++ b/src/lib/conversations/conversations.test.ts
@@ -206,44 +206,33 @@ describe("Conversation Functions", () => {
   });
 
   describe("autoTitleIfNull", () => {
-    it("titles the conversation only when owned and currently untitled", async () => {
-      mockedPrisma.conversation.findFirst.mockResolvedValue(
-        makeConversation({ id: "conv-1", title: null })
-      );
+    it("titles the conversation atomically when owned and currently untitled", async () => {
+      mockedPrisma.conversation.updateMany.mockResolvedValue({ count: 1 });
       const titled = makeConversation({ id: "conv-1", title: "Egg ideas" });
-      mockedPrisma.conversation.update.mockResolvedValue(titled);
+      mockedPrisma.conversation.findFirst.mockResolvedValue(titled);
 
       const result = await autoTitleIfNull("conv-1", "Egg ideas", "user-1");
 
       expect(result?.title).toBe("Egg ideas");
+      // The write is scoped to owner + still-null title so a concurrent rename
+      // can't be clobbered; a foreign id simply matches zero rows.
+      expect(mockedPrisma.conversation.updateMany).toHaveBeenCalledWith({
+        where: { id: "conv-1", userId: "user-1", title: null },
+        data: { title: "Egg ideas" },
+      });
       expect(mockedPrisma.conversation.findFirst).toHaveBeenCalledWith({
         where: { id: "conv-1", userId: "user-1" },
-      });
-      expect(mockedPrisma.conversation.update).toHaveBeenCalledWith({
-        where: { id: "conv-1" },
-        data: { title: "Egg ideas" },
         include: { _count: { select: { messages: true } } },
       });
     });
 
-    it("returns null without writing when the conversation is not owned", async () => {
-      mockedPrisma.conversation.findFirst.mockResolvedValue(null);
+    it("returns null without re-reading when nothing was updated (foreign id or already titled)", async () => {
+      mockedPrisma.conversation.updateMany.mockResolvedValue({ count: 0 });
 
       const result = await autoTitleIfNull("conv-1", "Hijack", "user-1");
 
       expect(result).toBeNull();
-      expect(mockedPrisma.conversation.update).not.toHaveBeenCalled();
-    });
-
-    it("returns null without writing when a title already exists", async () => {
-      mockedPrisma.conversation.findFirst.mockResolvedValue(
-        makeConversation({ id: "conv-1", title: "Existing" })
-      );
-
-      const result = await autoTitleIfNull("conv-1", "New", "user-1");
-
-      expect(result).toBeNull();
-      expect(mockedPrisma.conversation.update).not.toHaveBeenCalled();
+      expect(mockedPrisma.conversation.findFirst).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/conversations/conversations.ts
+++ b/src/lib/conversations/conversations.ts
@@ -80,22 +80,37 @@ export async function createConversation(
 
 export async function renameConversation(
   id: string,
-  title: string
+  title: string,
+  userId: string
 ): Promise<ConversationEntity> {
-  const conversation = await prisma.conversation.update({
-    where: { id },
+  // Ownership-scope the write: updateMany lets us filter on userId. A rename
+  // aimed at another user's conversation matches zero rows and 404s.
+  const result = await prisma.conversation.updateMany({
+    where: { id, userId },
     data: { title },
+  });
+
+  if (result.count === 0) {
+    throw new Error("Conversation not found");
+  }
+
+  const conversation = await prisma.conversation.findUnique({
+    where: { id },
     include: { _count: { select: { messages: true } } },
   });
 
-  return conversation;
+  return conversation as ConversationEntity;
 }
 
 export async function autoTitleIfNull(
   id: string,
-  title: string
+  title: string,
+  userId: string
 ): Promise<ConversationEntity | null> {
-  const existing = await prisma.conversation.findUnique({ where: { id } });
+  // Scope the lookup to the owner so a foreign id never gets titled.
+  const existing = await prisma.conversation.findFirst({
+    where: { id, userId },
+  });
   if (!existing || existing.title !== null) return null;
   return prisma.conversation.update({
     where: { id },

--- a/src/lib/conversations/conversations.ts
+++ b/src/lib/conversations/conversations.ts
@@ -107,14 +107,17 @@ export async function autoTitleIfNull(
   title: string,
   userId: string
 ): Promise<ConversationEntity | null> {
-  // Scope the lookup to the owner so a foreign id never gets titled.
-  const existing = await prisma.conversation.findFirst({
-    where: { id, userId },
-  });
-  if (!existing || existing.title !== null) return null;
-  return prisma.conversation.update({
-    where: { id },
+  // Scope the write itself to { id, userId, title: null } so it stays atomic:
+  // a concurrent rename or auto-title can't be clobbered between a separate
+  // check and write, and a foreign id matches zero rows.
+  const result = await prisma.conversation.updateMany({
+    where: { id, userId, title: null },
     data: { title },
+  });
+  if (result.count === 0) return null;
+
+  return prisma.conversation.findFirst({
+    where: { id, userId },
     include: { _count: { select: { messages: true } } },
   });
 }

--- a/src/lib/messages/messages.test.ts
+++ b/src/lib/messages/messages.test.ts
@@ -2,17 +2,22 @@ import { prisma } from "@/lib/db";
 import { createMessage, getMessages } from "./messages";
 
 // Mock Prisma
-jest.mock("@/lib/db", () => ({
-  prisma: {
+jest.mock("@/lib/db", () => {
+  const prismaMock = {
     message: {
       findMany: jest.fn(),
       create: jest.fn(),
     },
     conversation: {
       findUnique: jest.fn(),
+      create: jest.fn(),
     },
-  },
-}));
+    // Interactive transaction: run the callback against the same mock so the
+    // ownership check + writes are observable on the shared jest.fn()s.
+    $transaction: jest.fn((cb: (tx: unknown) => unknown) => cb(prismaMock)),
+  };
+  return { prisma: prismaMock };
+});
 
 const mockedPrisma = jest.mocked(prisma);
 
@@ -30,12 +35,7 @@ describe("Message Functions", () => {
       const mockMessages = [
         {
           id: "msg-1",
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: "Hello",
           role: "user",
@@ -43,12 +43,7 @@ describe("Message Functions", () => {
         },
         {
           id: "msg-2",
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: "Hi there!",
           role: "assistant",
@@ -97,12 +92,7 @@ describe("Message Functions", () => {
       const mockMessages = [
         {
           id: "msg-1",
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: "Conv 123 message",
           role: "user",
@@ -150,12 +140,7 @@ describe("Message Functions", () => {
       expect(result).toEqual(newMessage);
       expect(mockedPrisma.message.create).toHaveBeenCalledWith({
         data: {
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: "What can I cook?",
           role: "user",
@@ -186,12 +171,7 @@ describe("Message Functions", () => {
       expect(result).toEqual(assistantMessage);
       expect(mockedPrisma.message.create).toHaveBeenCalledWith({
         data: {
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: "You can make scrambled eggs!",
           role: "assistant",
@@ -216,12 +196,7 @@ describe("Message Functions", () => {
       expect(result).toEqual(emptyMessage);
       expect(mockedPrisma.message.create).toHaveBeenCalledWith({
         data: {
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: "",
           role: "user",
@@ -247,12 +222,7 @@ describe("Message Functions", () => {
       expect(result).toEqual(longMessage);
       expect(mockedPrisma.message.create).toHaveBeenCalledWith({
         data: {
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: longContent,
           role: "user",
@@ -278,12 +248,7 @@ describe("Message Functions", () => {
       expect(result).toEqual(specialMessage);
       expect(mockedPrisma.message.create).toHaveBeenCalledWith({
         data: {
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: specialContent,
           role: "user",
@@ -301,12 +266,7 @@ describe("Message Functions", () => {
 
       expect(mockedPrisma.message.create).toHaveBeenCalledWith({
         data: {
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: "Test message",
           role: "user",
@@ -352,12 +312,7 @@ describe("Message Functions", () => {
       expect(result).toEqual(systemMessage);
       expect(mockedPrisma.message.create).toHaveBeenCalledWith({
         data: {
-          conversation: {
-            connectOrCreate: {
-              where: { id: "conv-123" },
-              create: { id: "conv-123", userId: "user-123" },
-            },
-          },
+          conversationId: "conv-123",
           userId: "user-123",
           content: "System initialized",
           role: "system",

--- a/src/lib/messages/messages.test.ts
+++ b/src/lib/messages/messages.test.ts
@@ -8,6 +8,9 @@ jest.mock("@/lib/db", () => ({
       findMany: jest.fn(),
       create: jest.fn(),
     },
+    conversation: {
+      findUnique: jest.fn(),
+    },
   },
 }));
 
@@ -16,6 +19,10 @@ const mockedPrisma = jest.mocked(prisma);
 describe("Message Functions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: the conversation is owned by the requesting user (or doesn't
+    // exist yet, hence connectOrCreate). Individual tests override to simulate
+    // a foreign owner.
+    mockedPrisma.conversation.findUnique.mockResolvedValue(null as never);
   });
 
   describe("getMessages", () => {
@@ -51,11 +58,11 @@ describe("Message Functions", () => {
 
       mockedPrisma.message.findMany.mockResolvedValue(mockMessages);
 
-      const result = await getMessages("conv-123");
+      const result = await getMessages("conv-123", "user-123");
 
       expect(result).toEqual(mockMessages);
       expect(mockedPrisma.message.findMany).toHaveBeenCalledWith({
-        where: { conversationId: "conv-123" },
+        where: { conversationId: "conv-123", conversation: { userId: "user-123" } },
         orderBy: { createdAt: "asc" },
       });
       expect(mockedPrisma.message.findMany).toHaveBeenCalledTimes(1);
@@ -64,11 +71,11 @@ describe("Message Functions", () => {
     it("should return empty array when no messages found", async () => {
       mockedPrisma.message.findMany.mockResolvedValue([]);
 
-      const result = await getMessages("conv-456");
+      const result = await getMessages("conv-456", "user-123");
 
       expect(result).toEqual([]);
       expect(mockedPrisma.message.findMany).toHaveBeenCalledWith({
-        where: { conversationId: "conv-456" },
+        where: { conversationId: "conv-456", conversation: { userId: "user-123" } },
         orderBy: { createdAt: "asc" },
       });
     });
@@ -77,11 +84,11 @@ describe("Message Functions", () => {
       const dbError = new Error("Database connection failed");
       mockedPrisma.message.findMany.mockRejectedValue(dbError);
 
-      await expect(getMessages("conv-123")).rejects.toThrow(
+      await expect(getMessages("conv-123", "user-123")).rejects.toThrow(
         "Database connection failed"
       );
       expect(mockedPrisma.message.findMany).toHaveBeenCalledWith({
-        where: { conversationId: "conv-123" },
+        where: { conversationId: "conv-123", conversation: { userId: "user-123" } },
         orderBy: { createdAt: "asc" },
       });
     });
@@ -105,16 +112,16 @@ describe("Message Functions", () => {
 
       mockedPrisma.message.findMany.mockResolvedValue(mockMessages);
 
-      await getMessages("conv-123");
+      await getMessages("conv-123", "user-123");
 
       expect(mockedPrisma.message.findMany).toHaveBeenCalledWith({
-        where: { conversationId: "conv-123" },
+        where: { conversationId: "conv-123", conversation: { userId: "user-123" } },
         orderBy: { createdAt: "asc" },
       });
 
       // Verify it doesn't get called with different conversationId
       expect(mockedPrisma.message.findMany).not.toHaveBeenCalledWith({
-        where: { conversationId: "conv-456" },
+        where: { conversationId: "conv-456", conversation: { userId: "user-123" } },
         orderBy: { createdAt: "asc" },
       });
     });
@@ -307,6 +314,22 @@ describe("Message Functions", () => {
       });
     });
 
+    it("rejects writing into a conversation owned by another user", async () => {
+      mockedPrisma.conversation.findUnique.mockResolvedValue({
+        userId: "victim-999",
+      } as never);
+
+      await expect(
+        createMessage("conv-123", "user-123", "Hijack", "user")
+      ).rejects.toThrow("Conversation not found");
+
+      expect(mockedPrisma.conversation.findUnique).toHaveBeenCalledWith({
+        where: { id: "conv-123" },
+        select: { userId: true },
+      });
+      expect(mockedPrisma.message.create).not.toHaveBeenCalled();
+    });
+
     it("should handle different role types", async () => {
       const systemMessage = {
         id: "msg-system",
@@ -386,7 +409,7 @@ describe("Message Functions", () => {
       const allMessages = [userMessage, assistantMessage];
       mockedPrisma.message.findMany.mockResolvedValue(allMessages);
 
-      const retrievedMessages = await getMessages("conv-123");
+      const retrievedMessages = await getMessages("conv-123", "user-123");
       expect(retrievedMessages).toEqual(allMessages);
       expect(retrievedMessages).toHaveLength(2);
     });

--- a/src/lib/messages/messages.ts
+++ b/src/lib/messages/messages.ts
@@ -20,30 +20,28 @@ export async function createMessage(
   content: string,
   role: string
 ) {
-  // Guard against writing into a conversation owned by someone else. The
-  // connectOrCreate below would otherwise attach to any existing id; reject a
-  // foreign owner so a caller can't append to another user's thread.
-  const existing = await prisma.conversation.findUnique({
-    where: { id: conversationId },
-    select: { userId: true },
-  });
-  if (existing && existing.userId !== userId) {
-    throw new Error("Conversation not found");
-  }
+  // Guard against writing into a conversation owned by someone else, atomically.
+  // A separate pre-check + connectOrCreate could race: a foreign conversation
+  // created between the two would silently get our message attached. Inside a
+  // transaction we check ownership, create the conversation ourselves when it's
+  // absent (a duplicate id then fails the unique constraint rather than
+  // attaching), and write the message directly.
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.conversation.findUnique({
+      where: { id: conversationId },
+      select: { userId: true },
+    });
+    if (existing && existing.userId !== userId) {
+      throw new Error("Conversation not found");
+    }
+    if (!existing) {
+      await tx.conversation.create({
+        data: { id: conversationId, userId },
+      });
+    }
 
-  const message = await prisma.message.create({
-    data: {
-      conversation: {
-        connectOrCreate: {
-          where: { id: conversationId },
-          create: { id: conversationId, userId },
-        },
-      },
-      userId,
-      content,
-      role,
-    },
+    return tx.message.create({
+      data: { conversationId, userId, content, role },
+    });
   });
-
-  return message;
 }

--- a/src/lib/messages/messages.ts
+++ b/src/lib/messages/messages.ts
@@ -1,8 +1,13 @@
 import { prisma } from "@/lib/db";
 
-export async function getMessages(conversationId: string) {
+/**
+ * Read a conversation's messages — scoped to its owner. Filtering on the
+ * conversation relation's `userId` means a caller asking for someone else's
+ * `conversationId` simply gets an empty list, never another user's history.
+ */
+export async function getMessages(conversationId: string, userId: string) {
   const messages = await prisma.message.findMany({
-    where: { conversationId },
+    where: { conversationId, conversation: { userId } },
     orderBy: { createdAt: "asc" },
   });
 
@@ -15,6 +20,17 @@ export async function createMessage(
   content: string,
   role: string
 ) {
+  // Guard against writing into a conversation owned by someone else. The
+  // connectOrCreate below would otherwise attach to any existing id; reject a
+  // foreign owner so a caller can't append to another user's thread.
+  const existing = await prisma.conversation.findUnique({
+    where: { id: conversationId },
+    select: { userId: true },
+  });
+  if (existing && existing.userId !== userId) {
+    throw new Error("Conversation not found");
+  }
+
   const message = await prisma.message.create({
     data: {
       conversation: {


### PR DESCRIPTION
## Summary

Locks down the conversation, message, and chat routes so identity is derived from the verified better-auth session, never from a client-supplied `userId`. Unlike the earlier route-lockdown slices (#341–#343), this one also enforces **ownership in the service layer**, so a valid session for user A cannot read or mutate user B's conversations even by guessing a `conversationId`.

- `GET/POST /api/conversation`, `PATCH/DELETE /api/conversation/[id]`, `GET/POST /api/message`, and `POST /api/chat` call `getSessionUserId(req)` and return `401` when there's no valid session. A `userId` in the query/body is ignored.
- **Service-layer ownership scoping:**
  - `getMessages(conversationId, userId)` / `loadConversationContext` filter history by the conversation owner — a foreign `conversationId` returns an empty list.
  - `createMessage` rejects writes into a conversation owned by someone else (`Conversation not found`), closing the `connectOrCreate` cross-user write.
  - `renameConversation` / `autoTitleIfNull` scope writes by `{ id, userId }` (`updateMany` / `findFirst`); a foreign id matches zero rows and the route maps the throw to a `404`.
- Clients stop sending `userId` in request bodies/query (`useChatSession`, `ConversationContext` deletes). SWR keys keep `?userId=` only as a client-side cache key.

## Test plan

- `pnpm jest src/lib/conversations src/lib/messages src/lib/chat/context src/app/api/conversation src/app/api/message src/app/api/chat src/contexts` — cross-user denial at both route and service layers, plus 401s for unauthenticated callers.
- Manual: verify chat/history load and conversation rename/delete still work while signed in.

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation, message, and chat endpoints now derive identity from the signed-in session and no longer accept client-supplied user IDs.
  * Conversation context loading and message history are owner-scoped.

* **Bug Fixes**
  * Unauthenticated requests now consistently return 401.
  * Added/extended ownership enforcement for renaming, deleting, fetching, and posting messages, including clearer 404 “Conversation not found” responses.
  * Requests ignore any `userId` supplied via query/body.

* **Documentation**
  * Updated progress notes describing the secured conversation/message route behavior and remaining work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->