### PR TITLE
docs: add Step Uses glossary term

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -209,3 +209,11 @@ Whole-dish asides attached to a recipe (`notes` on the recipe block): make-ahead
 The action that copies the **whole recipe** as clean plain text (CAPS section headers, `•`/numbered lists — no markdown, so it survives pasting into WhatsApp/Notes), at the **currently displayed servings**. Shared formatter, surfaced on both the chat recipe card and the recipe page. Excludes user-specific pantry state.
 
 **Flagged ambiguity — vs Copy shopping list:** two distinct copy intents, never collapse into a bare "Copy." **Copy shopping list** copies *only the missing ingredients* for a shop trip. **Copy recipe** copies *the entire dish* to cook from or share. Both can coexist on the same card; the labels name the intent.
+
+---
+
+## Step Uses
+
+The per-step list of ingredients consumed *at that step*, each carrying the quantity used **in that step** — for a split-use ingredient (a slurry added partly at step 2, the rest at step 5), the partial amount at each step, never the master total. Rendered as a quiet chip row beside the step, never woven into the step prose. Quantities are numeric-and-scalable when possible; otherwise short free text ("remaining", "to taste") shown as-is, unscaled.
+
+**Why this matters:** the master ingredient list answers *"what do I gather?"*; Step Uses answers *"how much goes in **now**?"* — mid-cook, without leaving the step. Soft invariant: a split ingredient's partial amounts should sum to its master amount; this is model-authored, not enforced.


### PR DESCRIPTION
## Summary
- Adds the **Step Uses** glossary term to CONTEXT.md, capturing the design resolved for #407 (per-step ingredient quantities in the recipe Method / CookingMode).

## Context
Docs-only change, split out from the in-progress `feat/cookingmode-finish-moment-377` branch so it can ship independently.

## Test plan
- [x] Glossary entry reads as pure terminology (no implementation detail), consistent with surrounding CONTEXT.md entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new glossary entry for “Step Uses,” clarifying how per-step ingredient amounts are shown alongside each recipe step.
  * Explained that these amounts apply only to the current step, with split ingredients displayed as partial quantities when used.
  * Clarified the difference between the master ingredient list and step-level usage, including guidance on numeric quantities and free-text fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->