### PR TITLE
security(headers): add CSP, HSTS, and clickjacking/sniffing headers (#394)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -260,6 +260,11 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - **Fix has two parts:** (1) `useChatSession` now claims the real conversation id for `useChat` the moment a staging send creates it, instead of waiting for `commitConversation` to assign it to `activeConversationId` after the stream finishes — so `useChat`'s `id` never has to reset and drop the just-streamed reply from view (fixes #384, the finish-of-generation flash). (2) `Chat.tsx`'s empty-state gate now also checks `messagesLoading`, so switching between two existing conversations no longer shows the full-screen "New Chat" state while the newly-selected conversation's history is still being fetched (fixes #383).
 - Both issues shared one root cause; #384 was closed as a duplicate trigger and tracked under #383's agent brief.
 
+### Security headers on every response — Shipped Jul 2026 (#394)
+
+- **`next.config.ts` now sets six security headers on `/(.*)`:** a Content-Security-Policy (default/connect/font/form-action `'self'`; `img-src` additionally allows `blob: data:` + the two photo CDNs already in `images.remotePatterns`; `frame-ancestors 'none'`; `object-src 'none'`; `base-uri 'self'`), HSTS (2 years, includeSubDomains), `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, and a Permissions-Policy disabling camera/microphone/geolocation — **screen-wake-lock is deliberately left enabled** because CookingMode holds one.
+- The CSP keeps `'unsafe-inline'` for script/style (Next's inline bootstrap and injected styles need it; a nonce-based CSP requires middleware and wasn't worth it yet). Dev mode adds `'unsafe-eval'` + `ws:` so Turbopack/HMR keep working. Verified against a production build: all headers served, app renders with zero CSP violations.
+
 ## Design system
 
 The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — were drifting because each hand-rolled the same primitives. A design system is now the north star: shared atoms stop drift, and every surface gets tweaked incrementally so it "looks like it belongs". See the spec at `docs/superpowers/specs/2026-06-20-recipe-design-system-design.md` and the issue tracker (#277–#285).

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,36 @@ const bundleAnalyzer = withBundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
+const isDev = process.env.NODE_ENV === "development";
+
+// 'unsafe-inline' script/style is required by Next's inline bootstrap and
+// injected styles (a nonce-based CSP needs middleware — not worth it yet).
+// Dev additionally needs eval + websockets for Turbopack/HMR.
+const csp = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
+  "style-src 'self' 'unsafe-inline'",
+  // blob:/data: for next/image placeholders; the two photo CDNs match
+  // images.remotePatterns below.
+  "img-src 'self' blob: data: https://images.unsplash.com https://images.pexels.com",
+  "font-src 'self'",
+  `connect-src 'self'${isDev ? " ws:" : ""}`,
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: csp },
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // screen-wake-lock is deliberately left enabled — CookingMode holds one.
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
@@ -19,6 +49,9 @@ const nextConfig: NextConfig = {
         hostname: "images.pexels.com",
       },
     ],
+  },
+  async headers() {
+    return [{ source: "/(.*)", headers: securityHeaders }];
   },
 };
 


### PR DESCRIPTION
## What

Closes #394 — adds `headers()` to `next.config.ts` so every response carries:

| Header | Value |
|---|---|
| `Content-Security-Policy` | `default-src 'self'`; `script-src 'self' 'unsafe-inline'`; `style-src 'self' 'unsafe-inline'`; `img-src 'self' blob: data: images.unsplash.com images.pexels.com`; `font-src 'self'`; `connect-src 'self'`; `object-src 'none'`; `base-uri 'self'`; `form-action 'self'`; `frame-ancestors 'none'` |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` |
| `X-Frame-Options` | `DENY` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |

Design notes:
- **`screen-wake-lock` is deliberately not disabled** — CookingMode holds a wake lock.
- The `img-src` allowlist matches the two photo CDNs already in `images.remotePatterns` (Unsplash seed images, Pexels recipe photos).
- `'unsafe-inline'` script/style stays: Next's inline bootstrap and injected styles need it, and a nonce-based CSP requires middleware — not worth it at this stage. No external scripts/fonts exist (fonts self-hosted via `next/font`), so the rest of the policy is self-only.
- Dev mode appends `'unsafe-eval'` and `ws:` so Turbopack/HMR keep working; production gets the strict policy.

## Verification

- `pnpm build` + `pnpm start`, then `curl -I`: all six headers present on `/`.
- Playwright screenshot of the running production build: app fully renders (fonts, styles, granny icon, hydrated composer) with the CSP enforced — no visible breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PZ11teTpz28V4rGSkhRJT
