### PR TITLE
refactor(recipes): extract normalizeIngredient helper (#362)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -218,6 +218,10 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Tests** cover owner-can-mint, non-owner/unauthenticated cannot (401/404), idempotent re-mint, and the public read working token-only with owner fields never selected.
 - This completes the route-lockdown series (#341–#345); the now-unused `missingUserId()` 400 helper was removed (every route uses `unauthorized()`).
 
+### normalizeIngredient extracted — Shipped (#362)
+
+- **Ingredient normalisation lives in one place.** `saveRecipeFromBlock` and `updateRecipeForUser` both had an identical inline map — same `category ?? "Misc"` default and the same `parseFloat` / `Number.isNaN` amount-coercion. Extracted to `src/lib/recipes/normalizeIngredient.ts` (mirrors `normalizeTags.ts`); both call sites become one-liner `.map(normalizeIngredient)` calls. A unit-test file covers the amount-parsing edge cases (valid numeric, non-numeric, undefined, decimal) and the category default.
+
 ### Stateless model endpoints gated — Shipped (#358)
 
 - **The three model-calling routes that hold no user data are now session-gated too.** `POST /api/market-tip`, `POST /api/storage-tip`, and `POST /api/recipe/extract` call `getSessionUserId(req)` and return `unauthorized()` (401) before any `generateObject` / `parseRecipeText` call. The lockdown series (#341–#345) scoped the *data-owning* routes; these three were skipped because they read/write only the shared tip cache (or nothing), so there was no IDOR — but they were left **open to anonymous cost abuse** (loop them to burn OpenAI budget). This closes that gap: every model-calling route now requires a session, and anonymous visitors already carry one, so the app's own calls are unaffected.

--- a/src/lib/recipes/normalizeIngredient.test.ts
+++ b/src/lib/recipes/normalizeIngredient.test.ts
@@ -1,0 +1,40 @@
+import { normalizeIngredient } from "./normalizeIngredient";
+
+describe("normalizeIngredient", () => {
+  it("parses a valid numeric string amount", () => {
+    const result = normalizeIngredient({ name: "flour", amount: "200", unit: "g" });
+    expect(result.amount).toBe(200);
+  });
+
+  it("returns undefined amount when string is not a number", () => {
+    const result = normalizeIngredient({ name: "salt", amount: "to taste" });
+    expect(result.amount).toBeUndefined();
+  });
+
+  it("returns undefined amount when amount is undefined", () => {
+    const result = normalizeIngredient({ name: "pepper" });
+    expect(result.amount).toBeUndefined();
+  });
+
+  it("defaults category to Misc when omitted", () => {
+    const result = normalizeIngredient({ name: "egg" });
+    expect(result.category).toBe("Misc");
+  });
+
+  it("preserves an explicit category", () => {
+    const result = normalizeIngredient({ name: "chicken", category: "Protein" });
+    expect(result.category).toBe("Protein");
+  });
+
+  it("passes through name, unit, and note unchanged", () => {
+    const result = normalizeIngredient({ name: "oil", unit: "tbsp", note: "extra virgin" });
+    expect(result.name).toBe("oil");
+    expect(result.unit).toBe("tbsp");
+    expect(result.note).toBe("extra virgin");
+  });
+
+  it("handles decimal string amounts", () => {
+    const result = normalizeIngredient({ name: "butter", amount: "1.5", unit: "tbsp" });
+    expect(result.amount).toBe(1.5);
+  });
+});

--- a/src/lib/recipes/normalizeIngredient.ts
+++ b/src/lib/recipes/normalizeIngredient.ts
@@ -1,0 +1,9 @@
+import type { RecipeIngredientModel } from "./schemas";
+
+export function normalizeIngredient(ing: RecipeIngredientModel) {
+  const amount =
+    ing.amount !== undefined && !Number.isNaN(parseFloat(ing.amount))
+      ? parseFloat(ing.amount)
+      : undefined;
+  return { name: ing.name, category: ing.category ?? "Misc", amount, unit: ing.unit, note: ing.note };
+}

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -3,7 +3,8 @@ import { fetchRecipePhoto } from "../pexels/fetchPhoto";
 import type { PexelsPhoto } from "../pexels/fetchPhoto";
 import { prisma } from "../db";
 import { normalizeTags } from "./normalizeTags";
-import { Recipe, RecipeBlock, RecipeIngredientModel } from "./schemas";
+import { normalizeIngredient } from "./normalizeIngredient";
+import { Recipe, RecipeBlock } from "./schemas";
 
 export async function getRecipes(userId: string) {
   const recipes = await prisma.recipe.findMany({
@@ -51,18 +52,7 @@ export async function updateRecipeForUser(id: string, userId: string, block: Rec
       name: block.title,
       tags: normalizeTags(block.tags ?? []),
       baseServings: block.baseServings,
-      ingredients: block.ingredients.map((ing: RecipeIngredientModel) => ({
-        name: ing.name,
-        category: ing.category ?? "Misc",
-        amount:
-          ing.amount !== undefined
-            ? Number.isNaN(parseFloat(ing.amount))
-              ? undefined
-              : parseFloat(ing.amount)
-            : undefined,
-        unit: ing.unit,
-        note: ing.note,
-      })),
+      ingredients: block.ingredients.map(normalizeIngredient),
       prep: block.prep ?? [],
       steps: block.steps ?? [],
       notes: block.notes ?? [],
@@ -160,13 +150,7 @@ export async function saveRecipeFromBlock(block: RecipeBlock, userId: string, re
       tags,
       recipeId,
       baseServings: block.baseServings,
-      ingredients: block.ingredients.map((ing: RecipeIngredientModel) => ({
-        name: ing.name,
-        category: ing.category ?? "Misc",
-        amount: ing.amount !== undefined ? (Number.isNaN(parseFloat(ing.amount)) ? undefined : parseFloat(ing.amount)) : undefined,
-        unit: ing.unit,
-        note: ing.note,
-      })),
+      ingredients: block.ingredients.map(normalizeIngredient),
       prep: block.prep ?? [],
       steps: block.steps,
       notes: block.notes ?? [],


### PR DESCRIPTION
## Summary

- Extracted the duplicated ingredient-normalisation logic from `saveRecipeFromBlock` and `updateRecipeForUser` into a single `normalizeIngredient` function in `src/lib/recipes/normalizeIngredient.ts`
- Mirrors the existing `normalizeTags.ts` pattern — same file shape, same test structure
- Both call sites collapse to `.map(normalizeIngredient)`
- Added `normalizeIngredient.test.ts` covering: valid numeric amount, non-numeric string → `undefined`, missing amount → `undefined`, decimal amount, explicit category, default `"Misc"` category, pass-through of `name`/`unit`/`note`

Closes #362

## Test plan
- [ ] All 601 tests pass (`pnpm jest`)
- [ ] `normalizeIngredient.test.ts` runs green (7 new cases)
- [ ] Existing `recipes.test.ts` still green (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)