### PR TITLE
fix(auth): gate stateless model endpoints behind a session (#358)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -218,6 +218,11 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Tests** cover owner-can-mint, non-owner/unauthenticated cannot (401/404), idempotent re-mint, and the public read working token-only with owner fields never selected.
 - This completes the route-lockdown series (#341–#345); the now-unused `missingUserId()` 400 helper was removed (every route uses `unauthorized()`).
 
+### Stateless model endpoints gated — Shipped (#358)
+
+- **The three model-calling routes that hold no user data are now session-gated too.** `POST /api/market-tip`, `POST /api/storage-tip`, and `POST /api/recipe/extract` call `getSessionUserId(req)` and return `unauthorized()` (401) before any `generateObject` / `parseRecipeText` call. The lockdown series (#341–#345) scoped the *data-owning* routes; these three were skipped because they read/write only the shared tip cache (or nothing), so there was no IDOR — but they were left **open to anonymous cost abuse** (loop them to burn OpenAI budget). This closes that gap: every model-calling route now requires a session, and anonymous visitors already carry one, so the app's own calls are unaffected.
+- **Tests** assert a 401 (with no model call) for each route when unauthenticated; `recipe/extract` gained its first test file.
+
 ## Design system
 
 The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — were drifting because each hand-rolled the same primitives. A design system is now the north star: shared atoms stop drift, and every surface gets tweaked incrementally so it "looks like it belongs". See the spec at `docs/superpowers/specs/2026-06-20-recipe-design-system-design.md` and the issue tracker (#277–#285).

--- a/src/app/api/market-tip/route.test.ts
+++ b/src/app/api/market-tip/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { POST } from "./route";
 import { prisma } from "@/lib/db";
+import { getSessionUserId } from "@/lib/session";
 import { generateObject } from "ai";
 
 jest.mock("next/server", () => ({
@@ -24,10 +25,12 @@ jest.mock("@/lib/db", () => ({
 
 jest.mock("ai", () => ({ generateObject: jest.fn() }));
 jest.mock("@ai-sdk/openai", () => ({ openai: jest.fn(() => "model") }));
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
 
 const mockedFindMany = jest.mocked(prisma.marketTip.findMany);
 const mockedCreate = jest.mocked(prisma.marketTip.create);
 const mockedGenerate = jest.mocked(generateObject);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 const reqWith = (body: unknown) =>
   ({ json: async () => body } as unknown as NextRequest);
@@ -35,9 +38,20 @@ const reqWith = (body: unknown) =>
 beforeEach(() => {
   jest.clearAllMocks();
   mockedCreate.mockResolvedValue({} as never);
+  mockedGetSessionUserId.mockResolvedValue("user-123");
 });
 
 describe("POST /api/market-tip", () => {
+  it("401s when unauthenticated, without calling the model", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
+
+    const res = await POST(reqWith({ items: [{ name: "Tomato" }] }));
+
+    expect(res.status).toBe(401);
+    expect(mockedGenerate).not.toHaveBeenCalled();
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+
   it("returns cached tips without calling the model", async () => {
     mockedFindMany.mockResolvedValue([
       { key: "tomato", tip: "deep red, no bruises", createdAt: new Date() },

--- a/src/app/api/market-tip/route.ts
+++ b/src/app/api/market-tip/route.ts
@@ -1,4 +1,6 @@
 import { prisma } from "@/lib/db";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { canonicalTipKey } from "@/lib/marketTips/canonicalKey";
 import { isPickableCategory } from "@/lib/marketTips/pickable";
 import { KITCHEN_DOMAIN_RULE } from "@/lib/marketTips/relevance";
@@ -25,6 +27,12 @@ const TipGenSchema = z.object({
 
 export async function POST(req: NextRequest) {
   try {
+    // Model-calling endpoint: gate on a verified session so anonymous callers
+    // can't loop it and burn token budget. Anonymous visitors still carry a
+    // session cookie, so the app's own calls are unaffected.
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
+
     let payload: unknown;
     try {
       payload = await req.json();

--- a/src/app/api/recipe/extract/route.test.ts
+++ b/src/app/api/recipe/extract/route.test.ts
@@ -1,0 +1,70 @@
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+import { getSessionUserId } from "@/lib/session";
+import { parseRecipeText } from "@/lib/recipes/parseRecipeText";
+
+jest.mock("next/server", () => ({
+  NextRequest: jest.fn(),
+  NextResponse: {
+    json: jest.fn((data, init) => ({
+      json: async () => data,
+      status: init?.status || 200,
+    })),
+  },
+}));
+
+jest.mock("@/lib/recipes/parseRecipeText", () => ({
+  parseRecipeText: jest.fn(),
+}));
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
+
+const mockedParse = jest.mocked(parseRecipeText);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
+
+const reqWith = (body: unknown) =>
+  ({ json: async () => body } as unknown as NextRequest);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetSessionUserId.mockResolvedValue("user-123");
+});
+
+describe("POST /api/recipe/extract", () => {
+  it("401s when unauthenticated, without calling the model", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
+
+    const res = await POST(reqWith({ text: "1 egg\nfry it" }));
+
+    expect(res.status).toBe(401);
+    expect(mockedParse).not.toHaveBeenCalled();
+  });
+
+  it("400s when text is missing", async () => {
+    const res = await POST(reqWith({}));
+
+    expect(res.status).toBe(400);
+    expect(mockedParse).not.toHaveBeenCalled();
+  });
+
+  it("returns the parsed block for a valid recipe", async () => {
+    const block = {
+      ingredients: [{ name: "egg" }],
+      steps: ["fry it"],
+    };
+    mockedParse.mockResolvedValue(block as never);
+
+    const res = await POST(reqWith({ text: "1 egg\nfry it" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(block);
+  });
+
+  it("422s when no recipe can be found in the text", async () => {
+    mockedParse.mockResolvedValue({ ingredients: [], steps: [] } as never);
+
+    const res = await POST(reqWith({ text: "just some prose" }));
+
+    expect(res.status).toBe(422);
+  });
+});

--- a/src/app/api/recipe/extract/route.ts
+++ b/src/app/api/recipe/extract/route.ts
@@ -1,7 +1,15 @@
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { parseRecipeText } from "@/lib/recipes/parseRecipeText";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(req: NextRequest) {
+  // Model-calling endpoint: gate on a verified session so anonymous callers
+  // can't loop it and burn token budget. Anonymous visitors still carry a
+  // session cookie, so the app's own calls are unaffected.
+  const userId = await getSessionUserId(req);
+  if (!userId) return unauthorized();
+
   const body = await req.json();
   const { text } = body;
 

--- a/src/app/api/storage-tip/route.test.ts
+++ b/src/app/api/storage-tip/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { POST } from "./route";
 import { prisma } from "@/lib/db";
+import { getSessionUserId } from "@/lib/session";
 import { generateObject } from "ai";
 
 jest.mock("next/server", () => ({
@@ -24,10 +25,12 @@ jest.mock("@/lib/db", () => ({
 
 jest.mock("ai", () => ({ generateObject: jest.fn() }));
 jest.mock("@ai-sdk/openai", () => ({ openai: jest.fn(() => "model") }));
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
 
 const mockedFindMany = jest.mocked(prisma.storageTip.findMany);
 const mockedCreate = jest.mocked(prisma.storageTip.create);
 const mockedGenerate = jest.mocked(generateObject);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
 
 const reqWith = (body: unknown) =>
   ({ json: async () => body } as unknown as NextRequest);
@@ -35,9 +38,22 @@ const reqWith = (body: unknown) =>
 beforeEach(() => {
   jest.clearAllMocks();
   mockedCreate.mockResolvedValue({} as never);
+  mockedGetSessionUserId.mockResolvedValue("user-123");
 });
 
 describe("POST /api/storage-tip", () => {
+  it("401s when unauthenticated, without calling the model", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
+
+    const res = await POST(
+      reqWith({ items: [{ name: "Potato", type: "ingredient" }] }),
+    );
+
+    expect(res.status).toBe(401);
+    expect(mockedGenerate).not.toHaveBeenCalled();
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+
   it("returns cached tips without calling the model", async () => {
     mockedFindMany.mockResolvedValue([
       { key: "potato", tip: "cool, dark place — never the fridge", createdAt: new Date() },

--- a/src/app/api/storage-tip/route.ts
+++ b/src/app/api/storage-tip/route.ts
@@ -1,4 +1,6 @@
 import { prisma } from "@/lib/db";
+import { unauthorized } from "@/lib/http";
+import { getSessionUserId } from "@/lib/session";
 import { canonicalTipKey } from "@/lib/marketTips/canonicalKey";
 import { KITCHEN_DOMAIN_RULE } from "@/lib/marketTips/relevance";
 import { openai } from "@ai-sdk/openai";
@@ -25,6 +27,12 @@ const TipGenSchema = z.object({
 
 export async function POST(req: NextRequest) {
   try {
+    // Model-calling endpoint: gate on a verified session so anonymous callers
+    // can't loop it and burn token budget. Anonymous visitors still carry a
+    // session cookie, so the app's own calls are unaffected.
+    const userId = await getSessionUserId(req);
+    if (!userId) return unauthorized();
+
     let payload: unknown;
     try {
       payload = await req.json();


### PR DESCRIPTION
## What

Gates the three model-calling routes that hold no user data behind a verified session:

- `POST /api/market-tip`
- `POST /api/storage-tip`
- `POST /api/recipe/extract`

Each now calls `getSessionUserId(req)` and returns `unauthorized()` (401) **before** any `generateObject` / `parseRecipeText` call.

## Why

The route-lockdown series (#341–#345) locked down every *data-owning* route but skipped these three — they read/write only the shared tip cache (or nothing), so there was no IDOR. But that left them **open to anonymous cost abuse**: anyone could loop them to burn OpenAI budget. This closes that gap; every model-calling route now requires a session. Anonymous visitors already carry a session cookie, so the app's own calls are unaffected.

## Tests

- Each route asserts a **401 with no model call** when unauthenticated.
- `recipe/extract` gained its first test file (401, 400-missing-text, 200 happy path, 422 no-recipe).
- Full suite green: 593 passing.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `POST` endpoints for tip generation and recipe extraction now require a valid session before processing requests.
  * Unauthenticated requests return `401` immediately, preventing model calls and cache/database access.
  * Added and expanded tests to verify `401` responses and confirm no downstream processing occurs without a session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->