### PR TITLE
docs: add worktree setup script and usage note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ App: **“Ask Ah Mah”** — converts pantry items into recipes via chat.
 - **Local Resolution:** Resolve all conflicts locally (merge `main` into feature branch) before pushing. PRs must be "Clean" and "Mergeable".
 - **Commit Style:** Use `type(scope): description` (feat, fix, refactor, docs, test, chore).
 - **Process:** Suggest commits at logical checkpoints; do not auto-commit. Never push to `main`.
+- **Worktrees:** Use `scripts/new-worktree.sh <branch-name>` to spin one up under `.worktrees/`. `git worktree add` alone leaves `.env` (gitignored), `node_modules`, and the generated Prisma client missing, so `pnpm dev`/tests fail until those are set up — the script symlinks `.env` to the main tree's and runs `pnpm install` + `prisma generate`.
 
 ---
 

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Create a git worktree under .worktrees/<branch> branched from origin/main,
+# then wire up the untracked files a fresh worktree never gets: .env
+# (symlinked to the main tree's, so secrets stay in one place) and the
+# generated Prisma client + node_modules.
+#
+# Usage: scripts/new-worktree.sh <branch-name>
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <branch-name>" >&2
+  exit 1
+fi
+
+BRANCH="$1"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORKTREE_DIR="$REPO_ROOT/.worktrees/$BRANCH"
+
+git -C "$REPO_ROOT" fetch origin main
+git -C "$REPO_ROOT" worktree add "$WORKTREE_DIR" -b "$BRANCH" origin/main
+
+ln -s "$REPO_ROOT/.env" "$WORKTREE_DIR/.env"
+
+cd "$WORKTREE_DIR"
+pnpm install
+pnpm exec prisma generate
+
+echo "Worktree ready at $WORKTREE_DIR"


### PR DESCRIPTION
## Summary
- Add `scripts/new-worktree.sh` to create a worktree under `.worktrees/<branch>` from `origin/main`, symlink `.env` from the main tree, and run `pnpm install` + `prisma generate`
- Document the script in CLAUDE.md's Git Workflow section, noting that a bare `git worktree add` leaves `.env`, `node_modules`, and the generated Prisma client missing

## Test plan
- Ran `scripts/new-worktree.sh` manually to confirm it creates a working worktree with `.env` symlinked and dependencies installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a workflow guide for creating ready-to-use Git worktrees.
  * Introduced a helper script that sets up a new worktree, links environment settings, installs dependencies, and prepares generated assets so development and tests work immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->