### PR TITLE
feat(shopping-list): paste-and-extract add, mirroring Pantry's parse

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -176,7 +176,7 @@ Related: [ADR-0017](docs/adr/0017-storage-tips-clear-adr-0008.md), [ADR-0008](do
 
 A standing, **per-user**, persisted list of items the user intends to buy — its own top-level **Section**, the conceptual inverse of the **Pantry** (current stock) and kept adjacent to it in the nav. Items are **identities, not quantities**: a row is `shallot`, never `4 shallots`, so the same item from different recipes and from direct entry collapse to one row (canonical name). Each item carries its **Market Tip**.
 
-Items arrive two ways: the **cart button** on a recipe's ingredient row (adds the missing item), or **typed in directly** (e.g. "apples", unrelated to any recipe). Lifecycle is todo-list-style — checking an item (**bought**) strikes it through for the trip; crossing it out (**✕**, changed mind) deletes it. Moving a bought item into the **Pantry** is a separate, opt-in step, never a side effect of checking it.
+Items arrive two ways: the **cart button** on a recipe's ingredient row (adds the missing item), or **typed in directly** — a single plain word or two adds instantly, while a longer paste (e.g. a recipe's ingredient list copied off a webpage) is extracted into several items by the model, still reduced to bare identities per the quantity-less rule above. Lifecycle is todo-list-style — checking an item (**bought**) strikes it through for the trip; crossing it out (**✕**, changed mind) deletes it. Moving a bought item into the **Pantry** is a separate, opt-in step, never a side effect of checking it.
 
 Items are grouped by **[Aisle](#aisle)** so the list reads as a market walk rather than a flat pile.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -322,6 +322,11 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 - Shows up on all three recipe surfaces that render steps: the recipe page Method section and chat `RecipeLetter` (via shared `StepItem`/`StepList`), and CookingMode (its own local step renderer, via the same standalone `StepBody` component). Also included in the plain-text "Copy recipe" export and extracted when parsing pasted recipe text.
 - No DB migration — `uses` rides inside the existing `Json?` `steps` column and is optional everywhere, so legacy/pasted recipes without it render exactly as before. Full rationale, including why a link-to-master-ingredient design was rejected → [ADR-0021](./adr/0021-step-quantities-are-per-use-not-links.md).
 
+### Shopping List paste-and-extract add — Shipped Jul 2026
+
+- **The add box now takes a paste, not just a word.** Mirrors the Pantry's `/api/inventory/parse` pattern: a new `parseShoppingListText` (`src/lib/shoppingList/parseText.ts`) runs `generateObject` (`gpt-5-mini`) behind `POST /api/shopping-list/parse` to extract grocery items from a freeform block — e.g. a recipe's ingredient list copied off a webpage, quantities, prep notes, and UI noise (`img`, `Edit`) included. Extracted items still reduce to bare identities per ADR-0014 (`1 tsp chipotle paste` → `Chipotle paste`) and each carries a Pantry category, so it bridges straight to an **Aisle** without a follow-up `classifyAisles` round-trip.
+- **Hybrid routing, not a mode switch.** The add box (`src/features/ShoppingList/ShoppingList.tsx`) is a single textarea; a client-side heuristic (`/[\n,]/.test(text) || /\d/.test(text)`) sends a plain single word straight to the existing instant `POST /api/shopping-list` path, and anything multi-line, comma-separated, or amount-bearing to the new parse endpoint. Also fixes a latent bug where typing `apples, oranges` created one junk row instead of two.
+
 ## Design system
 
 The two recipe surfaces — `RecipeLetter` (chat) and `RecipeDisplay` (cookbook) — were drifting because each hand-rolled the same primitives. A design system is now the north star: shared atoms stop drift, and every surface gets tweaked incrementally so it "looks like it belongs". See the spec at `docs/superpowers/specs/2026-06-20-recipe-design-system-design.md` and the issue tracker (#277–#285).

--- a/src/app/api/shopping-list/parse/route.test.ts
+++ b/src/app/api/shopping-list/parse/route.test.ts
@@ -1,0 +1,102 @@
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+import { addShoppingListItems } from "@/lib/shoppingList";
+import { parseShoppingListText } from "@/lib/shoppingList/parseText";
+import { getSessionUserId } from "@/lib/session";
+
+jest.mock("next/server", () => ({
+  NextRequest: jest.fn(),
+  NextResponse: {
+    json: jest.fn((data, init) => ({
+      json: async () => data,
+      status: init?.status || 200,
+    })),
+  },
+}));
+
+jest.mock("@/lib/shoppingList", () => ({
+  addShoppingListItems: jest.fn(),
+}));
+
+jest.mock("@/lib/shoppingList/parseText", () => ({
+  parseShoppingListText: jest.fn(),
+}));
+
+jest.mock("@/lib/session", () => ({ getSessionUserId: jest.fn() }));
+
+const mockedParse = jest.mocked(parseShoppingListText);
+const mockedAdd = jest.mocked(addShoppingListItems);
+const mockedGetSessionUserId = jest.mocked(getSessionUserId);
+
+const reqWith = (body: unknown) =>
+  ({ json: async () => body } as unknown as NextRequest);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+  mockedGetSessionUserId.mockResolvedValue("user-123");
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe("POST /api/shopping-list/parse", () => {
+  it("extracts items from the pasted text and persists them for the session user", async () => {
+    const items = [
+      { name: "Chipotle paste", category: "Condiments" },
+      { name: "Cherry tomatoes", category: "Vegetable" },
+    ];
+    mockedParse.mockResolvedValue(items);
+
+    const res = await POST(reqWith({ text: "1 tsp chipotle paste\n7 cherry tomatoes" }));
+    const body = await res.json();
+
+    expect(mockedParse).toHaveBeenCalledWith("1 tsp chipotle paste\n7 cherry tomatoes");
+    expect(mockedAdd).toHaveBeenCalledWith(items, "user-123");
+    expect(body).toEqual({
+      success: true,
+      items,
+      message: "Added 2 item(s)",
+    });
+  });
+
+  it("400s when text is missing", async () => {
+    const res = await POST(reqWith({}));
+
+    expect(res.status).toBe(400);
+    expect(mockedParse).not.toHaveBeenCalled();
+  });
+
+  it("400s when text is blank", async () => {
+    const res = await POST(reqWith({ text: "   " }));
+
+    expect(res.status).toBe(400);
+    expect(mockedParse).not.toHaveBeenCalled();
+  });
+
+  it("401s when unauthenticated", async () => {
+    mockedGetSessionUserId.mockResolvedValue(null);
+
+    const res = await POST(reqWith({ text: "milk" }));
+
+    expect(res.status).toBe(401);
+    expect(mockedParse).not.toHaveBeenCalled();
+  });
+
+  it("500s when the model call throws", async () => {
+    mockedParse.mockRejectedValue(new Error("model down"));
+
+    const res = await POST(reqWith({ text: "milk" }));
+
+    expect(res.status).toBe(500);
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it("500s when persistence throws", async () => {
+    mockedParse.mockResolvedValue([{ name: "Milk", category: "Misc" }]);
+    mockedAdd.mockRejectedValue(new Error("db down"));
+
+    const res = await POST(reqWith({ text: "milk" }));
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/shopping-list/parse/route.test.ts
+++ b/src/app/api/shopping-list/parse/route.test.ts
@@ -73,6 +73,13 @@ describe("POST /api/shopping-list/parse", () => {
     expect(mockedParse).not.toHaveBeenCalled();
   });
 
+  it("400s when text exceeds the length cap", async () => {
+    const res = await POST(reqWith({ text: "a".repeat(10_001) }));
+
+    expect(res.status).toBe(400);
+    expect(mockedParse).not.toHaveBeenCalled();
+  });
+
   it("401s when unauthenticated", async () => {
     mockedGetSessionUserId.mockResolvedValue(null);
 

--- a/src/app/api/shopping-list/parse/route.ts
+++ b/src/app/api/shopping-list/parse/route.ts
@@ -1,0 +1,28 @@
+import { addShoppingListItems } from "@/lib/shoppingList";
+import { parseShoppingListText } from "@/lib/shoppingList/parseText";
+import { withAuth } from "@/lib/withAuth";
+import { NextRequest, NextResponse } from "next/server";
+
+export const POST = withAuth(async (req: NextRequest, { userId }) => {
+  try {
+    const { text } = await req.json();
+    if (!text || typeof text !== "string" || text.trim().length === 0) {
+      return NextResponse.json({ error: "text is required" }, { status: 400 });
+    }
+
+    const items = await parseShoppingListText(text);
+    await addShoppingListItems(items, userId);
+
+    return NextResponse.json({
+      success: true,
+      items,
+      message: `Added ${items.length} item(s)`,
+    });
+  } catch (error) {
+    console.error("Failed to parse shopping list entry", error);
+    return NextResponse.json(
+      { error: "Failed to parse shopping list entry" },
+      { status: 500 },
+    );
+  }
+});

--- a/src/app/api/shopping-list/parse/route.ts
+++ b/src/app/api/shopping-list/parse/route.ts
@@ -9,6 +9,9 @@ export const POST = withAuth(async (req: NextRequest, { userId }) => {
     if (!text || typeof text !== "string" || text.trim().length === 0) {
       return NextResponse.json({ error: "text is required" }, { status: 400 });
     }
+    if (text.length > 10_000) {
+      return NextResponse.json({ error: "text is too long" }, { status: 400 });
+    }
 
     const items = await parseShoppingListText(text);
     await addShoppingListItems(items, userId);

--- a/src/features/ShoppingList/ShoppingList.test.tsx
+++ b/src/features/ShoppingList/ShoppingList.test.tsx
@@ -148,6 +148,84 @@ describe("ShoppingList", () => {
     expect(mutate).toHaveBeenCalledWith("/api/shopping-list?userId=user-1");
   });
 
+  it("routes a comma-separated paste through the parse API", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          { name: "Apples", category: "Vegetable" },
+          { name: "Oranges", category: "Vegetable" },
+        ],
+      }),
+    });
+
+    render(<ShoppingList />);
+
+    fireEvent.change(screen.getByPlaceholderText(/apples/i), {
+      target: { value: "apples, oranges" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/shopping-list/parse",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ text: "apples, oranges" }),
+        }),
+      );
+    });
+
+    expect(mutate).toHaveBeenCalledWith("/api/shopping-list?userId=user-1");
+  });
+
+  it("routes a multi-line paste through the parse API", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [{ name: "Kale", category: "Vegetable" }],
+      }),
+    });
+
+    render(<ShoppingList />);
+
+    fireEvent.change(screen.getByPlaceholderText(/apples/i), {
+      target: { value: "50g kale\nimg" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/shopping-list/parse",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ text: "50g kale\nimg" }),
+        }),
+      );
+    });
+  });
+
+  it("routes a single line with a quantity through the parse API", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [{ name: "Eggs", category: "Protein" }] }),
+    });
+
+    render(<ShoppingList />);
+
+    fireEvent.change(screen.getByPlaceholderText(/apples/i), {
+      target: { value: "2 eggs" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/shopping-list/parse",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
   it("marks an item bought via PATCH when its checkbox is toggled", async () => {
     mockData = { items: [{ id: "row-1", name: "Apples", bought: false }] };
 

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -92,11 +92,23 @@ const ShoppingList = () => {
     }
   };
 
+  // Applies the change to the SWR cache immediately (so the row updates on
+  // click, not a round-trip later), fires the request in the background, and
+  // rolls back if it fails. The API only returns `{ success }`, so on success
+  // we revalidate in the background to reconcile with the server.
   const mutateList = async (
     method: "PATCH" | "DELETE",
     body: Record<string, unknown>,
+    optimisticUpdate: (items: ShoppingListRow[]) => ShoppingListRow[],
   ) => {
     if (!userId) return;
+    const key = `/api/shopping-list?userId=${encodeURIComponent(userId)}`;
+    const previous = data;
+    mutate<GetShoppingListResponse>(
+      key,
+      { items: optimisticUpdate(items) },
+      { revalidate: false },
+    );
     try {
       const res = await fetch("/api/shopping-list", {
         method,
@@ -104,23 +116,32 @@ const ShoppingList = () => {
         body: JSON.stringify(body),
       });
       if (res.ok) {
-        revalidate();
+        mutate(key);
       } else {
+        mutate(key, previous, { revalidate: false });
         toast.error("Aiyah, that didn't work. Try again?");
       }
     } catch (e) {
+      mutate(key, previous, { revalidate: false });
       console.error("Failed to update shopping list:", e);
       toast.error("Aiyah, that didn't work. Try again?");
     }
   };
 
   const toggleBought = (item: ShoppingListRow) =>
-    mutateList("PATCH", { id: item.id, bought: !item.bought });
+    mutateList("PATCH", { id: item.id, bought: !item.bought }, (items) =>
+      items.map((i) => (i.id === item.id ? { ...i, bought: !i.bought } : i)),
+    );
 
   const removeItem = (item: ShoppingListRow) =>
-    mutateList("DELETE", { id: item.id });
+    mutateList("DELETE", { id: item.id }, (items) =>
+      items.filter((i) => i.id !== item.id),
+    );
 
-  const clearBought = () => mutateList("DELETE", { clearBought: true });
+  const clearBought = () =>
+    mutateList("DELETE", { clearBought: true }, (items) =>
+      items.filter((i) => !i.bought),
+    );
 
   const items = data?.items ?? [];
   const hasBought = items.some((item) => item.bought);

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -94,8 +94,10 @@ const ShoppingList = () => {
 
   // Applies the change to the SWR cache immediately (so the row updates on
   // click, not a round-trip later), fires the request in the background, and
-  // rolls back if it fails. The API only returns `{ success }`, so on success
-  // we revalidate in the background to reconcile with the server.
+  // reconciles with a revalidate on both success and failure. Revalidating
+  // (rather than rolling back to a captured "previous" snapshot) means an
+  // overlapping second mutation's optimistic write is never clobbered by a
+  // stale snapshot from the first.
   const mutateList = async (
     method: "PATCH" | "DELETE",
     body: Record<string, unknown>,
@@ -103,7 +105,6 @@ const ShoppingList = () => {
   ) => {
     if (!userId) return;
     const key = `/api/shopping-list?userId=${encodeURIComponent(userId)}`;
-    const previous = data;
     mutate<GetShoppingListResponse>(
       key,
       { items: optimisticUpdate(items) },
@@ -115,14 +116,12 @@ const ShoppingList = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
-      if (res.ok) {
-        mutate(key);
-      } else {
-        mutate(key, previous, { revalidate: false });
+      mutate(key);
+      if (!res.ok) {
         toast.error("Aiyah, that didn't work. Try again?");
       }
     } catch (e) {
-      mutate(key, previous, { revalidate: false });
+      mutate(key);
       console.error("Failed to update shopping list:", e);
       toast.error("Aiyah, that didn't work. Try again?");
     }

--- a/src/features/ShoppingList/ShoppingList.tsx
+++ b/src/features/ShoppingList/ShoppingList.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { Eyebrow } from "@/features/shared/components/recipe";
 import { TipsToggle } from "@/features/shared/components/TipsToggle";
@@ -44,19 +43,38 @@ const ShoppingList = () => {
   );
 
   const onSubmit = async () => {
-    const name = draft.trim();
-    if (!userId || !name || submitting) return;
+    const text = draft.trim();
+    if (!userId || !text || submitting) return;
     setSubmitting(true);
+    // Multi-line, comma-separated, or amount-bearing text is treated as a
+    // paste (e.g. a recipe's ingredient list) and routed through the LLM
+    // extractor; a single plain line stays on the instant direct-add path.
+    const needsParse = /[\n,]/.test(text) || /\d/.test(text);
     try {
-      const res = await fetch("/api/shopping-list", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ items: [{ name }] }),
-      });
+      const res = needsParse
+        ? await fetch("/api/shopping-list/parse", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ text }),
+          })
+        : await fetch("/api/shopping-list", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ items: [{ name: text }] }),
+          });
       if (res.ok) {
         setDraft("");
         mutate(`/api/shopping-list?userId=${encodeURIComponent(userId)}`);
-        toast.success(`${name} — on the list.`);
+        if (needsParse) {
+          const { items } = (await res.json()) as { items: { name: string }[] };
+          toast.success(
+            items.length === 1
+              ? `${items[0].name} — on the list.`
+              : `${items.length} things, on the list.`,
+          );
+        } else {
+          toast.success(`${text} — on the list.`);
+        }
       } else {
         toast.error("Aiyah, couldn't add that. Try again?");
       }
@@ -168,14 +186,21 @@ const ShoppingList = () => {
             e.preventDefault();
             onSubmit();
           }}
-          className="flex gap-2 mb-5"
+          className="flex gap-2 mb-5 items-end"
         >
-          <Input
+          <textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
-            placeholder="e.g., apples, oranges, shallots"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                onSubmit();
+              }
+            }}
+            placeholder="e.g., apples, oranges, shallots — or paste a recipe's ingredients"
+            rows={1}
             disabled={submitting}
-            className="flex-1"
+            className="flex-1 rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm resize-none"
           />
           <Button
             type="submit"
@@ -183,7 +208,7 @@ const ShoppingList = () => {
             className="gap-1.5 font-semibold shrink-0"
           >
             <Plus className="size-[15px]" />
-            Add
+            {submitting ? "Adding…" : "Add"}
           </Button>
         </form>
 

--- a/src/lib/shoppingList/parseText.test.ts
+++ b/src/lib/shoppingList/parseText.test.ts
@@ -1,0 +1,51 @@
+import { generateObject } from "ai";
+import { parseShoppingListText } from "./parseText";
+
+jest.mock("ai", () => ({ generateObject: jest.fn() }));
+jest.mock("@ai-sdk/openai", () => ({ openai: jest.fn(() => "model") }));
+
+const mockedGenerate = jest.mocked(generateObject);
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("parseShoppingListText", () => {
+  it("returns the model's extracted items", async () => {
+    const items = [
+      { name: "Chipotle paste", category: "Condiments" },
+      { name: "Cherry tomatoes", category: "Vegetable" },
+    ];
+    mockedGenerate.mockResolvedValue({ object: { items } } as never);
+
+    const result = await parseShoppingListText(
+      "1 tsp chipotle paste\nimg\n7 cherry tomatoes\nhalved",
+    );
+
+    expect(result).toEqual(items);
+  });
+
+  it("sends the pasted text and category rules to the model", async () => {
+    mockedGenerate.mockResolvedValue({ object: { items: [] } } as never);
+
+    await parseShoppingListText("2 eggs");
+
+    expect(mockedGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("2 eggs"),
+      }),
+    );
+    expect(mockedGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("Protein"),
+      }),
+    );
+  });
+
+  it("does not set a temperature (gpt-5-mini only supports the default)", async () => {
+    mockedGenerate.mockResolvedValue({ object: { items: [] } } as never);
+
+    await parseShoppingListText("milk");
+
+    const call = mockedGenerate.mock.calls[0][0];
+    expect(call).not.toHaveProperty("temperature");
+  });
+});

--- a/src/lib/shoppingList/parseText.ts
+++ b/src/lib/shoppingList/parseText.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { AddShoppingListItemSchema, type AddShoppingListItem } from "./schemas";
 
 const ParseSchema = z.object({
-  items: z.array(AddShoppingListItemSchema),
+  items: z.array(AddShoppingListItemSchema).max(50),
 });
 
 /**

--- a/src/lib/shoppingList/parseText.ts
+++ b/src/lib/shoppingList/parseText.ts
@@ -1,0 +1,41 @@
+import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
+import { openai } from "@ai-sdk/openai";
+import { generateObject } from "ai";
+import { z } from "zod";
+import { AddShoppingListItemSchema, type AddShoppingListItem } from "./schemas";
+
+const ParseSchema = z.object({
+  items: z.array(AddShoppingListItemSchema),
+});
+
+/**
+ * Extract Shopping List items from a freeform paste — typically a recipe's
+ * ingredient list copied off the web, quantities, prep notes, and UI noise
+ * (`img`, `Edit`) included. Mirrors `/api/inventory/parse`'s extraction
+ * pattern, but every item comes back as a bare identity per ADR-0014 (a row
+ * is `Cherry tomato`, never `7 cherry tomatoes`), and each item carries a
+ * Pantry category so it can bridge straight to an Aisle via `toAisle` — no
+ * follow-up `classifyAisles` call needed.
+ */
+export async function parseShoppingListText(
+  text: string,
+): Promise<AddShoppingListItem[]> {
+  const { object } = await generateObject({
+    model: openai("gpt-5-mini"),
+    schema: ParseSchema,
+    // gpt-5-mini only supports the default temperature; setting it errors.
+    prompt: `Parse the following freeform text into Shopping List items. The user pasted a recipe's ingredient list (often copied off a webpage) or typed a few things they need to buy.
+
+RULES:
+- Extract ONLY real grocery ingredients meant for buying. Skip anything that isn't one: webpage noise ("img", "Edit", "Save"), kitchenware/equipment (pots, pans, utensils, appliances), and standalone prep/description lines that aren't ingredients themselves (e.g. "halved", "warmed", "small, sliced" sitting on their own line under an ingredient).
+- Each item gets ONLY a name and a category — NEVER a quantity or unit. The Shopping List holds identities, not amounts: "1 tsp chipotle paste" → "Chipotle paste", "50g kale" → "Kale", "7 cherry tomatoes" → "Cherry tomatoes".
+- Keep names natural — plural is fine for things bought in multiples ("Cherry tomatoes"), singular for mass/single ingredients ("Kale", "Chipotle paste"). Title case.
+- category is REQUIRED for every item:
+${PROMPT_FRAGMENTS.categoryRules}
+
+TEXT:
+${text}`,
+  });
+
+  return object.items;
+}


### PR DESCRIPTION
## Summary

- The Shopping List's add box was a single-line `<Input>` that POSTed the entire string as one `{ name }` row — no splitting, no LLM. Typing `apples, oranges` created one junk row instead of two, and it couldn't handle a pasted recipe ingredient list.
- Mirrors the Pantry's existing paste-and-extract pattern (`/api/inventory/parse`): a new `parseShoppingListText` (`src/lib/shoppingList/parseText.ts`) runs `generateObject` (`gpt-5-mini`) behind `POST /api/shopping-list/parse` to extract grocery items from a freeform block — quantities, prep notes, and web noise (`img`, `Edit`) dropped.
- Extracted items stay **quantity-less identities** per [ADR-0014](./docs/adr/0014-shopping-list-is-standing-and-quantityless.md) (`1 tsp chipotle paste` → `Chipotle paste`), and each item carries a Pantry `category` so it bridges straight to an **Aisle** without a follow-up `classifyAisles` round-trip.
- The add box hybrid-routes: a single plain line still goes through the existing instant `POST /api/shopping-list` path (no model wait); anything multi-line, comma-separated, or amount-bearing routes through the new parse endpoint.
- Docs updated: `CONTEXT.md` (Shopping List entry) and `docs/progress.md` (shipped note).

## Test plan

- [x] `pnpm jest` — 718/718 tests pass (91 in shopping-list scope, including new routing/extraction cases)
- [x] `pnpm eslint` on touched files — clean
- [x] `pnpm tsc --noEmit` — pre-existing errors only, confirmed identical with these changes stashed out
- [ ] Manual: paste a messy recipe ingredient block into the Shopping List add box and confirm items land correctly, grouped by aisle, with no visible "Other → aisle" reshuffle
- [ ] Manual: type a single word (e.g. `milk`) and confirm it lands instantly
- [ ] Manual: type `apples, oranges` and confirm two distinct rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paste-and-extract “Add to Shopping List” for multi-line, comma-separated, and quantity-based ingredient text.
  * Short single-word/two-word inputs are still added instantly as a single item.
  * Replaced the add input with a textarea (Enter submits; Shift+Enter adds a newline).
* **Bug Fixes**
  * Fixed comma-separated pastes being added as an incorrect single item.
  * Improved add/edit/remove behavior with immediate optimistic updates and later server reconciliation.
* **Documentation**
  * Updated Shopping List guidance and added a shipped progress note for the new paste-and-extract UX.
* **Tests**
  * Added API and UI test coverage for parsing, auth/validation, persistence, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->