### PR TITLE
feat(tips): apply comprehensible-voice fragment to storage-tip & market-tip

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -229,6 +229,11 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Decision: comprehension over localization.** Considered and rejected geo-detecting SG/MY users to toggle Singlish on/off — it strips the persona for exactly the non-local users drawn to it, and mislabels the SG/MY diaspora whose IP reads as elsewhere. Glossing fixes comprehension for everyone with no detection and no second voice to maintain.
 - Verified live against `gpt-4.1-mini`: region-specific terms (ikan bilis, tapau, kangkong, belacan) glossed on first mention; wok/bok choy left alone; Singlish particles and warm asides unchanged.
 
+### Comprehensible-voice fragment extended to tip surfaces — Shipped Jul 2026 (#366)
+
+- **`storage-tip` and `market-tip` now share the same `PROMPT_FRAGMENTS.comprehensibleVoice` fragment as chat** (#365) — no rule text duplicated, all three persona surfaces stay consistent from one source of truth.
+- Verified live against `gpt-5-mini` (the model these two routes use): "ikan bilis (dried anchovies)", "belacan (fermented shrimp paste)", and "kangkong (water spinach)" glossed on first mention in both a storage tip and a market tip; "wok", "bok choy", and "tofu" left alone. The gloss comfortably coexists with the existing 12-word tip cap.
+
 ## Design system
 
 The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — were drifting because each hand-rolled the same primitives. A design system is now the north star: shared atoms stop drift, and every surface gets tweaked incrementally so it "looks like it belongs". See the spec at `docs/superpowers/specs/2026-06-20-recipe-design-system-design.md` and the issue tracker (#277–#285).

--- a/src/app/api/market-tip/route.test.ts
+++ b/src/app/api/market-tip/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { POST } from "./route";
 import { prisma } from "@/lib/db";
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { getSessionUserId } from "@/lib/session";
 import { generateObject } from "ai";
 
@@ -129,5 +130,17 @@ describe("POST /api/market-tip", () => {
     expect(mockedCreate).not.toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ key: "avocado" }) }),
     );
+  });
+
+  it("carries the shared comprehensible-voice fragment in the model prompt", async () => {
+    mockedFindMany.mockResolvedValue([] as never);
+    mockedGenerate.mockResolvedValue({
+      object: { tips: [{ key: "avocado", tip: "dark, gives slightly" }] },
+    } as never);
+
+    await POST(reqWith({ items: [{ name: "Avocado", category: "Misc" }] }));
+
+    const prompt = mockedGenerate.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain(PROMPT_FRAGMENTS.comprehensibleVoice);
   });
 });

--- a/src/app/api/market-tip/route.ts
+++ b/src/app/api/market-tip/route.ts
@@ -4,6 +4,7 @@ import { getSessionUserId } from "@/lib/session";
 import { canonicalTipKey } from "@/lib/marketTips/canonicalKey";
 import { isPickableCategory } from "@/lib/marketTips/pickable";
 import { KITCHEN_DOMAIN_RULE } from "@/lib/marketTips/relevance";
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { NextRequest, NextResponse } from "next/server";
@@ -82,6 +83,8 @@ export async function POST(req: NextRequest) {
         schema: TipGenSchema,
         temperature: 0.4,
         prompt: `You are Ah Mah, a warm Singaporean grandmother at the wet market. For each item, give ONE short tip on how to PICK a good fresh one at the shop — what to look for, feel for, or smell.
+
+${PROMPT_FRAGMENTS.comprehensibleVoice}
 
 RULES:
 - Return exactly one entry per item, using the EXACT given item text as "key".

--- a/src/app/api/storage-tip/route.test.ts
+++ b/src/app/api/storage-tip/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { POST } from "./route";
 import { prisma } from "@/lib/db";
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { getSessionUserId } from "@/lib/session";
 import { generateObject } from "ai";
 
@@ -157,5 +158,17 @@ describe("POST /api/storage-tip", () => {
   it("400s when items is missing", async () => {
     const res = await POST(reqWith({}));
     expect(res.status).toBe(400);
+  });
+
+  it("carries the shared comprehensible-voice fragment in the model prompt", async () => {
+    mockedFindMany.mockResolvedValue([] as never);
+    mockedGenerate.mockResolvedValue({
+      object: { tips: [{ key: "potato", tip: "cool, dark place" }] },
+    } as never);
+
+    await POST(reqWith({ items: [{ name: "Potato", type: "ingredient" }] }));
+
+    const prompt = mockedGenerate.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain(PROMPT_FRAGMENTS.comprehensibleVoice);
   });
 });

--- a/src/app/api/storage-tip/route.ts
+++ b/src/app/api/storage-tip/route.ts
@@ -3,6 +3,7 @@ import { unauthorized } from "@/lib/http";
 import { getSessionUserId } from "@/lib/session";
 import { canonicalTipKey } from "@/lib/marketTips/canonicalKey";
 import { KITCHEN_DOMAIN_RULE } from "@/lib/marketTips/relevance";
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { NextRequest, NextResponse } from "next/server";
@@ -83,6 +84,8 @@ export async function POST(req: NextRequest) {
         schema: TipGenSchema,
         temperature: 0.4,
         prompt: `You are Ah Mah, a warm Singaporean grandmother. For each kitchen item, give ONE short tip on how to KEEP it well at home — for food, how to store it so it lasts (where, how, what to avoid); for equipment, how to care for it so it lasts.
+
+${PROMPT_FRAGMENTS.comprehensibleVoice}
 
 Each item below is written as "name = kind".
 


### PR DESCRIPTION
## Summary
- Extends the shared `PROMPT_FRAGMENTS.comprehensibleVoice` fragment (introduced in #365 / #368) to the two remaining AI persona surfaces: `storage-tip` (how to keep an item well at home) and `market-tip` (how to pick a fresh one at the wet market).
- No rule text duplicated — both routes reference the single shared fragment, so all three persona surfaces (chat + these two) stay consistent from one source of truth.
- Adds a regression test to each route's test file asserting the fragment is present in the generated model prompt.
- Docs: logged the decision in `docs/progress.md`.

Closes #366

## Test plan
- [x] `pnpm jest` — full suite passes (596/596)
- [x] `pnpm tsc --noEmit` — no new type errors
- [x] `pnpm lint` — no new warnings/errors in touched files
- [x] Live spot-check against `gpt-5-mini` (the model these routes use): "ikan bilis (dried anchovies)", "belacan (fermented shrimp paste)", and "kangkong (water spinach)" glossed on first mention in both a storage tip and a market tip; "wok", "bok choy", "tofu" left un-glossed. Gloss coexists cleanly with the existing 12-word tip cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)