### PR TITLE
fix(voice): keep pantry/sign-in errors in Ah Mah's voice, align contact email

### DIFF
--- a/src/components/AboutPopOver/index.tsx
+++ b/src/components/AboutPopOver/index.tsx
@@ -20,7 +20,7 @@ export default function AboutPopOver({
 }: InfoPopoverProps) {
   const copyEmail = async () => {
     try {
-      await navigator.clipboard.writeText("lun.tay.work@gmail.com");
+      await navigator.clipboard.writeText("lun.tay@gmail.com");
       toast.success("Email copied — drop Ah Mah a note!");
     } catch (err) {
       console.error("Failed to copy email", err);

--- a/src/features/Auth/SignInDialog.test.tsx
+++ b/src/features/Auth/SignInDialog.test.tsx
@@ -110,7 +110,7 @@ describe("SignInDialog", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText(/couldn.t sign in with google/i),
+        screen.getByText(/google didn.t let you in/i),
       ).toBeInTheDocument(),
     );
   });

--- a/src/features/Auth/SignInDialog.tsx
+++ b/src/features/Auth/SignInDialog.tsx
@@ -38,10 +38,10 @@ export function SignInDialog() {
         callbackURL: "/",
       });
       if (signInError) {
-        setError("Couldn't sign in with Google — please try again.");
+        setError("Aiyah, Google didn't let you in — try again?");
       }
     } catch {
-      setError("Couldn't sign in with Google — please try again.");
+      setError("Aiyah, Google didn't let you in — try again?");
     } finally {
       setGoogleLoading(false);
     }

--- a/src/features/Inventory/Inventory.tsx
+++ b/src/features/Inventory/Inventory.tsx
@@ -293,7 +293,10 @@ const Inventory = () => {
     router.replace("/?tab=chat");
   };
 
-  if (error) return <div>Error: {error.message}</div>;
+  if (error) {
+    console.error("[Inventory]", error);
+    return <div>Aiyah, the pantry door is stuck — try again?</div>;
+  }
 
   const { ingredientInventory = [], kitchenwareInventory = [] } = data || {};
   const ingredientGroups = groupIngredients(ingredientInventory);


### PR DESCRIPTION
## Summary
- Pantry load failures now show Ah Mah's voice ("Aiyah, the pantry door is stuck — try again?") instead of a raw `Error: {message}` string, with the real error logged to console for debugging.
- Google sign-in failures (both the `signInError` branch and the `catch` block) now read "Aiyah, Google didn't let you in — try again?" instead of generic copy.
- The "Copy email" contact action now copies `lun.tay@gmail.com`, matching the account email, instead of a mismatched address.

Closes #401.

## Test plan
- [x] `pnpm test` — 61 suites / 670 tests, all passing (includes updated `SignInDialog.test.tsx` assertion for the new copy)