### PR TITLE
fix(recipe): propagate ingredient tweaks into step text, drop tweak bench avatar

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -293,6 +293,8 @@ The spine (#314), lifecycle (#315), Market Tips (#316), and the recipe on-ramp +
 
 ## Decisions
 
+- **Tweak ingredient swaps now propagate into step/prep text** (Jul 2026): the tweak system prompt (`src/app/api/recipe/[id]/tweak/route.ts`) told the model to return only arrays that structurally changed, with no instruction to check whether the ingredient being swapped was actually named in `steps`/`prep` text — a "swap parsley for coriander" tweak updated the ingredient list but left the method steps referencing the old ingredient. Prompt now explicitly tells the model to check `steps`/`prep` for mentions of the changed ingredient and include those arrays in the patch if their wording changed too. Prompt-only fix — no client-side text-replacement fallback, matching ADR-0010's trust in the model to keep the recipe and change-list coherent.
+- **Tweak bench drops the Ah Mah face avatar**: the `/granny-icon.png` avatar next to assistant messages in the Tweak bench (`TweakBench.tsx`) was removed — it's local to this panel only, not shared with the main Chat feature's message list.
 - **`shelfLife` removed** (May 2026) — no freshness/urgency UI; the app can't reliably know what's gone bad. Full rationale → [ADR-0008](./adr/0008-no-shelf-life-ui.md).
 - **Optional quantity = "unlimited"**: unset `quantity` means the item has no limit. Avoids forcing a count on pantry staples where "do I have enough?" is never the question.
 - **Structured-on-save over streaming extraction**: metadata (`baseServings`, `ingredients`, `description`, `totalTimeMinutes`) is extracted when the user saves a recipe, not streamed inline. Simpler streaming path; extraction failures degrade gracefully without breaking the chat.

--- a/src/app/api/recipe/[id]/tweak/route.ts
+++ b/src/app/api/recipe/[id]/tweak/route.ts
@@ -36,6 +36,7 @@ ${JSON.stringify(workingDraft, null, 2)}
 - Apply the user's instruction as a precise, minimal change to the working draft.
 - Return ONLY the fields that changed — do NOT echo unchanged fields. Output size should reflect how much changed, not the size of the recipe.
 - Arrays (\`ingredients\`, \`steps\`, \`prep\`, \`tags\`) are all-or-nothing: if ANY element of an array changed, return the ENTIRE updated array (every element, in order). If an array is unchanged, OMIT the key.
+- When an ingredient is added, removed, or renamed, check \`steps\` and \`prep\` for literal mentions of the old ingredient name and update that wording too — an ingredient swap is not "done" until every step that names it agrees. If any step or prep text changes as a result, include that whole array in the patch per the rule above.
 - To clear an array entirely (e.g. drop all tags), return it as \`[]\`. Omitting a key means "leave unchanged"; \`[]\` means "make empty" — they are different.
 - Scalar fields (\`title\`, \`description\`, \`baseServings\`, \`totalTimeMinutes\`): include only if changed.
 - Update the \`description\` ("Ah Mah's note") if the dish character meaningfully changes (e.g. protein swap, cuisine shift). Include a \`description_updated\` change entry when you do.

--- a/src/features/RecipeDisplay/TweakBench.tsx
+++ b/src/features/RecipeDisplay/TweakBench.tsx
@@ -17,7 +17,6 @@ import {
   recipeWithIdToBlock,
   TweakPatchSchema,
 } from "@/lib/recipes/schemas";
-import Image from "next/image";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -448,36 +447,26 @@ function TweakProgress() {
   const showProgress = usePhaseAfter(startedAt, TWEAK_PROGRESS_DELAY_MS);
 
   return (
-    <div className="flex gap-2.5 items-start">
-      <div className="relative w-7 h-7 shrink-0">
-        <Image src="/granny-icon.png" alt="" fill className="object-contain" />
-      </div>
-      <div className="flex-1 pt-0.5">
-        {showProgress ? (
-          <CyclingVoiceLines lines={lines} intervalMs={4000} loop />
-        ) : (
-          <div
-            aria-live="polite"
-            className="flex items-center gap-2.5 font-display italic text-dense text-foreground leading-[1.5]"
-          >
-            {lines[0]}
-            <LoadingDots />
-          </div>
-        )}
-      </div>
+    <div>
+      {showProgress ? (
+        <CyclingVoiceLines lines={lines} intervalMs={4000} loop />
+      ) : (
+        <div
+          aria-live="polite"
+          className="flex items-center gap-2.5 font-display italic text-dense text-foreground leading-[1.5]"
+        >
+          {lines[0]}
+          <LoadingDots />
+        </div>
+      )}
     </div>
   );
 }
 
 function AssistantBubble({ text }: { text: string }) {
   return (
-    <div className="flex gap-2.5 items-start">
-      <div className="relative w-7 h-7 shrink-0">
-        <Image src="/granny-icon.png" alt="" fill className="object-contain" />
-      </div>
-      <div className="flex-1 font-display italic text-dense text-foreground leading-[1.5] pt-0.5">
-        {text}
-      </div>
+    <div className="font-display italic text-dense text-foreground leading-[1.5]">
+      {text}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Tweak system prompt (`src/app/api/recipe/[id]/tweak/route.ts`) now explicitly tells the model to check `steps`/`prep` for mentions of an ingredient it's adding/removing/renaming and to include that whole array in the patch if the wording changes. Fixes a bug where swapping an ingredient (e.g. parsley → coriander) updated the ingredient list but left the old ingredient named in the method steps.
- Removed the "Ah Mah face" avatar (`/granny-icon.png`) from the Tweak bench chat panel (`TweakBench.tsx`) — it's local to this panel only, not shared with the main Chat feature.
- `docs/progress.md` updated with both decisions.

## Test plan
- [x] `TweakBench.test.tsx` — 6/6 pass
- [x] `tsc --noEmit` — no new errors in touched files
- [ ] Manually re-run an ingredient-swap tweak (e.g. "can I use coriander instead of parsley?") against a saved recipe and confirm the step text updates alongside the ingredient list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ingredient swaps now also update matching wording in recipe steps and prep instructions, keeping the recipe text consistent.
  * The tweak bench assistant message display is simplified by removing the avatar next to assistant responses.
* **Documentation**
  * Updated the progress notes to reflect the latest recipe-tweak and UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->