### PR TITLE
feat(chat): group first-run composer with the welcome hero

### DIFF
--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -21,6 +21,17 @@ const Chat = () => {
   const router = useRouter();
 
   const messageCount = allMessages.length - 1; // exclude initial
+  const isEmpty = messageCount === 0 && status === "ready" && !isSending;
+
+  const composer = (
+    <MessageInput
+      onSendMessage={handleSendMessage}
+      disabled={status !== "ready" || isSending}
+      // In the first-run hero the composer is inset by the centered column, so
+      // drop the bottom-bar padding and let it align with the opener cards.
+      className={isEmpty ? "px-0 pb-0 pt-0" : undefined}
+    />
+  );
 
   if (!userId) {
     return (
@@ -36,26 +47,26 @@ const Chat = () => {
     <div
       className="flex flex-col animate-in fade-in duration-300 h-full"
     >
-      {messageCount === 0 && status === "ready" && !isSending ? (
+      {isEmpty ? (
         <ChatEmptyState
           onSend={handleSendMessage}
           onCookWith={() => router.replace("/?tab=pantry&selectionMode=1")}
+          composer={composer}
         />
       ) : (
-        <MessageList
-          messages={allMessages}
-          status={status}
-          submittedAt={submittedAt}
-          isSending={isSending}
-          userId={userId}
-          onSend={handleSendMessage}
-          onRecipeDetected={handleRecipeDetected}
-        />
+        <>
+          <MessageList
+            messages={allMessages}
+            status={status}
+            submittedAt={submittedAt}
+            isSending={isSending}
+            userId={userId}
+            onSend={handleSendMessage}
+            onRecipeDetected={handleRecipeDetected}
+          />
+          {composer}
+        </>
       )}
-      <MessageInput
-        onSendMessage={handleSendMessage}
-        disabled={status !== "ready" || isSending}
-      />
     </div>
   );
 };

--- a/src/features/Chat/components/ChatEmptyState.tsx
+++ b/src/features/Chat/components/ChatEmptyState.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 import Image from "next/image";
 
 import { Stamp } from "@/features/shared/components/Stamp";
@@ -15,6 +17,9 @@ const PROMPTS = [
 interface ChatEmptyStateProps {
   onSend: (text: string) => void;
   onCookWith: () => void;
+  // The message composer, rendered as the closing element of the hero so the
+  // input sits with the greeting instead of pinned to the bottom of the column.
+  composer: ReactNode;
 }
 
 /**
@@ -24,12 +29,19 @@ interface ChatEmptyStateProps {
  * quick-start chips. Once the first message is sent, the normal message thread
  * takes over and the greeting reappears as Ah Mah's opening bubble.
  */
-export function ChatEmptyState({ onSend, onCookWith }: ChatEmptyStateProps) {
+export function ChatEmptyState({
+  onSend,
+  onCookWith,
+  composer,
+}: ChatEmptyStateProps) {
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="min-h-full mx-auto flex w-full max-w-2xl flex-col items-center justify-center px-4 py-10 text-center animate-in fade-in slide-in-from-bottom-2 duration-500">
-        {/* Stamped Ah Mah mark */}
-        <Stamp className="size-16 mb-5">
+    <div className="flex flex-1 flex-col overflow-y-auto">
+      {/* `m-auto` centers the hero when there's room but collapses to the top
+          and scrolls when the viewport is too short to fit it — unlike
+          `justify-center`, which would clip the composer out of reach. */}
+      <div className="m-auto flex w-full max-w-2xl flex-col items-center px-4 py-10 text-center animate-in fade-in slide-in-from-bottom-2 duration-500 [@media(max-height:720px)]:py-5">
+        {/* Stamped Ah Mah mark — dropped on short viewports to save height */}
+        <Stamp className="size-16 mb-5 [@media(max-height:720px)]:hidden">
           <span className="relative size-10">
             <Image
               src="/granny-icon.png"
@@ -51,7 +63,7 @@ export function ChatEmptyState({ onSend, onCookWith }: ChatEmptyStateProps) {
         </p>
 
         {/* Opener cards */}
-        <div className="mt-7 grid w-full gap-2.5 text-left sm:grid-cols-3">
+        <div className="mt-7 grid w-full gap-2.5 text-left sm:grid-cols-3 [@media(max-height:720px)]:mt-4">
           {PROMPTS.map((p) => (
             <button
               key={p.label}
@@ -71,10 +83,13 @@ export function ChatEmptyState({ onSend, onCookWith }: ChatEmptyStateProps) {
         {/* Secondary path — browse the pantry instead of typing an opener */}
         <button
           onClick={onCookWith}
-          className="mt-6 inline-flex min-h-11 items-center gap-1.5 text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline cursor-pointer"
+          className="mt-6 inline-flex min-h-11 items-center gap-1.5 text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline cursor-pointer [@media(max-height:720px)]:mt-3"
         >
           🥬 Or pick from your pantry →
         </button>
+
+        {/* Composer — sits with the hero so typing feels like the next step */}
+        <div className="mt-8 w-full [@media(max-height:720px)]:mt-4">{composer}</div>
       </div>
     </div>
   );

--- a/src/features/Chat/components/MessageInput.tsx
+++ b/src/features/Chat/components/MessageInput.tsx
@@ -1,15 +1,20 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import { useState } from "react";
 
 interface MessageInputProps {
   onSendMessage: (message: string) => Promise<void>;
   disabled: boolean;
+  // Overrides the form's default outer padding. Used by the first-run hero to
+  // sit the composer flush with the opener cards instead of the bottom bar.
+  className?: string;
 }
 
 export const MessageInput = ({
   onSendMessage,
   disabled,
+  className,
 }: MessageInputProps) => {
   const [input, setInput] = useState("");
 
@@ -22,7 +27,7 @@ export const MessageInput = ({
           setInput("");
         }
       }}
-      className="p-4"
+      className={cn("p-4", className)}
     >
       <div className="flex gap-1 items-center bg-muted/50 rounded-xl border border-border/60 px-3 py-1 max-w-5xl mx-auto">
         <Input

--- a/src/features/RecipeList/RecipeList.tsx
+++ b/src/features/RecipeList/RecipeList.tsx
@@ -9,8 +9,8 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
-import RecipeCard from "./components/RecipeCard";
 import { AddRecipeModal } from "./components/AddRecipeModal";
+import RecipeCard from "./components/RecipeCard";
 import { RecipeSidebar } from "./components/RecipeSidebar";
 
 const HIDE_SCROLLBAR =
@@ -31,7 +31,7 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
   const { data: recipes, isLoading } = useSWR<RecipeWithId[]>(
     userId ? `/api/recipe?userId=${userId}` : null,
     fetcher,
-    { shouldRetryOnError: true, revalidateOnMount: true }
+    { shouldRetryOnError: true, revalidateOnMount: true },
   );
 
   const deleteRecipe = async (recipeId: string) => {
@@ -52,10 +52,15 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
   const allRecipes = recipes ?? [];
   const isEmpty = allRecipes.length === 0 && !isLoading;
 
-  const tagCounts = allRecipes.reduce((acc, r) => {
-    (r.tags ?? []).forEach((t) => { acc[t] = (acc[t] ?? 0) + 1; });
-    return acc;
-  }, {} as Record<string, number>);
+  const tagCounts = allRecipes.reduce(
+    (acc, r) => {
+      (r.tags ?? []).forEach((t) => {
+        acc[t] = (acc[t] ?? 0) + 1;
+      });
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
   const tagEntries = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]);
 
   const handleTagToggle = (tag: string) => {
@@ -100,32 +105,58 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
                     return t > max ? t : max;
                   }, 0);
                   if (!latest) return `${base}.`;
-                  const day = new Date(latest).toLocaleDateString("en-US", { weekday: "long" });
+                  const day = new Date(latest).toLocaleDateString("en-US", {
+                    weekday: "long",
+                  });
                   return `${base}. Last one in: ${day}.`;
                 })()}
           </p>
         </div>
-        <div className="flex items-center gap-2 w-full sm:w-auto shrink-0">
+        <div className="flex gap-2 w-full sm:w-auto shrink-0">
           {!isEmpty && (
             <>
-              {tagEntries.length > 0 && <button
-                onClick={() => setMobileFilterOpen(true)}
-                className="sm:hidden shrink-0 flex items-center gap-1.5 px-3 py-[7px] font-sans text-dense font-medium text-muted-foreground bg-card border border-border rounded-full cursor-pointer hover:text-foreground transition-colors"
-              >
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path d="M1 3h10M3 6h6M5 9h2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-                </svg>
-                Filter
-                {activeTags.size > 0 && (
-                  <span className="ml-0.5 flex items-center justify-center w-4 h-4 rounded-full bg-primary text-primary-foreground text-[9px] font-bold">
-                    {activeTags.size}
-                  </span>
-                )}
-              </button>}
+              {tagEntries.length > 0 && (
+                <button
+                  onClick={() => setMobileFilterOpen(true)}
+                  className="sm:hidden shrink-0 flex items-center gap-1.5 px-3 py-[7px] font-sans text-dense font-medium text-muted-foreground bg-card border border-border rounded-full cursor-pointer hover:text-foreground transition-colors"
+                >
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path
+                      d="M1 3h10M3 6h6M5 9h2"
+                      stroke="currentColor"
+                      strokeWidth="1.4"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                  Filter
+                  {activeTags.size > 0 && (
+                    <span className="ml-0.5 flex items-center justify-center w-4 h-4 rounded-full bg-primary text-primary-foreground text-[9px] font-bold">
+                      {activeTags.size}
+                    </span>
+                  )}
+                </button>
+              )}
               <label className="flex items-center gap-2 px-3 py-[7px] bg-card border border-border rounded-full sm:min-w-[200px] flex-1 sm:flex-none text-muted-foreground cursor-text">
-                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="shrink-0">
-                  <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.4" />
-                  <path d="m10.5 10.5 3 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  className="shrink-0"
+                >
+                  <circle
+                    cx="7"
+                    cy="7"
+                    r="4.5"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                  />
+                  <path
+                    d="m10.5 10.5 3 3"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                    strokeLinecap="round"
+                  />
                 </svg>
                 <input
                   value={search}
@@ -141,8 +172,19 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
             onClick={() => setShowAdd(true)}
             className="shrink-0 gap-1.5 px-3 py-[7px] font-sans text-dense font-semibold rounded-full"
           >
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="size-[12px]">
-              <path d="M6 1v10M1 6h10" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              className="size-[12px]"
+            >
+              <path
+                d="M6 1v10M1 6h10"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+              />
             </svg>
             Add recipe
           </Button>
@@ -162,13 +204,20 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
           />
         )}
 
-        <div className={`flex-1 overflow-y-auto px-4 sm:px-6 py-5 ${HIDE_SCROLLBAR}`}>
+        <div
+          className={`flex-1 overflow-y-auto px-4 sm:px-6 py-5 ${HIDE_SCROLLBAR}`}
+        >
           {isLoading ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-[18px]">
-              {[0, 1, 2].map((i) => <SkeletonCard key={i} />)}
+              {[0, 1, 2].map((i) => (
+                <SkeletonCard key={i} />
+              ))}
             </div>
           ) : isEmpty ? (
-            <CookbookEmpty onChatClick={onChatClick} onPasteClick={() => setShowAdd(true)} />
+            <CookbookEmpty
+              onChatClick={onChatClick}
+              onPasteClick={() => setShowAdd(true)}
+            />
           ) : filtered.length === 0 ? (
             <p className="font-display italic text-emphasis text-muted-foreground">
               {activeTags.size > 0
@@ -195,13 +244,26 @@ export default function RecipeList({ onChatClick }: RecipeListProps) {
   );
 }
 
-function CookbookEmpty({ onChatClick, onPasteClick }: { onChatClick?: () => void; onPasteClick?: () => void }) {
+function CookbookEmpty({
+  onChatClick,
+  onPasteClick,
+}: {
+  onChatClick?: () => void;
+  onPasteClick?: () => void;
+}) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[18px]">
       {/* Instructional card — spans 2 rows on desktop */}
       <div className="bg-card border-[1.5px] border-dashed border-border rounded-lg p-6 lg:row-span-2 flex flex-col gap-3.5 shadow-[0_1px_0_var(--color-border-soft)]">
         <div className="w-11 h-11 rounded-lg bg-primary flex items-center justify-center text-primary-foreground shrink-0">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+          >
             <path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16l-7-3-7 3z" />
           </svg>
         </div>
@@ -210,7 +272,8 @@ function CookbookEmpty({ onChatClick, onPasteClick }: { onChatClick?: () => void
             Cookbook&rsquo;s empty for now.
           </div>
           <div className="font-display italic text-sm text-muted-foreground leading-relaxed">
-            When something&rsquo;s worth a second go, tap <em>Save</em>. Ah Mah keeps it tidy.
+            When something&rsquo;s worth a second go, tap <em>Save</em>. Ah Mah
+            keeps it tidy.
           </div>
         </div>
         <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- Moves the message composer into the first-run empty state so it sits directly beneath the opener cards / pantry chip as one centered hero group, instead of being pinned to the bottom of a tall, mostly-empty column.
- Empty-state container now centers via `m-auto` rather than `justify-center`, so on short viewports the hero scrolls from the top instead of clipping the composer out of reach.
- Below `720px` viewport height, the stamp mark hides and vertical spacing tightens so the whole hero + composer fits without scrolling.
- `MessageInput` gains an optional `className` to strip its bottom-bar padding when rendered inside the hero (aligns with the opener cards). Conversation mode is unchanged — the composer still pins to the bottom.

## Test plan
- Open a fresh chat (no messages): composer sits with the greeting, no large gap.
- Resize the window down to ~480px height: composer stays fully visible, stamp drops, spacing tightens.
- Send a message: composer returns to the bottom bar as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The chat composer now appears directly in the empty chat view, making it easier to start typing right away.
  * Chat input spacing can now adapt more flexibly to different chat layouts.

* **Bug Fixes**
  * Improved chat layout behavior on shorter screens for a cleaner, more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->