### PR TITLE
feat(auth): add official Google mark to sign-in button

### DIFF
--- a/src/features/Auth/GoogleIcon.tsx
+++ b/src/features/Auth/GoogleIcon.tsx
@@ -1,0 +1,29 @@
+import type { SVGProps } from "react";
+
+/**
+ * Official Google "G" mark in its four brand colors.
+ * Keep the paths and colors intact — Google's brand guidelines require the
+ * logo to appear unaltered on the "Sign in with Google" button.
+ */
+export function GoogleIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" {...props}>
+      <path
+        fill="#EA4335"
+        d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+      />
+      <path
+        fill="#4285F4"
+        d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+      />
+    </svg>
+  );
+}

--- a/src/features/Auth/SignInDialog.tsx
+++ b/src/features/Auth/SignInDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { authClient } from "@/lib/auth-client";
 import { useState } from "react";
+import { GoogleIcon } from "./GoogleIcon";
 
 export function SignInDialog() {
   const [open, setOpen] = useState(false);
@@ -45,8 +46,9 @@ export function SignInDialog() {
           onClick={handleGoogle}
           disabled={loading}
           variant="outline"
-          className="w-full"
+          className="w-full gap-3 font-medium"
         >
+          <GoogleIcon className="size-[18px] shrink-0" />
           {loading ? "Redirecting…" : "Continue with Google"}
         </Button>
       </DialogContent>

--- a/src/features/Auth/index.ts
+++ b/src/features/Auth/index.ts
@@ -1,2 +1,3 @@
 export { AuthButton } from "./AuthButton";
+export { GoogleIcon } from "./GoogleIcon";
 export { SignInDialog } from "./SignInDialog";


### PR DESCRIPTION
## Summary
- Add the official four-color Google "G" logo to the "Continue with Google" button so it reads instantly as an official Google sign-in.
- New colocated `GoogleIcon` component — logo paths and brand colors kept unaltered per Google's brand guidelines; marked `aria-hidden` since the button text already names the action.
- Mark sits left of the label (`gap-3`, `font-medium`) and stays visible during the "Redirecting…" state, so the button never loses its Google identity.
- Existing `variant="outline"` styling is reused so the button stays cohesive with the app.

## Test plan
- Open the sign-in dialog and confirm the multicolor Google "G" renders at 18px next to "Continue with Google".
- Click it and verify the mark remains while the button shows "Redirecting…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded Google icon to the sign-in experience for a more recognizable “Continue with Google” button.
  * Updated the Google sign-in button layout for better spacing and full-width presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->