### PR TITLE
docs: Ah Mah brand doc + condense CLAUDE.md principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,9 @@ App: **“Ask Ah Mah”** — converts pantry items into recipes via chat.
 - Let the LLM drive mutations via tools
 - Avoid cross-feature coupling
 - Optimize for readability
+- Simplicity first: minimum code that solves the problem; no speculative abstractions, configurability, or error handling for impossible cases.
+- Surgical changes: touch only what the task needs; match existing style; don't refactor or delete code you weren't asked to (mention dead code, don't remove it).
+- Think before coding: surface assumptions, tradeoffs, and simpler alternatives; ask when something is unclear rather than guessing.
 
 ---
 

--- a/docs/brand-ahmah.md
+++ b/docs/brand-ahmah.md
@@ -1,0 +1,80 @@
+# Ask Ah Mah — Brand & Character
+
+> The single source of truth for **who Ah Mah is**, the emotional core of the product,
+> and how the brand grows beyond the app. Keep the in-app Ah Mah voice (system prompts,
+> loader voice-lines, copy) consistent with the voice spine in §2.
+>
+> Related: product vision → [`prd.md`](./prd.md) · domain glossary → [`../CONTEXT.md`](../CONTEXT.md) · what's shipped → [`progress.md`](./progress.md)
+
+---
+
+## 1. The emotional core (the "why")
+
+Beyond good recipes, the aim is to help nervous beginners **pick up cooking and find it's not so scary after all**. Two layered truths:
+
+- **The win is permission, not a perfect plate.** Pride belongs to *taking the first step* — "I was scared, I tried it, it's fine." First step > flawless result.
+- **Cooking is love pointed outward.** The deepest purpose: *"one of the best ways to show love is to cook for the people you love."* This beats both "become capable" (ego) and "be cared for" (comfort) — and it's far more shareable ("look what I cooked for my mum" travels; "look at my plate" doesn't).
+- **Differentiator:** nearly all food content is *aspirational* (be impressed). Ah Mah is *permission-giving* (it's okay to be a beginner — here's proof). That lane is rare and ownable.
+
+---
+
+## 2. Ah Mah — character & voice
+
+Ah Mah is a **character** (an idealized archetype from imagination, not a documentary of a real grandma).
+
+- **A master who is completely unbothered by your mistakes.** Mastery expressed as *serenity*, not high standards. (The Bob Ross model: her obvious excellence is exactly what makes "don't worry, it's a happy accident" feel *safe* — a beginner trusts calm reassurance more from someone who can clearly rescue anything.)
+- **Why a grandma, not a parent — the structural license:** a parent corrects because they're accountable for how you turn out; a grandmother just wants you fed and happy. That's *why* Ah Mah gets to be all encouragement and no judgment — it's her role, not a personality softness.
+- **What she is NOT:** the perfectionist/hovering grandma (*"aiyoh, not like that, you're wasting the garlic"*). That grandma is the intimidation the app fights, wearing a friendly face.
+
+**Voice spine:**
+1. **Method** — *"Just give it a go."* (permission to start)
+2. **Safety** — *"Ah Mah won't scold you; and if it goes wrong, Ah Mah will show you how to save it."* (grandma-not-parent + the calm rescue)
+3. **Purpose** — *"One of the best ways to show love is to cook for the people you love."*
+
+**The test for any content or voice:** *does this make a scared person exhale, or tense up?* (Bob Ross always made you exhale.)
+
+**Watch-out:** keep "cooking is showing love" an **invitation / gift you get to give**, never a **duty**. The moment it becomes "you *should* cook for your loved ones," it's the guilt we've kept out everywhere else (same spirit as: no streaks — see [`progress.md`](./progress.md) and the joy-loop issues #377/#378).
+
+### Signature pillar — "Happy Accidents"
+Not just a content series — the **thesis**. *"No mistakes in Ah Mah's kitchen, only extra-crispy edges."* She has an unfazed line and a fix for the split sauce, the mushy rice, the over-charred garlic. It's the **most un-copyable** content available, because aspirational accounts will never post their failures.
+
+---
+
+## 3. "Ah Mah beyond the app" — growth
+
+**North star:** Ah Mah becomes a *persona/brand that lives beyond the app*, not just an in-app assistant — a voice people follow, quote, and pass around.
+
+**Three growth motions (different cost & timing):**
+
+| Motion | What | Effort | Reality check |
+|---|---|---|---|
+| Referral (private 1:1 share) | "I cooked this, try it" + link to a friend | Low — ~90% built (`/r/<token>` public page + OG preview) | Fits the nervous beginner; trusted-referral converts |
+| Public social (#ahmah) | Broadcast plate photos, hashtag spreads | High — branded card + photo capture | Viral ceiling, but bets beginners post publicly (weak) |
+| Owned content (Ah Mah blog) | SEO/brand in her voice | High + ongoing | But the `MarketTip`/`StorageTip` corpus is a near-zero-cost seed |
+
+**Sequencing truth:** distribution *amplifies* a loved product — it can't manufacture love. So the **core joy loop (#377/#378) is the first domino**; sharing and blog are amplifiers layered after the app is genuinely loved.
+
+**Hashtag caveat:** `#ahmah` is generic ("ah mah" = grandma; collides with every real grandmother post). The ownable assets are **her voice** + a **recognizable share-card frame** — brand the *artifact*, not the tag.
+
+**The nervous-beginner problem & its resolution:** beginners won't broadcast a wobbly first attempt publicly — that's confident-foodie behavior. But they *will* (a) text one trusted person, and (b) happily be *featured by grandma*. So public virality is better seeded by a **founder-run account** + a low-bar **"featured by Ah Mah" UGC engine** than by asking shy users to post.
+
+---
+
+## 4. Concrete near-term move (decided)
+
+Start an **@askahmah Instagram**; post the founder's own next cook.
+
+- **Dodges the "beginners won't broadcast" wall** — the founder posts, seeding the culture and demonstrating the behavior.
+- **Guard rail:** post like *a beginner cooking with grandma* — honest, imperfect, show the process (and what goes sideways) — **not** a glossy food magazine. The imperfection *is* the brand.
+- **Phone-holder:** character-led (Ah Mah's voice), with the founder visible as the **nervous grandkid learning** — which mirrors the app's user↔Ah Mah dynamic and is authentic precisely because she's an imagined ideal, not a real memory. (The audience are all "grandkids" too.)
+- **First-post shape** (embodies the whole brand at once): cook something → show the real process incl. any happy accident → caption in Ah Mah's unbothered voice → **say who you made it for.** Demonstrated, not described.
+- **UGC loop (later):** a user sends their proud/wonky first cook → reposted & celebrated in her voice ("featured by grandma") → the in-app finish moment (#377) can *gently* invite "tag @askahmah." Never pressured.
+
+---
+
+## 5. In-app expression (the "core must be loved first" foundation)
+
+- **#377** — CookingMode finish moment + boolean "made it" marker (recall, not a score). In-the-moment joy at the stove. No streaks / XP / photos.
+- **#378** — Ah Mah's model-authored per-step note (reassurance / sensory cue), blocked by #377.
+
+These are the in-app expression of the character above; the growth motions in §3–4 ride on top once they land.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -16,6 +16,7 @@ alwaysApply: true
 > - **What's shipped / what's next** → [`docs/progress.md`](./progress.md)
 > - **Why things are built the way they are** → [`docs/adr/`](./adr/)
 > - **Canonical domain vocabulary** → [`CONTEXT.md`](../CONTEXT.md)
+> - **Who Ah Mah is / brand & growth** → [`docs/brand-ahmah.md`](./brand-ahmah.md)
 > - **How to run it / tech stack** → [`README.md`](../README.md)
 
 ## 1. Product Vision


### PR DESCRIPTION
## Summary

- **New `docs/brand-ahmah.md`** — the single source of truth for *who Ah Mah is*: the emotional core (permission > perfect plate; cooking as love pointed outward), the character definition (Bob Ross master + grandma-not-parent license + what she is *not*), the three-line voice spine, the "Happy Accidents" thesis, the "beyond the app" growth thinking (referral / #ahmah / blog + sequencing), and the concrete @askahmah first move.
- **`docs/prd.md`** — one-line pointer added to the doc-map so the brand doc is discoverable.
- **`CLAUDE.md`** — condensed the four numbered coding-principles sections (*Think Before Coding / Simplicity First / Surgical Changes / Goal-Driven Execution*) into three tight bullets under `## Principles`; dropped the redundant/verbose remainder and the heading-numbering clash.

Docs-only — no code changes. Cross-links to the in-app joy-loop issues #377/#378 and the existing `/r/<token>` share infra.

## Test plan

- Docs only; nothing to run. Skim `docs/brand-ahmah.md` for voice/accuracy and confirm the `docs/prd.md` link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new brand guidance page covering Ah Mah’s voice, emotional core, content principles, and growth direction.
  * Updated the product vision doc to point readers to the new brand and growth guidance.
* **Chores**
  * Refined internal contributor guidance to encourage simpler, more focused changes and clearer assumptions when requirements are uncertain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->