### PR TITLE
fix(tips): show a loading placeholder while a tip generates

### DIFF
--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -45,6 +45,7 @@ const CategoryCard = ({
   selectedIds,
   onToggle,
   tips,
+  tipsLoading,
 }: {
   label: string;
   items: InventoryItem[];
@@ -53,6 +54,7 @@ const CategoryCard = ({
   selectedIds?: Set<string>;
   onToggle?: (id: string) => void;
   tips?: Record<string, string>;
+  tipsLoading?: boolean;
 }) => (
   <section className="bg-card border border-border rounded-lg p-4 shadow-[0_1px_0_var(--color-border-soft)]">
     <div className="flex items-baseline justify-between border-b border-dashed border-border pb-2 mb-2">
@@ -73,6 +75,7 @@ const CategoryCard = ({
           selected={selectedIds?.has(item.id)}
           onToggle={onToggle}
           storageTip={tips?.[canonicalTipKey(item.name)]}
+          storageTipLoading={tipsLoading && !tips?.[canonicalTipKey(item.name)]}
         />
       ))}
     </ul>
@@ -161,7 +164,10 @@ const Inventory = () => {
     ...(data?.kitchenwareInventory ?? []),
   ].map((i) => ({ name: i.name, type: i.type }));
   const showTips = tipsOn && !selectionMode;
-  const storageTips = useStorageTips(tipItems, showTips);
+  const { tips: storageTips, isLoading: storageTipsLoading } = useStorageTips(
+    tipItems,
+    showTips,
+  );
 
   const onSubmit = async () => {
     if (!userId || !draft.trim() || submitting) return;
@@ -524,6 +530,7 @@ const Inventory = () => {
                 selectedIds={selectedIds}
                 onToggle={toggleItem}
                 tips={showTips ? storageTips : {}}
+                tipsLoading={showTips && storageTipsLoading}
               />
             ))}
             {equipmentItems.length > 0 && (
@@ -535,6 +542,7 @@ const Inventory = () => {
                 selectedIds={selectedIds}
                 onToggle={toggleItem}
                 tips={showTips ? storageTips : {}}
+                tipsLoading={showTips && storageTipsLoading}
               />
             )}
           </div>

--- a/src/features/Inventory/components/InventoryItemRow.tsx
+++ b/src/features/Inventory/components/InventoryItemRow.tsx
@@ -11,6 +11,8 @@ interface InventoryItemRowProps {
   onToggle?: (itemId: string) => void;
   /** Ah Mah's "keep it well at home" tip; shown when present and non-empty. */
   storageTip?: string;
+  /** True while this item's tip is still being generated. */
+  storageTipLoading?: boolean;
 }
 
 export function InventoryItemRow({
@@ -20,6 +22,7 @@ export function InventoryItemRow({
   selected = false,
   onToggle,
   storageTip,
+  storageTipLoading,
 }: InventoryItemRowProps) {
   const qty =
     item.quantity && item.unit
@@ -87,6 +90,11 @@ export function InventoryItemRow({
         {storageTip && (
           <span className="block font-display italic text-dense text-muted-foreground leading-snug">
             — {storageTip}
+          </span>
+        )}
+        {!storageTip && storageTipLoading && (
+          <span className="block font-display italic text-dense text-muted-foreground/60 leading-snug animate-pulse">
+            — Ah Mah&rsquo;s thinking of a tip…
           </span>
         )}
       </span>

--- a/src/features/ShoppingList/ShoppingList.test.tsx
+++ b/src/features/ShoppingList/ShoppingList.test.tsx
@@ -10,7 +10,9 @@ jest.mock("@/contexts/SessionContext", () => ({
 
 jest.mock("sonner", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
 
-jest.mock("@/hooks/useMarketTips", () => ({ useMarketTips: jest.fn(() => ({})) }));
+jest.mock("@/hooks/useMarketTips", () => ({
+  useMarketTips: jest.fn(() => ({ tips: {}, isLoading: false })),
+}));
 const mockedUseMarketTips = jest.mocked(useMarketTips);
 
 let mockData: {
@@ -29,7 +31,7 @@ jest.mock("swr", () => {
 beforeEach(() => {
   jest.clearAllMocks();
   mockData = { items: [] };
-  mockedUseMarketTips.mockReturnValue({});
+  mockedUseMarketTips.mockReturnValue({ tips: {}, isLoading: false });
   global.fetch = jest
     .fn()
     .mockResolvedValue({ ok: true, json: async () => ({}) });
@@ -247,7 +249,8 @@ describe("ShoppingList", () => {
       items: [{ id: "row-1", name: "Tomatoes", bought: false }],
     };
     mockedUseMarketTips.mockReturnValue({
-      [canonicalTipKey("Tomatoes")]: "Pick firm, deep-red ones.",
+      tips: { [canonicalTipKey("Tomatoes")]: "Pick firm, deep-red ones." },
+      isLoading: false,
     });
 
     render(<ShoppingList />);
@@ -270,11 +273,22 @@ describe("ShoppingList", () => {
 
   it("shows no tip for a staple the engine returns nothing for", () => {
     mockData = { items: [{ id: "row-1", name: "Salt", bought: false }] };
-    mockedUseMarketTips.mockReturnValue({});
+    mockedUseMarketTips.mockReturnValue({ tips: {}, isLoading: false });
 
     render(<ShoppingList />);
 
     expect(screen.getByText("Salt")).toBeInTheDocument();
     expect(screen.queryByText(/—/)).not.toBeInTheDocument();
+  });
+
+  it("shows a thinking placeholder while a pickable item's tip is generating", () => {
+    mockData = {
+      items: [{ id: "row-1", name: "Tomatoes", bought: false, category: "Vegetable" }],
+    };
+    mockedUseMarketTips.mockReturnValue({ tips: {}, isLoading: true });
+
+    render(<ShoppingList />);
+
+    expect(screen.getByText(/thinking of a tip/i)).toBeInTheDocument();
   });
 });

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -9,6 +9,7 @@ import { useMarketTips } from "@/hooks/useMarketTips";
 import { useTipsPreference } from "@/hooks/useTipsPreference";
 import { MARKET_TIPS_PREF_KEY } from "@/lib/marketTips/preferences";
 import { canonicalTipKey } from "@/lib/marketTips/canonicalKey";
+import { isPickableCategory } from "@/lib/marketTips/pickable";
 import { groupByAisle } from "@/lib/shoppingList";
 import { cn, fetcher } from "@/lib/utils";
 import { Check, Plus, X } from "lucide-react";
@@ -142,7 +143,7 @@ const ShoppingList = () => {
   // about pickable items, so staples (salt, sugar, flour) return no tip.
   // Default ON; toggling off skips the fetch entirely.
   const [tipsOn, setTipsOn] = useTipsPreference(MARKET_TIPS_PREF_KEY, true);
-  const tips = useMarketTips(
+  const { tips, isLoading: tipsLoading } = useMarketTips(
     items.map((item) => ({ name: item.name, category: item.category })),
     tipsOn,
   );
@@ -246,6 +247,15 @@ const ShoppingList = () => {
                             — {tips[canonicalTipKey(item.name)]}
                           </span>
                         )}
+                        {tipsOn &&
+                          !item.bought &&
+                          tipsLoading &&
+                          !tips[canonicalTipKey(item.name)] &&
+                          isPickableCategory(item.category) && (
+                            <span className="block font-display italic text-dense text-muted-foreground/60 leading-snug animate-pulse">
+                              — Ah Mah&rsquo;s thinking of a tip…
+                            </span>
+                          )}
                       </span>
                       <button
                         type="button"

--- a/src/hooks/useMarketTips.ts
+++ b/src/hooks/useMarketTips.ts
@@ -13,7 +13,10 @@ interface TipItem {
  * Fetches Ah Mah's picking tips for a set of (missing) ingredients.
  * Only pickable items are requested; the SWR key is the sorted canonical
  * names, so identical lists dedupe and tips are cached for an hour.
- * Returns a canonical-key → tip map ("" means no tip).
+ * Returns a canonical-key → tip map ("" means no tip) alongside `isLoading`,
+ * which stays true for the duration of any in-flight request (initial fetch
+ * or revalidation after the item list changes) — callers use it to show a
+ * placeholder instead of leaving a toggled-on tip line silently blank.
  *
  * Pass `enabled = false` (e.g. when the surface's tips toggle is off) to skip
  * the request entirely — the SWR key goes null, so no network call is made.
@@ -21,7 +24,7 @@ interface TipItem {
 export function useMarketTips(
   items: TipItem[],
   enabled = true,
-): Record<string, string> {
+): { tips: Record<string, string>; isLoading: boolean } {
   const pickable = items.filter((i) => isPickableCategory(i.category));
   const swrKey =
     enabled && pickable.length
@@ -31,7 +34,7 @@ export function useMarketTips(
           .join("|")}`
       : null;
 
-  const { data } = useSWR<{ tips: Record<string, string> }>(
+  const { data, isValidating } = useSWR<{ tips: Record<string, string> }>(
     swrKey,
     async () => {
       const res = await fetch("/api/market-tip", {
@@ -54,5 +57,7 @@ export function useMarketTips(
   // keepPreviousData holds the last tips even after the key goes null, so the
   // disabled return must be gated explicitly — otherwise toggling off never
   // clears the tips already on screen.
-  return enabled ? (data?.tips ?? {}) : {};
+  return enabled
+    ? { tips: data?.tips ?? {}, isLoading: isValidating }
+    : { tips: {}, isLoading: false };
 }

--- a/src/hooks/useStorageTips.ts
+++ b/src/hooks/useStorageTips.ts
@@ -11,7 +11,11 @@ interface TipItem {
 /**
  * Fetches Ah Mah's "keep it well at home" tips for a set of pantry items.
  * The SWR key is the sorted canonical names, so identical lists dedupe and
- * tips are cached for an hour. Returns a canonical-key → tip map ("" = no tip).
+ * tips are cached for an hour. Returns a canonical-key → tip map ("" = no
+ * tip) alongside `isLoading`, which stays true for the duration of any
+ * in-flight request (initial fetch or revalidation after the item list
+ * changes) — callers use it to show a placeholder instead of leaving a
+ * toggled-on tip line silently blank.
  *
  * Pass `enabled = false` (the Pantry tips toggle is off, and defaults off) to
  * skip the request entirely — the SWR key goes null, so no network call fires.
@@ -19,7 +23,7 @@ interface TipItem {
 export function useStorageTips(
   items: TipItem[],
   enabled = true,
-): Record<string, string> {
+): { tips: Record<string, string>; isLoading: boolean } {
   const swrKey =
     enabled && items.length
       ? `storage-tip:${items
@@ -28,7 +32,7 @@ export function useStorageTips(
           .join("|")}`
       : null;
 
-  const { data } = useSWR<{ tips: Record<string, string> }>(
+  const { data, isValidating } = useSWR<{ tips: Record<string, string> }>(
     swrKey,
     async () => {
       const res = await fetch("/api/storage-tip", {
@@ -51,5 +55,7 @@ export function useStorageTips(
   // keepPreviousData holds the last tips even after the key goes null, so the
   // disabled return must be gated explicitly — otherwise toggling off never
   // clears the tips already on screen.
-  return enabled ? (data?.tips ?? {}) : {};
+  return enabled
+    ? { tips: data?.tips ?? {}, isLoading: isValidating }
+    : { tips: {}, isLoading: false };
 }


### PR DESCRIPTION
## Summary
- Toggling on Ah Mah's tips for the Shopping List / Pantry looked hung for several seconds when a tip hadn't been generated yet — the row just stayed blank.
- `useMarketTips`/`useStorageTips` now expose `isLoading` (from SWR's `isValidating`, so it covers both first fetch and revalidation).
- Rows without a tip yet show "— Ah Mah's thinking of a tip…" in the existing italic/muted tip-line style with a subtle pulse, reusing the same slot instead of introducing new UI chrome.

## Test plan
- [x] `npx jest` — 628 tests passing, including a new test asserting the placeholder renders while loading
- [x] Manually verified via Playwright against the dev server with the `/api/market-tip` response delayed: toggling tips on for a never-before-tipped item immediately shows the "thinking" placeholder, then the real tip once the response resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators for tip generation in Inventory and Shopping List views.
  * Users now see a temporary “thinking of a tip” placeholder while storage or market tips are being fetched.

* **Bug Fixes**
  * Improved tip display behavior so loading states are shown consistently instead of leaving empty gaps.
  * Tip data is now cleared more predictably when tip fetching is disabled.

* **Tests**
  * Updated shopping list coverage to verify tip, no-tip, and loading placeholder behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->