### PR TITLE
fix(recipe): lock down share-token mint to the owner via session

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -168,14 +168,14 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Every visitor now has a real session.** The client-generated `localStorage["ask-ah-mah-session"]` id is gone. The better-auth `anonymous()` plugin mints an unforgeable anonymous session on first load (`useSession` calls `signIn.anonymous()` when there's no session); signed-in users still use their Google session. `userId` is always `session.user.id`, and `isAuthenticated` now means non-anonymous (`!user.isAnonymous`).
 - **Server is the source of truth for identity.** New helper `getSessionUserId(req)` (`src/lib/session.ts`) resolves the caller from the verified session cookie via `auth.api.getSession`, returning the id or `null` (routes map that to a 401 via `unauthorized()`). This is the primitive the route-lockdown slices (#341–#345) build on — routes stop trusting a `userId` from the request.
 - **Schema**: `User.isAnonymous Boolean?` (additive migration `20260629000000_add_user_is_anonymous`). New anonymous users get their starter pantry seeded.
-- **Not yet wired**: share-token mint trust is #345, and guest→Google data migration on link is #346.
+- **Not yet wired**: guest→Google data migration on link is #346.
 
 ### Recipe routes locked down — Shipped (#341)
 
 - **Recipe routes derive identity from the session, never the request.** `GET/POST/DELETE /api/recipe`, `PATCH /api/recipe/[id]`, and `POST /api/recipe/[id]/tweak` now call `getSessionUserId(req)` and return `unauthorized()` (401) when there's no valid session. A `userId` in the query string or body is ignored entirely — an attacker can no longer read or mutate another user's cookbook by supplying a foreign id.
 - **Clients stopped sending `userId` in request bodies** (RecipeList delete, AddRecipeModal save, MessageList save, RecipeDisplay save, TweakBench tweak). SWR GET keys keep `?userId=` purely as a client-side cache key / fetch gate; the server disregards it. The now-unused `userId` prop was dropped from `TweakBench`.
 - **Tests** cover cross-user access being denied (query/body-supplied foreign id resolves to the session user) and 401s for unauthenticated callers, mocking `getSessionUserId`.
-- **Out of scope here**: `POST /api/recipe/[id]/share` still trusts a body `userId` — hardened separately in #345.
+- **Out of scope here**: `POST /api/recipe/[id]/share` was hardened separately in #345.
 
 ### Pantry (inventory) routes locked down — Shipped (#342)
 
@@ -198,6 +198,13 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
   - `renameConversation` / `autoTitleIfNull` scope their writes by `{ id, userId }` (`updateMany` / `findFirst`); a rename aimed at a foreign id matches zero rows and the route maps the thrown `Conversation not found` to a 404 (mirrors `deleteConversation`).
 - **Clients stopped sending `userId` in request bodies / query** (`useChatSession` chat transport + message POST + conversation create; `ConversationContext` deletes). SWR keys keep `?userId=` only as a client-side cache key.
 - **Tests** cover cross-user denial at both the route and service layers, plus 401s for unauthenticated callers, mocking `getSessionUserId`.
+
+### Share-token mint locked down — Shipped (#345)
+
+- **Minting a share link is owner-only, derived from the session.** `POST /api/recipe/[id]/share` calls `getSessionUserId(req)` and returns `unauthorized()` (401) when there's no session; a `userId` in the body is ignored. `mintShareToken(id, userId)` was already owner-scoped (`findFirst` + compare-and-set `updateMany` both filter on `{ id, userId }`), so a non-owner's mint resolves to "not found" → the route returns 404. The client (`RecipeDisplay` share button) stopped sending `userId` — the session cookie is the identity.
+- **The public read path stays open by design.** `/r/<token>` and `getRecipeByShareToken(token)` match on the token alone (never `userId`), require no session, and project a public shape that omits owner-scoped fields (`userId`, `shareToken`). Anyone with the link can view that one recipe.
+- **Tests** cover owner-can-mint, non-owner/unauthenticated cannot (401/404), idempotent re-mint, and the public read working token-only with owner fields never selected.
+- This completes the route-lockdown series (#341–#345); the now-unused `missingUserId()` 400 helper was removed (every route uses `unauthorized()`).
 
 ## Design system
 

--- a/src/app/api/recipe/[id]/share/route.test.ts
+++ b/src/app/api/recipe/[id]/share/route.test.ts
@@ -1,0 +1,71 @@
+import { mintShareToken } from "@/lib/recipes";
+import { getSessionUserId } from "@/lib/session";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+jest.mock("@/lib/recipes", () => ({ mintShareToken: jest.fn() }));
+
+// Identity comes from the verified session, never the request body.
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
+
+jest.mock("next/server", () => ({
+  NextRequest: jest.fn(),
+  NextResponse: {
+    json: jest.fn((data, init) => ({
+      json: async () => data,
+      status: init?.status ?? 200,
+    })),
+  },
+}));
+
+const mockedMint = jest.mocked(mintShareToken);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
+
+const makeRequest = (body?: unknown) =>
+  ({ json: async () => body ?? {} }) as NextRequest;
+const params = Promise.resolve({ id: "recipe-1" });
+
+describe("POST /api/recipe/[id]/share", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: an authenticated caller. Tests override to simulate no session.
+    mockedGetSessionUserId.mockResolvedValue("user-123");
+  });
+
+  it("mints a token for the owner and returns it", async () => {
+    mockedMint.mockResolvedValue("tok_abc");
+
+    const res = await POST(makeRequest(), { params });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ token: "tok_abc" });
+    expect(mockedMint).toHaveBeenCalledWith("recipe-1", "user-123");
+  });
+
+  it("returns 401 without minting when unauthenticated", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(), { params });
+
+    expect(res.status).toBe(401);
+    expect(mockedMint).not.toHaveBeenCalled();
+  });
+
+  it("ignores a userId in the body and mints as the session user", async () => {
+    mockedMint.mockResolvedValue("tok_abc");
+
+    await POST(makeRequest({ userId: "victim-999" }), { params });
+
+    expect(mockedMint).toHaveBeenCalledTimes(1);
+    expect(mockedMint).toHaveBeenCalledWith("recipe-1", "user-123");
+  });
+
+  it("returns 404 when the recipe is not the caller's (mint throws 'not found')", async () => {
+    mockedMint.mockRejectedValue(new Error("not found"));
+
+    const res = await POST(makeRequest(), { params });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Recipe not found" });
+  });
+});

--- a/src/app/api/recipe/[id]/share/route.ts
+++ b/src/app/api/recipe/[id]/share/route.ts
@@ -1,8 +1,12 @@
 import { mintShareToken } from "@/lib/recipes";
-import { missingUserId } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
+import { unauthorized } from "@/lib/http";
 import { NextRequest, NextResponse } from "next/server";
 
 // Mints (or returns) the public share token for a recipe the caller owns.
+// Identity comes from the verified session; a request-supplied userId is
+// ignored, so only the owner can mint a link for their own recipe. The public
+// read path (/r/<token>, getRecipeByShareToken) stays open by design.
 // Idempotent: repeated calls return the same token.
 export async function POST(
   req: NextRequest,
@@ -10,16 +14,13 @@ export async function POST(
 ) {
   const { id } = await params;
 
-  try {
-    const { userId } = await req.json();
-    if (!userId) return missingUserId();
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
 
+  try {
     const token = await mintShareToken(id, userId);
     return NextResponse.json({ token });
   } catch (err) {
-    if (err instanceof SyntaxError) {
-      return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
-    }
     if (err instanceof Error && err.message === "not found") {
       return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
     }

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -536,10 +536,9 @@ export default function RecipeDisplay({
     if (!userId || sharing) return;
     setSharing(true);
     try {
+      // Identity comes from the session cookie; the server ignores any body.
       const res = await fetch(`/api/recipe/${recipe.id}/share`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId }),
       });
       if (!res.ok) throw new Error("share failed");
       const { token } = await res.json();

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,9 +1,5 @@
 import { NextResponse } from "next/server";
 
-export function missingUserId() {
-  return NextResponse.json({ error: "userId is required" }, { status: 400 });
-}
-
 export function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 }

--- a/src/lib/recipes/recipes.test.ts
+++ b/src/lib/recipes/recipes.test.ts
@@ -1,6 +1,11 @@
 import { prisma } from "@/lib/db";
 import { fetchRecipePhoto } from "@/lib/pexels/fetchPhoto";
-import { deleteRecipeForUser, saveRecipeFromBlock } from "./recipes";
+import {
+  deleteRecipeForUser,
+  getRecipeByShareToken,
+  mintShareToken,
+  saveRecipeFromBlock,
+} from "./recipes";
 import type { RecipeBlock } from "./schemas";
 
 jest.mock("@/lib/db", () => ({
@@ -8,6 +13,9 @@ jest.mock("@/lib/db", () => ({
     recipe: {
       create: jest.fn(),
       deleteMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      updateMany: jest.fn(),
     },
   },
 }));
@@ -135,5 +143,75 @@ describe("deleteRecipeForUser", () => {
     (mockPrisma.recipe.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
 
     await expect(deleteRecipeForUser("recipe-1", "user-1")).resolves.not.toThrow();
+  });
+});
+
+describe("mintShareToken", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("mints and returns a new token for a recipe the user owns", async () => {
+    (mockPrisma.recipe.findFirst as jest.Mock).mockResolvedValueOnce({
+      shareToken: null,
+    });
+    (mockPrisma.recipe.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+    const token = await mintShareToken("recipe-1", "user-1");
+
+    expect(typeof token).toBe("string");
+    expect(token.length).toBeGreaterThan(0);
+    // The owner lookup AND the compare-and-set write are both scoped to userId.
+    expect(mockPrisma.recipe.findFirst).toHaveBeenCalledWith({
+      where: { id: "recipe-1", userId: "user-1" },
+      select: { shareToken: true },
+    });
+    expect(mockPrisma.recipe.updateMany).toHaveBeenCalledWith({
+      where: { id: "recipe-1", userId: "user-1", shareToken: null },
+      data: { shareToken: token },
+    });
+  });
+
+  it("is idempotent — returns the existing token without a second write", async () => {
+    (mockPrisma.recipe.findFirst as jest.Mock).mockResolvedValueOnce({
+      shareToken: "tok_existing",
+    });
+
+    const token = await mintShareToken("recipe-1", "user-1");
+
+    expect(token).toBe("tok_existing");
+    expect(mockPrisma.recipe.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("throws 'not found' when the recipe is not the user's (non-owner cannot mint)", async () => {
+    (mockPrisma.recipe.findFirst as jest.Mock).mockResolvedValueOnce(null);
+
+    await expect(mintShareToken("recipe-1", "attacker")).rejects.toThrow(
+      "not found",
+    );
+    expect(mockPrisma.recipe.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("getRecipeByShareToken", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("resolves a recipe by token alone — no userId, no session required", async () => {
+    const publicRow = { id: "recipe-1", name: "Char Kway Teow" };
+    (mockPrisma.recipe.findUnique as jest.Mock).mockResolvedValue(publicRow);
+
+    const result = await getRecipeByShareToken("tok_abc");
+
+    expect(result).toBe(publicRow);
+    const call = (mockPrisma.recipe.findUnique as jest.Mock).mock.calls[0][0];
+    // Matches on the token only — never userId — so anyone with the link reads it.
+    expect(call.where).toEqual({ shareToken: "tok_abc" });
+    // Owner-scoped fields must never be selected into the public projection.
+    expect(call.select).not.toHaveProperty("userId");
+    expect(call.select).not.toHaveProperty("shareToken");
+  });
+
+  it("returns null for an unknown token", async () => {
+    (mockPrisma.recipe.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(getRecipeByShareToken("nope")).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- `POST /api/recipe/[id]/share` now derives identity from the verified better-auth session via `getSessionUserId` and returns 401 without one. Any `userId` in the body is ignored.
- `mintShareToken(id, userId)` was already owner-scoped (compare-and-set `findFirst` + `updateMany`, both filtered by `userId`), so a non-owner mint resolves to "not found" → 404.
- The public read path stays open by design: `getRecipeByShareToken(token)` matches the token alone with no session, projecting `PUBLIC_RECIPE_SELECT` (never `userId`/`shareToken`). `/r/<token>` continues to work for anyone with the link.
- Client share button stops sending `userId`.
- Removed the now-unused `missingUserId()` 400 helper — every route now uses `unauthorized()`. This completes the #341–#345 lockdown series.

## Test plan
- `pnpm jest src/app/api/recipe src/lib/recipes` — route + service tests green
- Tests cover: owner can mint, non-owner/unauthenticated cannot (401/404), body `userId` ignored, idempotent re-mint, public read works token-only.
- Manual: as the recipe owner, share a recipe → token returned; open `/r/<token>` in a logged-out browser → recipe renders.

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)