### PR TITLE
refactor(errors): typed error hierarchy to replace string-matched error checks

### DIFF
--- a/src/app/api/conversation/[id]/route.test.ts
+++ b/src/app/api/conversation/[id]/route.test.ts
@@ -4,6 +4,7 @@ import {
   deleteConversation,
   renameConversation,
 } from "@/lib/conversations";
+import { NotFoundError } from "@/lib/errors";
 import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
 
@@ -116,7 +117,7 @@ describe("Conversation by-id API routes", () => {
 
     it("returns 404 when renaming a conversation the user does not own", async () => {
       mockedRenameConversation.mockRejectedValue(
-        new Error("Conversation not found")
+        new NotFoundError("Conversation")
       );
 
       const request = createMockRequest("http://localhost:3000/api/conversation/conv-1", {
@@ -188,7 +189,7 @@ describe("Conversation by-id API routes", () => {
     });
 
     it("returns 404 when the conversation does not belong to the user", async () => {
-      mockedDeleteConversation.mockRejectedValue(new Error("Conversation not found"));
+      mockedDeleteConversation.mockRejectedValue(new NotFoundError("Conversation"));
 
       const request = createMockRequest(
         "http://localhost:3000/api/conversation/conv-1",

--- a/src/app/api/conversation/[id]/route.ts
+++ b/src/app/api/conversation/[id]/route.ts
@@ -3,6 +3,7 @@ import {
   deleteConversation,
   renameConversation,
 } from "@/lib/conversations";
+import { NotFoundError } from "@/lib/errors";
 import { withAuthDynamic } from "@/lib/withAuth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -22,10 +23,7 @@ export const PATCH = withAuthDynamic<{ id: string }>(async (req: NextRequest, { 
       const conversation = await renameConversation(id, title, userId);
       return NextResponse.json({ conversation });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message === "Conversation not found"
-      ) {
+      if (error instanceof NotFoundError) {
         return NextResponse.json(
           { error: "Conversation not found" },
           { status: 404 }
@@ -48,7 +46,7 @@ export const DELETE = withAuthDynamic<{ id: string }>(async (_req, { userId, par
     await deleteConversation(id, userId);
     return new Response(null, { status: 204 });
   } catch (error) {
-    if (error instanceof Error && error.message === "Conversation not found") {
+    if (error instanceof NotFoundError) {
       return NextResponse.json(
         { error: "Conversation not found" },
         { status: 404 }

--- a/src/app/api/message/route.test.ts
+++ b/src/app/api/message/route.test.ts
@@ -1,5 +1,6 @@
 import { GET, POST } from "./route";
 import { createMessage, getMessages } from "@/lib/messages";
+import { NotFoundError } from "@/lib/errors";
 import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
 
@@ -340,7 +341,7 @@ describe("Message API Routes", () => {
 
     it("returns 404 when writing to a conversation the user does not own", async () => {
       mockedCreateMessage.mockRejectedValue(
-        new Error("Conversation not found")
+        new NotFoundError("Conversation")
       );
 
       const request = createMockRequest("http://localhost:3000/api/message", {

--- a/src/app/api/message/route.ts
+++ b/src/app/api/message/route.ts
@@ -1,4 +1,5 @@
 import { maybeAutoTitleConversation } from "@/lib/conversations";
+import { NotFoundError } from "@/lib/errors";
 import { createMessage, getMessages } from "@/lib/messages";
 import { withAuth } from "@/lib/withAuth";
 import { NextRequest, NextResponse } from "next/server";
@@ -45,7 +46,7 @@ export const POST = withAuth(async (req: NextRequest, { userId }) => {
 
     return NextResponse.json({ message });
   } catch (error) {
-    if (error instanceof Error && error.message === "Conversation not found") {
+    if (error instanceof NotFoundError) {
       return NextResponse.json(
         { error: "Conversation not found" },
         { status: 404 }

--- a/src/app/api/recipe/[id]/route.ts
+++ b/src/app/api/recipe/[id]/route.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from "@/lib/errors";
 import { updateRecipeForUser } from "@/lib/recipes";
 import { RecipeBlockSchema } from "@/lib/recipes/schemas";
 import { withAuthDynamic } from "@/lib/withAuth";
@@ -21,7 +22,7 @@ export const PATCH = withAuthDynamic<{ id: string }>(async (req: NextRequest, { 
     if (err instanceof SyntaxError) {
       return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
     }
-    if (err instanceof Error && err.message === "not found") {
+    if (err instanceof NotFoundError) {
       return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
     }
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/api/recipe/[id]/share/route.test.ts
+++ b/src/app/api/recipe/[id]/share/route.test.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from "@/lib/errors";
 import { mintShareToken } from "@/lib/recipes";
 import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
@@ -60,8 +61,8 @@ describe("POST /api/recipe/[id]/share", () => {
     expect(mockedMint).toHaveBeenCalledWith("recipe-1", "user-123");
   });
 
-  it("returns 404 when the recipe is not the caller's (mint throws 'not found')", async () => {
-    mockedMint.mockRejectedValue(new Error("not found"));
+  it("returns 404 when the recipe is not the caller's (mint throws NotFoundError)", async () => {
+    mockedMint.mockRejectedValue(new NotFoundError("Recipe"));
 
     const res = await POST(makeRequest(), { params });
 

--- a/src/app/api/recipe/[id]/share/route.ts
+++ b/src/app/api/recipe/[id]/share/route.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from "@/lib/errors";
 import { mintShareToken } from "@/lib/recipes";
 import { withAuthDynamic } from "@/lib/withAuth";
 import { NextResponse } from "next/server";
@@ -14,7 +15,7 @@ export const POST = withAuthDynamic<{ id: string }>(async (_req, { userId, param
     const token = await mintShareToken(id, userId);
     return NextResponse.json({ token });
   } catch (err) {
-    if (err instanceof Error && err.message === "not found") {
+    if (err instanceof NotFoundError) {
       return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
     }
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/api/recipe/route.test.ts
+++ b/src/app/api/recipe/route.test.ts
@@ -1,4 +1,5 @@
 import { deleteRecipeForUser, getRecipes, saveRecipe, saveRecipeFromBlock } from "@/lib/recipes";
+import { NotFoundError } from "@/lib/errors";
 import { getSessionUserId } from "@/lib/session";
 import { NextRequest } from "next/server";
 import { DELETE, GET, POST } from "./route";
@@ -721,7 +722,7 @@ describe("Recipe API Routes", () => {
     });
 
     it("should return 404 when recipe not found or not owned", async () => {
-      mockedDeleteRecipeForUser.mockRejectedValue(new Error("Recipe not found or not owned by user"));
+      mockedDeleteRecipeForUser.mockRejectedValue(new NotFoundError("Recipe"));
 
       const request = createMockRequest("http://localhost:3000/api/recipe", {
         method: "DELETE",

--- a/src/app/api/recipe/route.ts
+++ b/src/app/api/recipe/route.ts
@@ -2,6 +2,7 @@ import { deleteRecipeForUser, getRecipes, saveRecipe, saveRecipeFromBlock } from
 import { processRecipe } from "@/lib/recipes/recipeProcessor";
 import { normalizeTags } from "@/lib/recipes/normalizeTags";
 import { fetchRecipePhoto } from "@/lib/pexels/fetchPhoto";
+import { NotFoundError } from "@/lib/errors";
 import { withAuth } from "@/lib/withAuth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -58,7 +59,7 @@ export const DELETE = withAuth(async (req: NextRequest, { userId }) => {
     await deleteRecipeForUser(recipeId, userId);
     return NextResponse.json({ success: true });
   } catch (error) {
-    if (error instanceof Error && error.message.includes("not found")) {
+    if (error instanceof NotFoundError) {
       return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
     }
     throw error;

--- a/src/lib/conversations/conversations.ts
+++ b/src/lib/conversations/conversations.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { NotFoundError } from "@/lib/errors";
 import { generateObject } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { z } from "zod";
@@ -91,7 +92,7 @@ export async function renameConversation(
   });
 
   if (result.count === 0) {
-    throw new Error("Conversation not found");
+    throw new NotFoundError("Conversation");
   }
 
   const conversation = await prisma.conversation.findUnique({
@@ -131,7 +132,7 @@ export async function deleteConversation(
   });
 
   if (result.count === 0) {
-    throw new Error("Conversation not found");
+    throw new NotFoundError("Conversation");
   }
 }
 

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,33 @@
+import { NotFoundError, UnauthorizedError } from "./errors";
+
+describe("NotFoundError", () => {
+  it("carries statusCode 404", () => {
+    expect(new NotFoundError().statusCode).toBe(404);
+  });
+
+  it("builds a readable message from the resource name", () => {
+    expect(new NotFoundError("Recipe").message).toBe("Recipe not found");
+  });
+
+  it("falls back to a generic message when no resource is given", () => {
+    expect(new NotFoundError().message).toBe("Not found");
+  });
+
+  it("is instanceof Error", () => {
+    expect(new NotFoundError()).toBeInstanceOf(Error);
+  });
+});
+
+describe("UnauthorizedError", () => {
+  it("carries statusCode 401", () => {
+    expect(new UnauthorizedError().statusCode).toBe(401);
+  });
+
+  it("has message Unauthorized", () => {
+    expect(new UnauthorizedError().message).toBe("Unauthorized");
+  });
+
+  it("is instanceof Error", () => {
+    expect(new UnauthorizedError()).toBeInstanceOf(Error);
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,15 @@
+export class NotFoundError extends Error {
+  readonly statusCode = 404;
+  constructor(resource?: string) {
+    super(resource ? `${resource} not found` : "Not found");
+    this.name = "NotFoundError";
+  }
+}
+
+export class UnauthorizedError extends Error {
+  readonly statusCode = 401;
+  constructor() {
+    super("Unauthorized");
+    this.name = "UnauthorizedError";
+  }
+}

--- a/src/lib/messages/messages.ts
+++ b/src/lib/messages/messages.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { NotFoundError } from "@/lib/errors";
 
 /**
  * Read a conversation's messages — scoped to its owner. Filtering on the
@@ -32,7 +33,7 @@ export async function createMessage(
       select: { userId: true },
     });
     if (existing && existing.userId !== userId) {
-      throw new Error("Conversation not found");
+      throw new NotFoundError("Conversation");
     }
     if (!existing) {
       await tx.conversation.create({

--- a/src/lib/recipes/recipes.test.ts
+++ b/src/lib/recipes/recipes.test.ts
@@ -135,7 +135,7 @@ describe("deleteRecipeForUser", () => {
     (mockPrisma.recipe.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
 
     await expect(deleteRecipeForUser("recipe-1", "wrong-user")).rejects.toThrow(
-      "Recipe not found or not owned by user",
+      "Recipe not found",
     );
   });
 

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "crypto";
 import { fetchRecipePhoto } from "../pexels/fetchPhoto";
 import type { PexelsPhoto } from "../pexels/fetchPhoto";
 import { prisma } from "../db";
+import { NotFoundError } from "../errors";
 import { normalizeTags } from "./normalizeTags";
 import { normalizeIngredient } from "./normalizeIngredient";
 import { Recipe, RecipeBlock } from "./schemas";
@@ -41,7 +42,7 @@ export async function deleteRecipeForUser(recipeId: string, userId: string) {
     where: { id: recipeId, userId },
   });
   if (result.count === 0) {
-    throw new Error("Recipe not found or not owned by user");
+    throw new NotFoundError("Recipe");
   }
 }
 
@@ -62,7 +63,7 @@ export async function updateRecipeForUser(id: string, userId: string, block: Rec
     },
   });
   if (result.count === 0) {
-    throw new Error("not found");
+    throw new NotFoundError("Recipe");
   }
   return await prisma.recipe.findUnique({ where: { id } });
 }
@@ -83,7 +84,7 @@ export async function mintShareToken(id: string, userId: string) {
     where: { id, userId },
     select: { shareToken: true },
   });
-  if (!recipe) throw new Error("not found");
+  if (!recipe) throw new NotFoundError("Recipe");
   if (recipe.shareToken) return recipe.shareToken;
 
   // Compare-and-set so concurrent callers can't each mint a different token and
@@ -100,7 +101,7 @@ export async function mintShareToken(id: string, userId: string) {
     where: { id, userId },
     select: { shareToken: true },
   });
-  if (!current?.shareToken) throw new Error("not found");
+  if (!current?.shareToken) throw new NotFoundError("Recipe");
   return current.shareToken;
 }
 


### PR DESCRIPTION
Closes #363

## Summary
- Adds `NotFoundError` and `UnauthorizedError` typed error classes in `src/lib/errors.ts`, each carrying a `statusCode` property
- Lib functions (`recipes`, `conversations`, `messages`) now throw typed errors instead of bare `Error` with hardcoded message strings
- All route handlers catch by `instanceof NotFoundError` instead of `.message ===` / `.message.includes()` string comparisons
- Tests updated to throw `NotFoundError` in mocks; new `errors.test.ts` covers the type→statusCode mapping

## Test plan
- All 635 tests pass
- Renaming a message string in a lib function no longer silently breaks a route's status-code mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 404 handling across conversation and recipe actions, so missing or inaccessible items now return more consistent “not found” responses.
  * Fixed ownership-related failures when creating messages, renaming/deleting conversations, updating/deleting recipes, and sharing recipes to behave as expected.
  * Updated tests to match the new error behavior and keep response messages stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->