### PR TITLE
feat(recipe): diagnostic Salt/Fat/Acid/Heat balance check for generation

### DIFF
--- a/docs/adr/0018-recipe-generation-runs-a-diagnostic-balance-check.md
+++ b/docs/adr/0018-recipe-generation-runs-a-diagnostic-balance-check.md
@@ -1,0 +1,53 @@
+# ADR-0018 — Recipe generation runs a diagnostic balance check, not a mandatory one
+
+**Status:** Accepted
+
+## Context
+
+Generated recipes were coming out **flat** — technically correct and cookable, but under-seasoned, one-note, missing brightness. The dish worked; it just wasn't *yummy*.
+
+The chat system prompt already teaches Ah Mah to *explain* the science of cooking — Maillard, fond, deglazing, doneness cues in the Kenji López-Alt spirit (`src/app/api/chat/constants.ts`). But nothing made her **check that the dish she just wrote is actually balanced** before serving it. Explaining technique and composing a balanced plate are different jobs; only the first was covered.
+
+The fix draws on Samin Nosrat's *Salt / Fat / Acid / Heat* — a lens for diagnosing *why a dish tastes flat*. The open question was **how prescriptive** to make it, and **where** it should apply.
+
+Options considered:
+
+1. **Mandatory checklist** — every recipe MUST carry a salt element, a fat element, an acid element, and a suitable heat method. Clean, enforceable, testable.
+2. **Diagnostic lens** — before emitting, run the dish through the four axes; add an element only where the dish would be flat without it, and leave deliberately-clean dishes alone.
+3. **Do nothing** — rely on the existing science-voice guidance to carry balance implicitly (the status quo that produced flat dishes).
+
+## Decision
+
+### The balance check is a diagnostic, not a mandate
+
+Ah Mah runs Salt/Fat/Acid/Heat as a self-check before emitting a full recipe, but is explicitly told it is *diagnostic, not a checklist*: add or adjust an axis only when the dish would be flat without it, and leave a dish that is **deliberately clean** on an axis alone.
+
+A mandatory rule breaks on this app's own cuisine. Plain **congee** needs no acid; **Teochew steamed fish** wants little fat — its whole point is clean, sweet fish. A "every savoury dish must contain acid" rule would force lime into congee and make generation *worse* while feeling more rigorous. Samin wrote SFAH as a lens for diagnosing flatness, not a bill of materials every plate must carry — so we encode it as she intended.
+
+### The four axes are read for this cuisine, not literally
+
+"Salt" means savoury depth (soy, fish sauce, oyster sauce, miso, shrimp paste), not just NaCl. "Acid" means brightness (black/rice vinegar, calamansi, lime, tamarind, tomato). "Fat" is the richness/carrier (oil, coconut milk, sesame oil, lard). "Heat" is the right method and level (wok hei vs a gentle simmer vs a steam). A literal reading would mislead toward table salt and lemon.
+
+### Balance surfaces only through the existing `steps[].tip`
+
+When a balancing move is the non-obvious save, the *why* rides the step tip that already exists for exactly this purpose ("a squeeze of calamansi at the end lifts everything — don't skip it"). No new recipe field, no "balance section." A dedicated balance voice would be a fourth advice channel competing with `steps[].tip`, the recipe-level `notes`, and the ingredient-level `note` — the exact kind of co-located-voice clash that [ADR-0014](0014-shopping-list-is-standing-and-quantityless.md) and the `notes`-vs-`note` distinction in `CONTEXT.md` were written to prevent.
+
+### Scope is full-recipe generation only — Mode 2 and Mode 3
+
+The check is added once to `CHAT_SYSTEM_PROMPT`, governing the named-dish recipe (Mode 2) and Cook With What You Have (Mode 3, which already inherits the Mode 2 recipe rules). It is **deliberately excluded** from two other paths:
+
+- **Mode 1 (suggestions)** emits only blurbs and `keyIngredients` — no steps, no method, so there is no composition surface to balance.
+- **The Tweak route** (`src/app/api/recipe/[id]/tweak/route.ts`) has a hard *minimal-change* contract: return only what the user's instruction changed. A balance check there would add ingredients the user never asked for and pollute the "What changed" list — a contract violation, not an improvement.
+
+## Why not the alternatives
+
+**Mandatory checklist (option 1).** Testable and tidy, but wrong for the food: it forces elements into deliberately-clean dishes and degrades exactly the recipes it means to protect. The failure we are fixing is the model *never considering* balance, not the model *lacking a rule to obey* — a diagnostic closes that gap without the collateral damage.
+
+**Do nothing (option 3).** The science-voice guidance teaches Ah Mah to *narrate* technique, but a well-narrated dish can still be flat. That is precisely the observed status quo, so it is not a fix.
+
+## Consequences
+
+- A `PROMPT_FRAGMENTS.balanceCheck` fragment in `src/lib/prompts/fragments.ts`, interpolated into `CHAT_SYSTEM_PROMPT` (mirrors the `comprehensibleVoice` precedent). A unit test asserts its presence, matching the existing fragment tests.
+- No schema change, no new recipe field, no `CONTEXT.md` glossary term — the balance check has no user-facing surface, so it stays out of the domain glossary.
+- Kenji's technique/doneness guidance is untouched; this ADR adds only Samin's balance lens on top of it.
+- A future contributor who wants to "tighten" this by making balance mandatory, or by adding it to the Tweak route, should re-read this ADR first: both were considered and rejected for the reasons above.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -238,6 +238,11 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **`storage-tip` and `market-tip` now share the same `PROMPT_FRAGMENTS.comprehensibleVoice` fragment as chat** (#365) — no rule text duplicated, all three persona surfaces stay consistent from one source of truth.
 - Verified live against `gpt-5-mini` (the model these two routes use): "ikan bilis (dried anchovies)", "belacan (fermented shrimp paste)", and "kangkong (water spinach)" glossed on first mention in both a storage tip and a market tip; "wok", "bok choy", and "tofu" left alone. The gloss comfortably coexists with the existing 12-word tip cap.
 
+### Diagnostic balance check for recipe generation — Shipped Jul 2026
+
+- **Recipe generation now runs a Salt/Fat/Acid/Heat balance pass** (`PROMPT_FRAGMENTS.balanceCheck`) before emitting a full recipe, to fix dishes that came out flat/under-seasoned. It is a **diagnostic, not a mandate** — the model adds an axis only where the dish would be flat without it, and leaves deliberately-clean dishes (congee, steamed fish) alone. Axes are read for Asian home cooking (salt = savoury depth incl. soy/fish sauce; acid = brightness incl. black vinegar/calamansi/tamarind).
+- Surfaced only through the existing `steps[].tip` when the balancing move is the non-obvious save — no new recipe field. Applied to Mode 2 (named dish) + Mode 3 (Cook With What You Have) only; **excluded** from Mode 1 suggestions (no method surface) and the Tweak route (minimal-change contract). See [ADR-0018](adr/0018-recipe-generation-runs-a-diagnostic-balance-check.md).
+
 ## Design system
 
 The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — were drifting because each hand-rolled the same primitives. A design system is now the north star: shared atoms stop drift, and every surface gets tweaked incrementally so it "looks like it belongs". See the spec at `docs/superpowers/specs/2026-06-20-recipe-design-system-design.md` and the issue tracker (#277–#285).

--- a/src/app/api/chat/constants.test.ts
+++ b/src/app/api/chat/constants.test.ts
@@ -26,4 +26,8 @@ describe("CHAT_SYSTEM_PROMPT recipe example", () => {
   it("carries the shared comprehensible-voice fragment", () => {
     expect(CHAT_SYSTEM_PROMPT).toContain(PROMPT_FRAGMENTS.comprehensibleVoice);
   });
+
+  it("carries the diagnostic balance-check fragment", () => {
+    expect(CHAT_SYSTEM_PROMPT).toContain(PROMPT_FRAGMENTS.balanceCheck);
+  });
 });

--- a/src/app/api/chat/constants.ts
+++ b/src/app/api/chat/constants.ts
@@ -113,6 +113,8 @@ ${PROMPT_FRAGMENTS.tagCatalog}
   Do NOT invent variants (e.g. "minced-beef" → use "beef"; "tortilla" or "wrap" → use "bread"; "one-pan" → use "one-pot"). Do NOT use ingredient names as tags (no "onion", "garlic", etc.).
 - A brief warm sentence BEFORE the block is fine (e.g. "Here it is — the way I make it:").
 
+${PROMPT_FRAGMENTS.balanceCheck}
+
 ## Mode 3 — Cook With What You Have
 
 Triggered when the user message starts with **"Suggest recipes using:"** or **"More ideas — different from these"**.

--- a/src/lib/prompts/fragments.ts
+++ b/src/lib/prompts/fragments.ts
@@ -26,6 +26,16 @@ function buildTagCatalog(): string {
 
 const COMPREHENSIBLE_VOICE = `**Stay understandable to everyone, not just Singaporeans.** Keep your voice fully intact — particles ("lah", "ah", "aiyah"), warmth, cadence, grammar rhythm — none of that changes. But the first time you mention a genuinely region-specific term (a dish, ingredient, or place a global audience won't know — e.g. "ikan bilis", "tapau", "kangkong", "wet market"), gloss it inline with a short parenthetical: "ikan bilis (dried anchovies)", "tapau (pack it to go)". Gloss that term only once per conversation — don't re-gloss it on later mentions. Never gloss globally-understood terms (wok, bok choy, tofu, soy, ginger) — that reads as condescending, not helpful.`;
 
+const BALANCE_CHECK = `**Before you emit a recipe, taste it in your head.** Run the dish through Salt, Fat, Acid, Heat — Samin Nosrat's lens for *why a dish tastes flat*:
+- **Salt (savoury depth):** is there enough seasoning to make it sing? Read "salt" widely — soy, fish sauce, oyster sauce, miso, shrimp paste all count.
+- **Fat (richness & carrier):** oil, coconut milk, sesame oil, lard — the thing that carries flavour and mouthfeel.
+- **Acid (brightness):** the most-often-missing one. Black or rice vinegar, calamansi, lime, tamarind, tomato — a lift that stops the dish being heavy or one-note.
+- **Heat (right method & level):** wok hei vs a gentle simmer vs a steam — does the method suit the dish?
+
+This is a **diagnostic, not a checklist.** If an axis is missing *and the dish would be flat without it*, add or adjust it. If the dish is **deliberately clean** on an axis — congee needs no acid, a clean steamed fish wants little fat — leave it alone. Never force an element in just to tick a box.
+
+When a balancing move is the non-obvious save, put the *why* in that step's \`tip\` ("a squeeze of calamansi right at the end lifts everything — don't skip it"). Do **not** add a separate balance note or a new field — the balancing ingredient and step carry it like any other.`;
+
 export const PROMPT_FRAGMENTS = {
   /** Full "value — examples" block for ingredient category rules. */
   categoryRules: buildCategoryRules(),
@@ -35,4 +45,6 @@ export const PROMPT_FRAGMENTS = {
   tagCatalog: buildTagCatalog(),
   /** Keeps Ah Mah's Singlish voice while glossing region-specific terms on first mention. */
   comprehensibleVoice: COMPREHENSIBLE_VOICE,
+  /** Diagnostic Salt/Fat/Acid/Heat balance pass run before emitting a full recipe. */
+  balanceCheck: BALANCE_CHECK,
 } as const;


### PR DESCRIPTION
## Summary
- Recipes were coming out **flat / under-seasoned** — technically fine, but not *yummy*. The chat prompt taught Ah Mah to *explain* cooking science (Kenji-style) but never to *check her own dish is balanced* before serving it.
- Adds `PROMPT_FRAGMENTS.balanceCheck` — Samin Nosrat's **Salt / Fat / Acid / Heat** lens the model runs before emitting a full recipe.
- **Diagnostic, not mandatory:** adds an axis only where the dish would be flat without it; leaves deliberately-clean dishes (congee, steamed fish) alone. A hard "every dish needs acid" rule would force lime into congee and make generation worse.
- **Cuisine-aware axes:** salt = savoury depth (soy, fish sauce, miso); acid = brightness (black vinegar, calamansi, tamarind); fat = richness/carrier; heat = right method/level.
- **Surfaced only through the existing `steps[].tip`** when the balancing move is the non-obvious save — no new recipe field, no competing advice voice.
- **Scope:** Mode 2 (named dish) + Mode 3 (Cook With What You Have), via one insertion in `CHAT_SYSTEM_PROMPT`. **Excluded** from Mode 1 suggestions (no method surface) and the Tweak route (minimal-change contract). Kenji's science-voice line is untouched.
- Documented in [ADR-0018](docs/adr/0018-recipe-generation-runs-a-diagnostic-balance-check.md); no `CONTEXT.md` glossary term (no user-facing surface).

## Test plan
- ✅ `pnpm test` — 604 pass, incl. new fragment assertion in `constants.test.ts`.
- Manual (live model): a plain stir-fry should gain a brightness/savoury element with a `steps[].tip` explaining it; **congee should stay clean** (proves diagnostic-not-mandatory); Cook With What You Have shows the same awareness on both Close + Stretch; the Tweak Bench stays minimal and adds no unrequested balancing ingredients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)