### PR TITLE
fix(validation): harden input validation on message and chat routes (#360)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -218,6 +218,12 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Tests** cover owner-can-mint, non-owner/unauthenticated cannot (401/404), idempotent re-mint, and the public read working token-only with owner fields never selected.
 - This completes the route-lockdown series (#341–#345); the now-unused `missingUserId()` 400 helper was removed (every route uses `unauthorized()`).
 
+### Write-route input validation hardened — Shipped (#360)
+
+- **`POST /api/message`**: replaced the loose truthiness check with a Zod schema (`conversationId: string.min(1)`, `content: string.min(1)`, `role: enum["user","assistant"]`). An arbitrary role value (`"system"`, junk) now returns 400 rather than reaching the DB.
+- **`POST /api/chat`**: added Zod validation before the expensive LLM path — `conversationId: string.max(100)`, `messages: array.max(100)`. Prevents multi-MB payloads from ever reaching `captureMentionedInventory` / `loadConversationContext` / `streamText`.
+- Tests updated: the old "system role succeeds" case flipped to 400; new tests assert oversized messages array, oversized conversationId, and missing conversationId all 400 before any model call.
+
 ### normalizeIngredient extracted — Shipped (#362)
 
 - **Ingredient normalisation lives in one place.** `saveRecipeFromBlock` and `updateRecipeForUser` both had an identical inline map — same `category ?? "Misc"` default and the same `parseFloat` / `Number.isNaN` amount-coercion. Extracted to `src/lib/recipes/normalizeIngredient.ts` (mirrors `normalizeTags.ts`); both call sites become one-liner `.map(normalizeIngredient)` calls. A unit-test file covers the amount-parsing edge cases (valid numeric, non-numeric, undefined, decimal) and the category default.

--- a/src/app/api/chat/route.test.ts
+++ b/src/app/api/chat/route.test.ts
@@ -393,6 +393,42 @@ describe("Chat API Route", () => {
       expect(mockedStreamText).not.toHaveBeenCalled();
     });
 
+    it("returns 400 when messages array exceeds 100 items", async () => {
+      const request = createMockRequest({
+        conversationId: "conv-123",
+        messages: Array.from({ length: 101 }, (_, i) => ({
+          id: `msg-${i}`,
+          role: "user",
+          parts: [{ type: "text", text: "hi" }],
+        })),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+      expect(mockedStreamText).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when conversationId exceeds 100 characters", async () => {
+      const request = createMockRequest({
+        conversationId: "x".repeat(101),
+        messages: [{ id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+      expect(mockedStreamText).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when conversationId is missing", async () => {
+      const request = createMockRequest({
+        messages: [{ id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+      expect(mockedStreamText).not.toHaveBeenCalled();
+    });
+
     it("loads history for the session user, ignoring any body userId", async () => {
       mockedGetMessages.mockResolvedValue([]);
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -20,7 +20,7 @@ import { CHAT_SYSTEM_PROMPT } from "./constants";
 
 const PostSchema = z.object({
   conversationId: z.string().min(1).max(100),
-  messages: z.array(z.record(z.unknown())).max(100),
+  messages: z.array(z.record(z.string(), z.unknown())).max(100),
 });
 
 export async function POST(req: NextRequest) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -18,9 +18,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { CHAT_SYSTEM_PROMPT } from "./constants";
 
+const UIMessageSchema = z
+  .object({ id: z.string(), role: z.string(), parts: z.array(z.unknown()) })
+  .passthrough();
+
 const PostSchema = z.object({
   conversationId: z.string().min(1).max(100),
-  messages: z.array(z.record(z.string(), z.unknown())).max(100),
+  messages: z.array(UIMessageSchema).max(100),
 });
 
 export async function POST(req: NextRequest) {
@@ -32,7 +36,8 @@ export async function POST(req: NextRequest) {
     if (!body.success) {
       return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
     }
-    const { messages, conversationId } = body.data as unknown as { messages: UIMessage[]; conversationId: string };
+    const { conversationId, messages: rawMessages } = body.data;
+    const messages = rawMessages as unknown as UIMessage[];
 
     // Deterministically capture any pantry items the user mentions BEFORE the
     // chat model runs, so a subsequent getInventory call reflects them. Gated

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -15,19 +15,24 @@ import {
   UIMessage,
 } from "ai";
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { CHAT_SYSTEM_PROMPT } from "./constants";
+
+const PostSchema = z.object({
+  conversationId: z.string().min(1).max(100),
+  messages: z.array(z.record(z.unknown())).max(100),
+});
 
 export async function POST(req: NextRequest) {
   try {
     const userId = await getSessionUserId(req);
     if (!userId) return unauthorized();
 
-    const { messages, conversationId }: {
-      messages: UIMessage[];
-      conversationId: string;
-    } = await req.json();
-
-    if (!conversationId) return NextResponse.json({ error: "conversationId is required" }, { status: 400 });
+    const body = PostSchema.safeParse(await req.json());
+    if (!body.success) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+    const { messages, conversationId } = body.data as { messages: UIMessage[]; conversationId: string };
 
     // Deterministically capture any pantry items the user mentions BEFORE the
     // chat model runs, so a subsequent getInventory call reflects them. Gated

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -32,7 +32,7 @@ export async function POST(req: NextRequest) {
     if (!body.success) {
       return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
     }
-    const { messages, conversationId } = body.data as { messages: UIMessage[]; conversationId: string };
+    const { messages, conversationId } = body.data as unknown as { messages: UIMessage[]; conversationId: string };
 
     // Deterministically capture any pantry items the user mentions BEFORE the
     // chat model runs, so a subsequent getInventory call reflects them. Gated

--- a/src/app/api/message/route.test.ts
+++ b/src/app/api/message/route.test.ts
@@ -471,14 +471,14 @@ describe("Message API Routes", () => {
       );
     });
 
-    it("should handle malformed JSON", async () => {
-      const request = createMockRequest("http://localhost:3000/api/message", {
-        method: "POST",
-        body: "invalid json",
-        headers: { "Content-Type": "application/json" },
-      });
+    it("returns 400 for malformed JSON", async () => {
+      const request = {
+        json: async () => { throw new SyntaxError("Unexpected token"); },
+      } as unknown as NextRequest;
 
-      await expect(POST(request)).rejects.toThrow();
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+      expect(mockedCreateMessage).not.toHaveBeenCalled();
     });
 
     it("rejects role values outside user|assistant enum", async () => {

--- a/src/app/api/message/route.test.ts
+++ b/src/app/api/message/route.test.ts
@@ -280,12 +280,8 @@ describe("Message API Routes", () => {
       });
 
       const response = await POST(request);
-      const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data).toEqual({
-        error: "conversationId, content, and role are required",
-      });
       expect(mockedCreateMessage).not.toHaveBeenCalled();
     });
 
@@ -365,72 +361,50 @@ describe("Message API Routes", () => {
     });
 
     it("should return 400 when content is missing", async () => {
-      const requestBody = {
-        conversationId: "conv-123",
-        userId: "user-123",
-        role: "user",
-      };
-
       const request = createMockRequest("http://localhost:3000/api/message", {
         method: "POST",
-        body: JSON.stringify(requestBody),
+        body: JSON.stringify({ conversationId: "conv-123", role: "user" }),
         headers: { "Content-Type": "application/json" },
       });
 
       const response = await POST(request);
-      const data = await response.json();
-
       expect(response.status).toBe(400);
-      expect(data).toEqual({
-        error: "conversationId, content, and role are required",
-      });
       expect(mockedCreateMessage).not.toHaveBeenCalled();
     });
 
     it("should return 400 when role is missing", async () => {
-      const requestBody = {
-        conversationId: "conv-123",
-        userId: "user-123",
-        content: "Test message",
-      };
-
       const request = createMockRequest("http://localhost:3000/api/message", {
         method: "POST",
-        body: JSON.stringify(requestBody),
+        body: JSON.stringify({ conversationId: "conv-123", content: "Test message" }),
         headers: { "Content-Type": "application/json" },
       });
 
       const response = await POST(request);
-      const data = await response.json();
-
       expect(response.status).toBe(400);
-      expect(data).toEqual({
-        error: "conversationId, content, and role are required",
-      });
       expect(mockedCreateMessage).not.toHaveBeenCalled();
     });
 
     it("should return 400 when fields are empty strings", async () => {
-      const requestBody = {
-        conversationId: "",
-        userId: "",
-        content: "",
-        role: "",
-      };
-
       const request = createMockRequest("http://localhost:3000/api/message", {
         method: "POST",
-        body: JSON.stringify(requestBody),
+        body: JSON.stringify({ conversationId: "", content: "", role: "" }),
         headers: { "Content-Type": "application/json" },
       });
 
       const response = await POST(request);
-      const data = await response.json();
-
       expect(response.status).toBe(400);
-      expect(data).toEqual({
-        error: "conversationId, content, and role are required",
+      expect(mockedCreateMessage).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for an invalid role value", async () => {
+      const request = createMockRequest("http://localhost:3000/api/message", {
+        method: "POST",
+        body: JSON.stringify({ conversationId: "conv-123", content: "hi", role: "system" }),
+        headers: { "Content-Type": "application/json" },
       });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
       expect(mockedCreateMessage).not.toHaveBeenCalled();
     });
 
@@ -507,42 +481,16 @@ describe("Message API Routes", () => {
       await expect(POST(request)).rejects.toThrow();
     });
 
-    it("should handle different role types", async () => {
-      const systemMessage = {
-        id: "msg-system",
-        conversationId: "conv-123",
-        userId: "user-123",
-        content: "System initialized",
-        role: "system",
-        createdAt: new Date("2024-01-01T10:00:00.000Z"),
-      };
-
-      mockedCreateMessage.mockResolvedValue(systemMessage);
-
-      const requestBody = {
-        conversationId: "conv-123",
-        userId: "user-123",
-        content: "System initialized",
-        role: "system",
-      };
-
+    it("rejects role values outside user|assistant enum", async () => {
       const request = createMockRequest("http://localhost:3000/api/message", {
         method: "POST",
-        body: JSON.stringify(requestBody),
+        body: JSON.stringify({ conversationId: "conv-123", content: "System initialized", role: "system" }),
         headers: { "Content-Type": "application/json" },
       });
 
       const response = await POST(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data).toEqual({ message: systemMessage });
-      expect(mockedCreateMessage).toHaveBeenCalledWith(
-        "conv-123",
-        "user-123",
-        "System initialized",
-        "system"
-      );
+      expect(response.status).toBe(400);
+      expect(mockedCreateMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/api/message/route.ts
+++ b/src/app/api/message/route.ts
@@ -31,7 +31,13 @@ export async function POST(req: NextRequest) {
   const userId = await getSessionUserId(req);
   if (!userId) return unauthorized();
 
-  const parsed = PostSchema.safeParse(await req.json());
+  let rawBody: unknown;
+  try {
+    rawBody = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  const parsed = PostSchema.safeParse(rawBody);
   if (!parsed.success) {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }

--- a/src/app/api/message/route.ts
+++ b/src/app/api/message/route.ts
@@ -3,6 +3,13 @@ import { unauthorized } from "@/lib/http";
 import { createMessage, getMessages } from "@/lib/messages";
 import { getSessionUserId } from "@/lib/session";
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const PostSchema = z.object({
+  conversationId: z.string().min(1),
+  content: z.string().min(1),
+  role: z.enum(["user", "assistant"]),
+});
 
 export async function GET(req: NextRequest) {
   const userId = await getSessionUserId(req);
@@ -24,13 +31,11 @@ export async function POST(req: NextRequest) {
   const userId = await getSessionUserId(req);
   if (!userId) return unauthorized();
 
-  const { conversationId, content, role } = await req.json();
-  if (!conversationId || !content || !role) {
-    return NextResponse.json(
-      { error: "conversationId, content, and role are required" },
-      { status: 400 }
-    );
+  const parsed = PostSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
+  const { conversationId, content, role } = parsed.data;
 
   try {
     const message = await createMessage(conversationId, userId, content, role);


### PR DESCRIPTION
## Summary

- **`POST /api/message`** — added a Zod `PostSchema` constraining `role` to `z.enum(["user", "assistant"])`. Previously any string passed the truthiness check and was written to the DB. Now `"system"`, `"hacker"`, or any other value returns 400 before touching storage.
- **`POST /api/chat`** — added Zod validation capping `conversationId` at 100 chars and `messages` array at 100 items. Guards fire before `captureMentionedInventory`, `loadConversationContext`, and `streamText`, so an oversized payload never reaches the LLM stack.

Closes #360

## Test plan
- [ ] 607 tests pass (`pnpm jest`)
- [ ] `role: "system"` → 400, no DB write
- [ ] `messages` array of 101 items → 400, no model call
- [ ] `conversationId` of 101 chars → 400, no model call
- [ ] Missing `conversationId` → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for chat and message requests, returning a clear 400 error for invalid or oversized inputs.
  * Prevented unsupported message roles from being accepted.
  * Added safeguards so invalid requests stop before heavier processing starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->