### PR TITLE
chore(ai): move tips + recipe metadata to gpt-5-nano; flatten Tip voice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ App: **“Ask Ah Mah”** — converts pantry items into recipes via chat.
    - loads last `CONTEXT_WINDOW = 15` messages (`getMessages`)
    - merges with incoming messages
    - validates (`validateUIMessages`)
-   - calls `streamText(openai(MODEL_HEAVY))` (`src/lib/ai/models.ts` — `gpt-5-mini` for agentic/generation calls, `gpt-5-nano` for deterministic extraction/classification)
+   - calls `streamText(openai(MODEL_HEAVY))` (`src/lib/ai/models.ts` — `gpt-5-mini` reserved for tool-calling/agentic paths (chat, recipe tweak) and unit-conversion math (recipe-text parse); `gpt-5-nano` for everything else — extraction/classification and tip generation)
    - uses `CHAT_SYSTEM_PROMPT` and `stepCountIs(5)`
 3. Model tools:
    - `addInventoryItem`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,27 +148,27 @@ Formerly: the in-chat block that listed a recipe's missing items (the **Addition
 
 ## Market Tip
 
-Ah Mah's point-of-purchase wisdom for choosing a fresh item well — e.g. *"firm, deep-red tomato, no bruises"* or *"a dark avocado that gives slightly is ripe enough to use today."* Surfaced on the **[Shopping List](#shopping-list)** Section, one tip per item, and folded into the copied shopping-list text so it travels to wherever the user actually shops. Market Tips deliberately do **not** appear on the recipe card — co-locating a pick-tip with an ingredient's substitution `note` clashed (see [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md)).
+Point-of-purchase wisdom for choosing a fresh item well — e.g. *"firm, deep-red tomato, no bruises"* or *"a dark avocado that gives slightly is ripe enough to use today."* Surfaced on the **[Shopping List](#shopping-list)** Section, one tip per item, and folded into the copied shopping-list text so it travels to wherever the user actually shops. Market Tips deliberately do **not** appear on the recipe card — co-locating a pick-tip with an ingredient's substitution `note` clashed (see [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md)).
 
-A Market Tip speaks only to **selection quality at the moment of buying** — not to how long something keeps once home. Only *fresh / pickable* items (produce, fruit, seafood, meat) carry one; staples (salt, sauces, dry goods) have none and show no tip affordance. Tips are **universal, not user-specific**: the same advice serves every user, so they live in a single shared corpus keyed by canonical item name, never per account.
+A Market Tip speaks only to **selection quality at the moment of buying** — not to how long something keeps once home. Only *fresh / pickable* items (produce, fruit, seafood, meat) carry one; staples (salt, sauces, dry goods) have none and show no tip affordance. Tips are **universal, not user-specific**: the same advice serves every user, so they live in a single shared corpus keyed by canonical item name, never per account. Tips speak in a plain, factual register — not Ah Mah's voice (see [ADR-0023](docs/adr/0023-tips-speak-in-a-plain-register-not-ah-mahs-voice.md)).
 
 Both tip kinds are gated by **kitchen-domain relevance**: only items used for cooking or eating — food, drink, fresh groceries, and cooking equipment — are eligible. Anything unrelated to the kitchen (sports gear, vehicles, clothing, toiletries) gets no tip and is negative-cached, never re-asked. A wok is in-domain; a climbing harness is not.
 
 **Why this matters:** this is freshness-*adjacent* but deliberately distinct from the shelf-life idea rejected in [ADR-0008](docs/adr/0008-no-shelf-life-ui.md). Shelf-life asks "is *my* tomato still good?" — unknowable from app state. A Market Tip asks "how do I pick a good tomato?" — general knowledge the model already holds. The first is per-user and unreliable; the second is shared and sound.
 
-Related: [ADR-0013](docs/adr/0013-market-tips-are-llm-generated-and-shared.md), [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md)
+Related: [ADR-0013](docs/adr/0013-market-tips-are-llm-generated-and-shared.md), [ADR-0014](docs/adr/0014-shopping-list-is-standing-and-quantityless.md), [ADR-0023](docs/adr/0023-tips-speak-in-a-plain-register-not-ah-mahs-voice.md)
 
 ---
 
 ## Storage Tip
 
-Ah Mah's advice on **how to keep a kitchen item well at home** — covering both food longevity (*"potatoes in a cool, dark place, never the fridge"*, *"herbs stem-down in a glass of water"*) and equipment care (*"dry the wok on the heat, wipe a little oil so it won't rust"*). Surfaced per item in the **Pantry**, toggleable on/off.
+Advice on **how to keep a kitchen item well at home** — covering both food longevity (*"potatoes in a cool, dark place, never the fridge"*, *"herbs stem-down in a glass of water"*) and equipment care (*"dry the wok on the heat, wipe a little oil so it won't rust"*). Surfaced per item in the **Pantry**, toggleable on/off.
 
 Distinct from a **[Market Tip](#market-tip)**: a Market Tip is *pick it well at the shop* (point of purchase); a Storage Tip is *keep it well at home* (after purchase). Every kitchen-domain pantry item can carry one — food and cooking equipment alike — subject to the same kitchen-domain relevance gate.
 
-Like Market Tips, Storage Tips are **universal, not user-specific** (the same advice serves everyone) and live in their own shared corpus keyed by canonical item name. They clear [ADR-0008](docs/adr/0008-no-shelf-life-ui.md) by the same logic as Market Tips: *"how do I store a potato?"* is general, time-independent knowledge, not *"is **my** potato still good?"* — which depends on unknowable app state.
+Like Market Tips, Storage Tips are **universal, not user-specific** (the same advice serves everyone) and live in their own shared corpus keyed by canonical item name. They clear [ADR-0008](docs/adr/0008-no-shelf-life-ui.md) by the same logic as Market Tips: *"how do I store a potato?"* is general, time-independent knowledge, not *"is **my** potato still good?"* — which depends on unknowable app state. Like Market Tips, they speak in a plain, factual register — not Ah Mah's voice (see [ADR-0023](docs/adr/0023-tips-speak-in-a-plain-register-not-ah-mahs-voice.md)).
 
-Related: [ADR-0017](docs/adr/0017-storage-tips-clear-adr-0008.md), [ADR-0008](docs/adr/0008-no-shelf-life-ui.md), [ADR-0013](docs/adr/0013-market-tips-are-llm-generated-and-shared.md)
+Related: [ADR-0017](docs/adr/0017-storage-tips-clear-adr-0008.md), [ADR-0008](docs/adr/0008-no-shelf-life-ui.md), [ADR-0013](docs/adr/0013-market-tips-are-llm-generated-and-shared.md), [ADR-0023](docs/adr/0023-tips-speak-in-a-plain-register-not-ah-mahs-voice.md)
 
 ---
 

--- a/docs/adr/0023-tips-speak-in-a-plain-register-not-ah-mahs-voice.md
+++ b/docs/adr/0023-tips-speak-in-a-plain-register-not-ah-mahs-voice.md
@@ -1,0 +1,23 @@
+# ADR-0023 — Market Tips and Storage Tips speak in a plain, factual register, not Ah Mah's voice
+
+**Status:** Accepted
+
+## Context
+
+[ADR-0013](0013-market-tips-are-llm-generated-and-shared.md) and [ADR-0017](0017-storage-tips-clear-adr-0008.md) both frame Market Tips and Storage Tips as *Ah Mah's* advice, and both cite her warmth as part of the feature's justification ("the 'Ah Mah knows best' warmth the shopping list already earns"). The generation prompts for both routes opened with `"You are Ah Mah, a warm Singaporean grandmother…"` and pulled in the shared `comprehensibleVoice` fragment (Singlish particles, glossing).
+
+Both tip routes were moved from `gpt-5-mini` to `gpt-5-nano` for latency — tips render on a surface the user is actively waiting on (Shopping List, Pantry), and picking/storing advice is simple enough for a smaller model to handle well. Separately, a plain, factual voice was judged to read better for this surface than an in-character line: these are scannable reference blurbs consulted mid-shop or mid-cook, not conversation.
+
+A future reader who knows Chat speaks as Ah Mah will reasonably wonder why Tips don't — this ADR records that the split is deliberate, not an oversight from the model swap.
+
+## Decision
+
+Market Tips and Storage Tips drop the Ah Mah persona and the `comprehensibleVoice` fragment. Prompts now ask for a short, factual instruction directly (e.g. "Give ONE short, factual tip on how to PICK a good one of each item at the shop"). Chat, recipe generation, and recipe tweak keep Ah Mah's full voice — this is scoped to the two Tip routes only.
+
+The mechanical rules (≤12 words, plain imperative, `""` for non-varying items, the kitchen-domain relevance gate) are unchanged — only the persona/voice framing is removed.
+
+## Consequences
+
+- `CONTEXT.md`'s Market Tip and Storage Tip entries drop "Ah Mah's" framing.
+- Both cached corpora (`MarketTip`, `StorageTip`) held tips generated in the old warm/Singlish voice with no version column to distinguish old from new rows. Both tables were cleared once on deploy so every tip regenerates in the new voice — safe because tips are universal facts with no user-specific data, not a migration.
+- If a future reader wants tips voiced as Ah Mah again, reverting is a prompt change plus another one-time cache clear.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -120,8 +120,9 @@ Multi-conversation, organised pantry, auth, and a leaner recipe surface. Highlig
 ### Model split: gpt-5-mini vs gpt-5-nano — Shipped Jul 2026
 
 - **Every LLM call now goes through `src/lib/ai/models.ts`** (`MODEL_HEAVY` / `MODEL_LIGHT`) instead of an inline `"gpt-5-mini"` literal duplicated per call site.
-- **`MODEL_LIGHT` (`gpt-5-nano`)** — deterministic extraction/classification/titling, moved off mini for cost: inventory paste parse, shopping-list paste parse, aisle classification, chat's `captureMentionedInventory`, conversation auto-titling. These also dropped explicit `temperature` (gpt-5 models only accept the default).
-- **`MODEL_HEAVY` (`gpt-5-mini`)** — unchanged: the chat agent, recipe tweak, storage/market tips, recipe metadata processing, and recipe-text paste extraction stay on mini (voice quality, unit-conversion math, or tool-calling on these paths).
+- **`MODEL_LIGHT` (`gpt-5-nano`)** — deterministic extraction/classification/titling, moved off mini for latency/cost: inventory paste parse, shopping-list paste parse, aisle classification, chat's `captureMentionedInventory`, conversation auto-titling, storage/market tips, recipe metadata processing. These also dropped explicit `temperature` (gpt-5 models only accept the default).
+- **`MODEL_HEAVY` (`gpt-5-mini`)** — the chat agent, recipe tweak, and recipe-text paste extraction stay on mini (tool-calling, or unit-conversion math on the recipe-text path).
+- **Tip voice changed too:** storage/market tips dropped the "Ah Mah" persona and Singlish voice fragment in favor of a plain, factual register — a deliberate product decision alongside the model move, not a side effect of it. See [ADR-0023](./adr/0023-tips-speak-in-a-plain-register-not-ah-mahs-voice.md). Both cached tip tables (`MarketTip`, `StorageTip`) were cleared once on deploy so every tip regenerates in the new voice.
 
 ### Shopping List spine — the Pantry "Need" tab — Shipped Jun 2026 (#314)
 

--- a/src/app/api/market-tip/route.test.ts
+++ b/src/app/api/market-tip/route.test.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from "next/server";
 import { POST } from "./route";
 import { prisma } from "@/lib/db";
-import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { getSessionUserId } from "@/lib/session";
 import { generateObject } from "ai";
 
@@ -132,7 +131,7 @@ describe("POST /api/market-tip", () => {
     );
   });
 
-  it("carries the shared comprehensible-voice fragment in the model prompt", async () => {
+  it("does not use Ah Mah's persona voice in the model prompt", async () => {
     mockedFindMany.mockResolvedValue([] as never);
     mockedGenerate.mockResolvedValue({
       object: { tips: [{ key: "avocado", tip: "dark, gives slightly" }] },
@@ -141,6 +140,7 @@ describe("POST /api/market-tip", () => {
     await POST(reqWith({ items: [{ name: "Avocado", category: "Misc" }] }));
 
     const prompt = mockedGenerate.mock.calls[0][0].prompt as string;
-    expect(prompt).toContain(PROMPT_FRAGMENTS.comprehensibleVoice);
+    expect(prompt).not.toContain("Ah Mah");
+    expect(prompt).toContain("Give ONE short, factual tip");
   });
 });

--- a/src/app/api/market-tip/route.ts
+++ b/src/app/api/market-tip/route.ts
@@ -2,9 +2,8 @@ import { prisma } from "@/lib/db";
 import { canonicalTipKey } from "@/lib/marketTips/canonicalKey";
 import { isPickableCategory } from "@/lib/marketTips/pickable";
 import { KITCHEN_DOMAIN_RULE } from "@/lib/marketTips/relevance";
-import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { withAuth } from "@/lib/withAuth";
-import { MODEL_HEAVY } from "@/lib/ai/models";
+import { MODEL_LIGHT } from "@/lib/ai/models";
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { NextRequest, NextResponse } from "next/server";
@@ -76,19 +75,17 @@ export const POST = withAuth(async (req: NextRequest, { userId: _userId }) => {
     if (toGenerate.length > 0) {
       const list = toGenerate.map((k) => `- ${k}`).join("\n");
       const { object } = await generateObject({
-        model: openai(MODEL_HEAVY),
+        model: openai(MODEL_LIGHT),
         schema: TipGenSchema,
-        temperature: 0.4,
-        prompt: `You are Ah Mah, a warm Singaporean grandmother at the wet market. For each item, give ONE short tip on how to PICK a good fresh one at the shop — what to look for, feel for, or smell.
-
-${PROMPT_FRAGMENTS.comprehensibleVoice}
+        // gpt-5 models only support the default temperature; setting it errors.
+        prompt: `Give ONE short, factual tip on how to PICK a good one of each item at the shop — what to look for, feel for, or smell.
 
 RULES:
 - Return exactly one entry per item, using the EXACT given item text as "key".
 - "tip": max 12 words, plain imperative. NO "to pick a good X" preamble. e.g. "firm, deep red, no soft spots".
 - If quality does NOT meaningfully vary at the shop (dry goods, canned, bottled, salt, sugar, flour), return tip as an empty string "".
 - ${KITCHEN_DOMAIN_RULE}
-- Warm and practical, but keep it SHORT.
+- Plain and factual, no persona. Keep it SHORT.
 
 ITEMS:
 ${list}`,

--- a/src/app/api/storage-tip/route.test.ts
+++ b/src/app/api/storage-tip/route.test.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from "next/server";
 import { POST } from "./route";
 import { prisma } from "@/lib/db";
-import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { getSessionUserId } from "@/lib/session";
 import { generateObject } from "ai";
 
@@ -160,7 +159,7 @@ describe("POST /api/storage-tip", () => {
     expect(res.status).toBe(400);
   });
 
-  it("carries the shared comprehensible-voice fragment in the model prompt", async () => {
+  it("does not use Ah Mah's persona voice in the model prompt", async () => {
     mockedFindMany.mockResolvedValue([] as never);
     mockedGenerate.mockResolvedValue({
       object: { tips: [{ key: "potato", tip: "cool, dark place" }] },
@@ -169,6 +168,7 @@ describe("POST /api/storage-tip", () => {
     await POST(reqWith({ items: [{ name: "Potato", type: "ingredient" }] }));
 
     const prompt = mockedGenerate.mock.calls[0][0].prompt as string;
-    expect(prompt).toContain(PROMPT_FRAGMENTS.comprehensibleVoice);
+    expect(prompt).not.toContain("Ah Mah");
+    expect(prompt).toContain("Give ONE short, factual tip");
   });
 });

--- a/src/app/api/storage-tip/route.ts
+++ b/src/app/api/storage-tip/route.ts
@@ -1,9 +1,8 @@
 import { prisma } from "@/lib/db";
 import { canonicalTipKey } from "@/lib/marketTips/canonicalKey";
 import { KITCHEN_DOMAIN_RULE } from "@/lib/marketTips/relevance";
-import { PROMPT_FRAGMENTS } from "@/lib/prompts/fragments";
 import { withAuth } from "@/lib/withAuth";
-import { MODEL_HEAVY } from "@/lib/ai/models";
+import { MODEL_LIGHT } from "@/lib/ai/models";
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { NextRequest, NextResponse } from "next/server";
@@ -77,12 +76,10 @@ export const POST = withAuth(async (req: NextRequest, { userId: _userId }) => {
         .map((k) => `${k} = ${wanted.get(k)!.type}`)
         .join("\n");
       const { object } = await generateObject({
-        model: openai(MODEL_HEAVY),
+        model: openai(MODEL_LIGHT),
         schema: TipGenSchema,
-        temperature: 0.4,
-        prompt: `You are Ah Mah, a warm Singaporean grandmother. For each kitchen item, give ONE short tip on how to KEEP it well at home — for food, how to store it so it lasts (where, how, what to avoid); for equipment, how to care for it so it lasts.
-
-${PROMPT_FRAGMENTS.comprehensibleVoice}
+        // gpt-5 models only support the default temperature; setting it errors.
+        prompt: `Give ONE short, factual tip on how to KEEP each kitchen item well at home — for food, how to store it so it lasts (where, how, what to avoid); for equipment, how to care for it so it lasts.
 
 Each item below is written as "name = kind".
 
@@ -92,7 +89,7 @@ RULES:
 - "tip": max 12 words, plain imperative. NO "to store X" preamble. e.g. "cool, dark place — never the fridge".
 - ${KITCHEN_DOMAIN_RULE}
 - If there is no meaningful way to keep it better (it just sits in the cupboard), return tip as an empty string "".
-- Warm and practical, but keep it SHORT.
+- Plain and factual, no persona. Keep it SHORT.
 
 ITEMS:
 ${list}`,

--- a/src/lib/recipes/recipeProcessor.ts
+++ b/src/lib/recipes/recipeProcessor.ts
@@ -1,4 +1,4 @@
-import { MODEL_HEAVY } from "@/lib/ai/models";
+import { MODEL_LIGHT } from "@/lib/ai/models";
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { z } from "zod";
@@ -107,10 +107,10 @@ RECIPE TEXT:
 ${recipeInstructions}`;
 
   const result = await generateObject({
-    model: openai(MODEL_HEAVY),
+    model: openai(MODEL_LIGHT),
     schema: RecipeMetadataSchema,
+    // gpt-5 models only support the default temperature; setting it errors.
     prompt,
-    temperature: 0.2,
   });
 
   return {


### PR DESCRIPTION
## Summary
- Moves `storage-tip`, `market-tip`, and `recipeProcessor` (recipe metadata) from `MODEL_HEAVY` to `MODEL_LIGHT` (gpt-5-nano) — driven by latency, since tips render on a surface the user is actively waiting on, and the task is simple enough for nano.
- `parseRecipeText` stays on `MODEL_HEAVY` — its oz→g / cup-density / °F→°C unit-conversion math is too failure-prone for nano.
- Market Tips and Storage Tips drop the "Ah Mah, warm Singaporean grandmother" persona and the Singlish `comprehensibleVoice` fragment in favor of a plain, factual register — a deliberate product decision (see [ADR-0023](docs/adr/0023-tips-speak-in-a-plain-register-not-ah-mahs-voice.md)), not a side effect of the model swap. Chat, recipe generation, and recipe tweak are unaffected.
- Updates `CONTEXT.md` (Market Tip / Storage Tip glossary entries), `docs/progress.md`, and `CLAUDE.md` to match.

## Manual step after merge/deploy
Both `MarketTip`/`StorageTip` caches hold tips generated in the old voice with no version column to distinguish them. Clear both once so everything regenerates in the new voice:

```sql
DELETE FROM "market_tips";
DELETE FROM "storage_tips";
```

## Test plan
- `pnpm jest src/app/api/storage-tip src/app/api/market-tip src/lib/recipes` — 138/138 passing, including rewritten prompt-voice assertions.
- `pnpm tsc --noEmit` — 41 errors, matches the pre-existing baseline on main (no new errors).
- Manual smoke recommended post-merge: add pantry/shopping items and confirm tips render plain/factual with no Singlish; paste a recipe and confirm unit conversions are still correct (parseRecipeText unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)