### PR TITLE
feat(chat): keep Ah Mah's Singlish voice but gloss region-specific terms

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -223,6 +223,12 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **The three model-calling routes that hold no user data are now session-gated too.** `POST /api/market-tip`, `POST /api/storage-tip`, and `POST /api/recipe/extract` call `getSessionUserId(req)` and return `unauthorized()` (401) before any `generateObject` / `parseRecipeText` call. The lockdown series (#341–#345) scoped the *data-owning* routes; these three were skipped because they read/write only the shared tip cache (or nothing), so there was no IDOR — but they were left **open to anonymous cost abuse** (loop them to burn OpenAI budget). This closes that gap: every model-calling route now requires a session, and anonymous visitors already carry one, so the app's own calls are unaffected.
 - **Tests** assert a 401 (with no model call) for each route when unauthenticated; `recipe/extract` gained its first test file.
 
+### Comprehensible-voice fragment — Shipped Jul 2026 (#365)
+
+- **Ah Mah stays fully in character but no longer confuses non-Singaporean users.** New `PROMPT_FRAGMENTS.comprehensibleVoice` fragment (`src/lib/prompts/fragments.ts`) instructs the model to keep particles/warmth/cadence untouched, gloss genuinely region-specific terms inline on first mention only (e.g. "ikan bilis (dried anchovies)", "kangkong (water spinach)"), and never gloss globally-known terms (wok, bok choy, tofu). Wired into `CHAT_SYSTEM_PROMPT` for this slice; `storage-tip` and `market-tip` routes follow in #366 so all three persona surfaces share the one rule.
+- **Decision: comprehension over localization.** Considered and rejected geo-detecting SG/MY users to toggle Singlish on/off — it strips the persona for exactly the non-local users drawn to it, and mislabels the SG/MY diaspora whose IP reads as elsewhere. Glossing fixes comprehension for everyone with no detection and no second voice to maintain.
+- Verified live against `gpt-4.1-mini`: region-specific terms (ikan bilis, tapau, kangkong, belacan) glossed on first mention; wok/bok choy left alone; Singlish particles and warm asides unchanged.
+
 ## Design system
 
 The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — were drifting because each hand-rolled the same primitives. A design system is now the north star: shared atoms stop drift, and every surface gets tweaked incrementally so it "looks like it belongs". See the spec at `docs/superpowers/specs/2026-06-20-recipe-design-system-design.md` and the issue tracker (#277–#285).

--- a/src/app/api/chat/constants.test.ts
+++ b/src/app/api/chat/constants.test.ts
@@ -1,4 +1,5 @@
 import { extractRecipeBlocks } from "@/lib/recipes/parseBlocks";
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { RecipeBlockSchema } from "@/lib/recipes/schemas";
 import { CHAT_SYSTEM_PROMPT } from "./constants";
 
@@ -20,5 +21,9 @@ describe("CHAT_SYSTEM_PROMPT recipe example", () => {
     // the issue requires must remain in the prompt.
     expect(CHAT_SYSTEM_PROMPT).toContain("Step depth is earned");
     expect(CHAT_SYSTEM_PROMPT).toContain("Never echo absolute quantities into step bodies");
+  });
+
+  it("carries the shared comprehensible-voice fragment", () => {
+    expect(CHAT_SYSTEM_PROMPT).toContain(PROMPT_FRAGMENTS.comprehensibleVoice);
   });
 });

--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -2,6 +2,8 @@ import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 
 export const CHAT_SYSTEM_PROMPT = `You are Ah Mah, a warm Singaporean grandmother who teaches home cooking. You speak warmly and casually, with the occasional "lah", "ah", or "aiyah" landing naturally — not performatively.
 
+${PROMPT_FRAGMENTS.comprehensibleVoice}
+
 **Off-topic policy.** You only know cooking. For anything else — science, history, news, politics, weather, math, sports, anything not food/cooking/kitchen — DO NOT attempt an answer. No explanations, no half-explanations, no "but since you ask…" pivots into facts. A granny doesn't lecture on Rayleigh scattering. Reply short and warm, in character, then offer a cooking turn. Examples:
 - "Aiyah, why ask me? I only know what's in the wok. But if you want something *blue* on the table tonight — butterfly pea flower rice, can?"
 - "Cannot lah, that one outside my kitchen. Tell me what's in your fridge instead?"

--- a/src/lib/prompts/fragments.ts
+++ b/src/lib/prompts/fragments.ts
@@ -24,6 +24,8 @@ function buildTagCatalog(): string {
     .join("\n");
 }
 
+const COMPREHENSIBLE_VOICE = `**Stay understandable to everyone, not just Singaporeans.** Keep your voice fully intact — particles ("lah", "ah", "aiyah"), warmth, cadence, grammar rhythm — none of that changes. But the first time you mention a genuinely region-specific term (a dish, ingredient, or place a global audience won't know — e.g. "ikan bilis", "tapau", "kangkong", "wet market"), gloss it inline with a short parenthetical: "ikan bilis (dried anchovies)", "tapau (pack it to go)". Gloss that term only once per conversation — don't re-gloss it on later mentions. Never gloss globally-understood terms (wok, bok choy, tofu, soy, ginger) — that reads as condescending, not helpful.`;
+
 export const PROMPT_FRAGMENTS = {
   /** Full "value — examples" block for ingredient category rules. */
   categoryRules: buildCategoryRules(),
@@ -31,4 +33,6 @@ export const PROMPT_FRAGMENTS = {
   categoryList: CategorySchema.options.join(", "),
   /** Tag catalog string for recipe tag selection prompts. */
   tagCatalog: buildTagCatalog(),
+  /** Keeps Ah Mah's Singlish voice while glossing region-specific terms on first mention. */
+  comprehensibleVoice: COMPREHENSIBLE_VOICE,
 } as const;


### PR DESCRIPTION
## Summary
- Adds a shared `PROMPT_FRAGMENTS.comprehensibleVoice` fragment (`src/lib/prompts/fragments.ts`) so non-Singaporean users can follow Ah Mah without stalling on opaque terms, while her particles, warmth, and cadence stay fully intact — no proper-English rewrite, no geo detection, no second voice.
- Region-specific terms (e.g. "ikan bilis", "tapau", "kangkong") get a light inline gloss on first mention only; globally-known terms (wok, bok choy, tofu) are never glossed.
- Wired into `CHAT_SYSTEM_PROMPT` for this slice. `storage-tip` and `market-tip` routes reuse the same fragment in a follow-up (#366), so all three persona surfaces stay consistent from one source of truth.
- Adds a regression test asserting the fragment is present in `CHAT_SYSTEM_PROMPT`.
- Docs: logged the decision (and why geo-toggling was rejected) in `docs/progress.md`.

Closes #365

## Test plan
- [x] `pnpm jest` — full suite passes (594/594)
- [x] `pnpm tsc --noEmit` — no new type errors (confirmed pre-existing errors are unchanged from `main`)
- [x] `pnpm lint` — no new warnings/errors in touched files
- [x] Live spot-check against `gpt-4.1-mini` with the updated prompt: region-specific terms (ikan bilis, tapau, kangkong, belacan) glossed on first mention; wok/bok choy left alone; Singlish particles and warm asides unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)