### PR TITLE
chore: layout cleanup + KIV docs for #378/#395

### DIFF
--- a/.out-of-scope/ah-mah-step-note.md
+++ b/.out-of-scope/ah-mah-step-note.md
@@ -1,6 +1,6 @@
 # Ah Mah's Step Note (CookingMode)
 
-This project does not have a separate, model-authored per-step encouragement/reassurance line in CookingMode, distinct from the existing `step.tip` field.
+This project does not have a separate, model-authored encouragement/reassurance line in CookingMode, distinct from the existing `step.tip` field.
 
 ## Why this is out of scope
 
@@ -24,4 +24,4 @@ Reopen this if the owner decides it's worth the design work again. Whoever picks
 
 ## Prior requests
 
-- #378 — Ah Mah's step note (model-authored, per dish) in CookingMode
+- #378 — Ah Mah's step note (model-authored, per dish) in CookingMode. Note: brainstorming shifted this toward a per-step note (see "Why this is out of scope" above); the scope should be settled — dish or step — before this is picked up again.

--- a/.out-of-scope/ah-mah-step-note.md
+++ b/.out-of-scope/ah-mah-step-note.md
@@ -1,0 +1,27 @@
+# Ah Mah's Step Note (CookingMode)
+
+This project does not have a separate, model-authored per-step encouragement/reassurance line in CookingMode, distinct from the existing `step.tip` field.
+
+## Why this is out of scope
+
+Deprioritized during brainstorming for #378, not rejected on the merits: "lets kiv issue 378. i feel its not so important." (2026-07-10)
+
+Before it was shelved, brainstorming surfaced a real design gap worth recording: `step.tip` (`src/lib/recipes/schemas.ts`) already covers sensory doneness cues and failure-mode cautions, per the current `CHAT_SYSTEM_PROMPT` recipe-block instructions (`src/app/api/chat/constants.ts`). The step-note example in the issue — "listen for the sizzle — pull it the moment it's golden" — reads almost identically to what `tip` is already asked to produce. Shipping both fields without resolving that overlap risks the model writing the same content twice on one step.
+
+```ts
+// src/lib/recipes/schemas.ts
+export const RecipeStepSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+  tip: z.string().optional(),   // already covers sensory/doneness/failure-mode content
+  uses: z.array(RecipeStepUseSchema).optional(),
+});
+```
+
+## When to revisit
+
+Reopen this if the owner decides it's worth the design work again. Whoever picks it up should resolve the overlap first — e.g. by deciding the step note is *pure* encouragement with zero technique content ("you've got this"), or that it replaces `tip` entirely on steps judged "tricky" — before writing any prompt instructions or a visual treatment.
+
+## Prior requests
+
+- #378 — Ah Mah's step note (model-authored, per dish) in CookingMode

--- a/.out-of-scope/payload-size-caps.md
+++ b/.out-of-scope/payload-size-caps.md
@@ -1,0 +1,31 @@
+# Payload Size Caps
+
+This project does not enforce upper-bound length/size validation on free-text inputs (message content, recipe fields, tip batches) before they reach the database or an LLM prompt.
+
+## Why this is out of scope
+
+A full implementation shipped in PR #411 — bounded `content` on the message-create route, per-string/per-array caps on `RecipeBlockSchema`, a per-part size bound on chat message parts, and reduced market-tip/storage-tip batch sizes, all with test coverage and passing CI. The owner closed the PR without merging: "i do not like this payload size cap." The specific objection wasn't elaborated beyond that — not a quality complaint about the implementation, a disagreement with the approach itself.
+
+```ts
+// src/lib/recipes/schemas.ts — RecipeBlockSchema strings/arrays are
+// currently unbounded; PR #411's caps here were the part rejected.
+export const RecipeBlockSchema = z.object({
+  title: z.string(),
+  ingredients: z.array(RecipeIngredientModelSchema),
+  steps: z.array(RecipeStepSchema),
+  // ...
+});
+```
+
+## When to revisit
+
+Reopen this if:
+
+- The owner articulates a specific alternative approach to bounding input size (e.g. rate-limiting instead of per-field caps, or bounding at a different layer)
+- A real incident occurs where an oversized payload causes a DB or LLM cost problem
+
+Until then, don't re-attempt the per-field Zod `.max()` approach from PR #411 without first asking what specifically didn't work about it.
+
+## Prior requests
+
+- #395 — security: cap payload sizes on inputs that feed the DB and LLM prompts (PR #411, closed unmerged)

--- a/.out-of-scope/payload-size-caps.md
+++ b/.out-of-scope/payload-size-caps.md
@@ -4,7 +4,7 @@ This project does not enforce upper-bound length/size validation on free-text in
 
 ## Why this is out of scope
 
-A full implementation shipped in PR #411 — bounded `content` on the message-create route, per-string/per-array caps on `RecipeBlockSchema`, a per-part size bound on chat message parts, and reduced market-tip/storage-tip batch sizes, all with test coverage and passing CI. The owner closed the PR without merging: "i do not like this payload size cap." The specific objection wasn't elaborated beyond that — not a quality complaint about the implementation, a disagreement with the approach itself.
+A full implementation was proposed in PR #411 — bounded `content` on the message-create route, per-string/per-array caps on `RecipeBlockSchema`, a per-part size bound on chat message parts, and reduced market-tip/storage-tip batch sizes, all with test coverage and passing CI. The owner closed the PR without merging: "i do not like this payload size cap." The specific objection wasn't elaborated beyond that — not a quality complaint about the implementation, a disagreement with the approach itself.
 
 ```ts
 // src/lib/recipes/schemas.ts — RecipeBlockSchema strings/arrays are

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -10,7 +10,7 @@ export default function AppLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="mx-0 mt-0 sm:mx-2 sm:mt-2 md:mx-4 md:mt-4 lg:mx-0 lg:mt-0 flex h-dvh overflow-hidden">
+    <div className="mx-0 mt-0 flex h-dvh overflow-hidden">
       <Suspense fallback={null}>
         <AppSidebar />
       </Suspense>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -70,7 +70,7 @@ function HomeContent() {
           <TabsContent
             value="pantry"
             forceMount
-            className="flex-1 min-h-0 mt-0 overflow-hidden border border-border rounded-lg bg-muted paper data-[state=inactive]:hidden"
+            className="flex-1 min-h-0 mt-0 overflow-hidden border border-border bg-muted paper data-[state=inactive]:hidden"
           >
             <InventoryWrapper />
           </TabsContent>
@@ -79,7 +79,7 @@ function HomeContent() {
           <TabsContent
             value="shopping"
             forceMount
-            className="flex-1 min-h-0 mt-0 overflow-hidden border border-border rounded-lg bg-muted paper data-[state=inactive]:hidden"
+            className="flex-1 min-h-0 mt-0 overflow-hidden border border-border bg-muted paper data-[state=inactive]:hidden"
           >
             <ShoppingList />
           </TabsContent>
@@ -88,7 +88,7 @@ function HomeContent() {
           <TabsContent
             value="cookbook"
             forceMount
-            className="flex-1 min-h-0 mt-0 overflow-hidden border border-border rounded-lg data-[state=inactive]:hidden"
+            className="flex-1 min-h-0 mt-0 overflow-hidden border border-border data-[state=inactive]:hidden"
           >
             <RecipeList onChatClick={() => setActiveTab("chat")} />
           </TabsContent>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -44,7 +44,11 @@ function HomeContent() {
   return (
     <div className="bg-background paper h-full lg:h-full flex flex-col">
       <main className="w-full xl:container 2xl:max-w-screen-xl mx-auto h-[calc(100dvh-3.25rem)] sm:h-[calc(100dvh-3.75rem)] md:h-[calc(100dvh-4.5rem)] lg:flex-1 lg:min-h-0">
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
+        <Tabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          className="h-full flex flex-col"
+        >
           {/* Nav is driven by the AppSidebar (desktop) and MobileTopBar drawer (mobile);
               the Tabs container only switches the content panels below. */}
 
@@ -54,7 +58,7 @@ function HomeContent() {
             forceMount
             className="flex-1 min-h-0 mt-0 data-[state=inactive]:hidden"
           >
-            <div className="flex h-full overflow-hidden relative lg:border lg:border-border lg:rounded-lg">
+            <div className="flex h-full overflow-hidden relative lg:border lg:border-border">
               {/* Chat panel */}
               <section className="flex-1 min-w-0 relative flex flex-col bg-chat">
                 <ChatWrapper />


### PR DESCRIPTION
## Summary
- Simplify the app shell layout: drop desktop margin/border framing from the main container and chat panel
- Add out-of-scope docs recording why #378 (Ah Mah's step note) and #395 (payload size caps) were shelved, and what to check before revisiting

## Test plan
- Visually confirm desktop layout still looks correct (no double borders/margins)
- No functional changes to tips/recipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application layout to provide more consistent spacing across screen sizes.
  * Refined the desktop chat panel’s border styling by removing its rounded corners.
  * Preserved existing tab navigation and overall page structure.

* **Documentation**
  * Added internal documentation clarifying deferred decisions around cooking guidance and input size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->