### PR TITLE
feat(recipe): ingredient-quantity hints on mise en place

### DIFF
--- a/src/features/Chat/components/recipe/RecipeLetter.tsx
+++ b/src/features/Chat/components/recipe/RecipeLetter.tsx
@@ -8,6 +8,7 @@ type GetInventoryResponse = {
   ingredientInventory: InventoryItem[];
 };
 import { Button } from "@/components/ui/button";
+import { ingredientsToUses } from "@/lib/recipes/ingredientUses";
 import { ingredientMatches } from "@/lib/recipes/matchIngredient";
 import { RecipeBlock, RecipeIngredientModel } from "@/lib/recipes/schemas";
 import { cn } from "@/lib/utils";
@@ -212,6 +213,7 @@ export function RecipeLetter({
         cooked={cooked}
         onCookedChange={onCookedChange}
         servingsRatio={ratio}
+        prepUses={ingredientsToUses(ingredients)}
       />
     );
   }
@@ -350,7 +352,7 @@ export function RecipeLetter({
       {prep && prep.length > 0 && (
         <div className="mb-5">
           <Eyebrow className="text-muted-foreground block mb-2">Before you start</Eyebrow>
-          <DottedList items={prep} />
+          <DottedList items={prep} uses={ingredientsToUses(ingredients)} ratio={ratio} />
         </div>
       )}
 

--- a/src/features/Recipe/CookingMode.tsx
+++ b/src/features/Recipe/CookingMode.tsx
@@ -28,9 +28,13 @@ interface CookingModeProps {
   // way the master ingredient list scales. Defaults to 1 (no consumer that
   // omits it has a servings stepper to desync from).
   servingsRatio?: number;
+  // Master ingredient list mapped to Step Uses (see ingredientsToUses), applied
+  // to every prep card so ingredient names mentioned in prep prose get the same
+  // hover-for-quantity hint as steps.
+  prepUses?: RecipeStepUse[];
 }
 
-function prepToStep(item: string): Step {
+function prepToStep(item: string, uses?: RecipeStepUse[]): Step {
   const normalized = item.trim();
   const commaIdx = normalized.indexOf(",");
   const title =
@@ -38,12 +42,12 @@ function prepToStep(item: string): Step {
       ? normalized.slice(0, commaIdx).trim()
       : normalized.split(/\s+/).slice(0, 4).join(" ");
   const body = normalized;
-  return { title, body };
+  return { title, body, uses };
 }
 
-export function CookingMode({ title, steps, prep, onExit, cooked, onCookedChange, servingsRatio = 1 }: CookingModeProps) {
+export function CookingMode({ title, steps, prep, onExit, cooked, onCookedChange, servingsRatio = 1, prepUses }: CookingModeProps) {
   const allSteps: Step[] = [
-    ...(prep ?? []).map(prepToStep),
+    ...(prep ?? []).map((item) => prepToStep(item, prepUses)),
     ...steps,
   ];
   const [current, setCurrent] = useState(0);

--- a/src/features/RecipeDisplay/RecipeDisplay.tsx
+++ b/src/features/RecipeDisplay/RecipeDisplay.tsx
@@ -12,6 +12,7 @@ import {
   SectionHeading,
   StepItem,
 } from "@/features/shared/components/recipe";
+import { ingredientsToUses } from "@/lib/recipes/ingredientUses";
 import {
   type ChangeEntry,
   type RecipeIngredient,
@@ -342,7 +343,7 @@ function RecipeBody({
         {prep.length > 0 && (
           <section className="mb-9">
             <SectionHeading className="mb-4">Before you start</SectionHeading>
-            <DottedList items={prep} />
+            <DottedList items={prep} uses={ingredientsToUses(ingredients)} ratio={scale} />
           </section>
         )}
 
@@ -627,6 +628,7 @@ export default function RecipeDisplay({
         cooked={!!workingDraft.cooked}
         onCookedChange={handleCookedChange}
         servingsRatio={servings / (recipe.baseServings || 2)}
+        prepUses={ingredientsToUses((workingDraft.ingredients ?? []) as RecipeIngredient[])}
       />
     );
   }

--- a/src/features/shared/components/recipe/DottedList.test.tsx
+++ b/src/features/shared/components/recipe/DottedList.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { DottedList } from "./DottedList";
+
+describe("DottedList", () => {
+  it("renders items as plain text when uses is omitted (notes usage)", () => {
+    render(<DottedList items={["Best eaten fresh, but keeps 2 days chilled."]} />);
+    expect(
+      screen.getByText("Best eaten fresh, but keeps 2 days chilled."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  describe("prep uses (mise en place hints)", () => {
+    it("turns a matched ingredient mention into a hoverable hint showing the scaled total", async () => {
+      render(
+        <DottedList
+          items={["Rinse glutinous rice until water runs nearly clear."]}
+          ratio={2}
+          uses={[{ name: "glutinous rice", amount: "2", unit: "cups" }]}
+        />,
+      );
+      const hint = screen.getByText("glutinous rice");
+      expect(hint.tagName).toBe("BUTTON");
+      expect(screen.queryByText("4 cups")).not.toBeInTheDocument();
+
+      await userEvent.hover(hint);
+      expect(await screen.findByText("4 cups")).toBeInTheDocument();
+    });
+
+    it("renders an ingredient with no amount as plain text (no empty popover)", () => {
+      render(
+        <DottedList
+          items={["Season with salt to taste."]}
+          uses={[{ name: "salt" }]}
+        />,
+      );
+      expect(screen.getByText("Season with salt to taste.")).toBeInTheDocument();
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/shared/components/recipe/DottedList.tsx
+++ b/src/features/shared/components/recipe/DottedList.tsx
@@ -1,15 +1,26 @@
+import type { RecipeStepUse } from "@/lib/recipes/schemas";
 import { cn } from "@/lib/utils";
+import { StepBody } from "./StepBody";
 
 /**
  * Dotted bullet list — prep ("Before you start") and whole-dish notes on both
  * recipe surfaces. Canonical style is the aligned reference treatment: a
  * right-aligned `·` marker in a fixed gutter, serif body, dashed dividers.
+ *
+ * `uses`/`ratio` are optional and only meaningful for prep: when passed, each
+ * item's prose is run through StepBody so ingredient names it mentions get
+ * the same hover-for-quantity hint as recipe steps (see StepBody.tsx). Notes
+ * callers omit them and items render as plain text, unchanged.
  */
 export function DottedList({
   items,
+  uses,
+  ratio,
   className,
 }: {
   items: string[];
+  uses?: RecipeStepUse[];
+  ratio?: number;
   className?: string;
 }) {
   return (
@@ -23,7 +34,7 @@ export function DottedList({
             ·
           </span>
           <span className="flex-1 font-display text-emphasis text-foreground leading-[1.45]">
-            {item}
+            {uses ? <StepBody body={item} uses={uses} ratio={ratio} /> : item}
           </span>
         </li>
       ))}

--- a/src/lib/recipes/ingredientUses.test.ts
+++ b/src/lib/recipes/ingredientUses.test.ts
@@ -1,0 +1,29 @@
+import { ingredientsToUses } from "./ingredientUses";
+
+describe("ingredientsToUses", () => {
+  it("stringifies a numeric amount (RecipeIngredient shape)", () => {
+    expect(ingredientsToUses([{ name: "glutinous rice", amount: 2, unit: "cups" }])).toEqual([
+      { name: "glutinous rice", amount: "2", unit: "cups" },
+    ]);
+  });
+
+  it("passes through a string amount as-is (RecipeIngredientModel shape)", () => {
+    expect(ingredientsToUses([{ name: "ginger", amount: "1 1/2", unit: "tbsp" }])).toEqual([
+      { name: "ginger", amount: "1 1/2", unit: "tbsp" },
+    ]);
+  });
+
+  it("maps a missing amount to undefined, not a stringified 'undefined'", () => {
+    expect(ingredientsToUses([{ name: "salt" }])).toEqual([
+      { name: "salt", amount: undefined, unit: undefined },
+    ]);
+  });
+
+  it("preserves order and maps every ingredient", () => {
+    const uses = ingredientsToUses([
+      { name: "garlic", amount: 3 },
+      { name: "spring onion" },
+    ]);
+    expect(uses.map((u) => u.name)).toEqual(["garlic", "spring onion"]);
+  });
+});

--- a/src/lib/recipes/ingredientUses.ts
+++ b/src/lib/recipes/ingredientUses.ts
@@ -1,0 +1,20 @@
+import type { RecipeStepUse } from "@/lib/recipes/schemas";
+
+// Prep ("Before you start") works on the whole ingredient — you rinse ALL the
+// rice, not a partial amount — so its hint is just the ingredient's master
+// total, scaled by servings at render like the ingredient list itself. This
+// maps the master list into the `uses` shape StepBody already knows how to
+// render (see StepBody.tsx / ADR-0021), so no new UI is needed.
+//
+// Ingredients with no amount (e.g. "salt to taste") map to a use with no
+// amount/text; StepBody's formatUseLabel then returns "", so the name renders
+// as plain text — no empty popover.
+export function ingredientsToUses(
+  ingredients: Array<{ name: string; amount?: string | number; unit?: string }>,
+): RecipeStepUse[] {
+  return ingredients.map((ing) => ({
+    name: ing.name,
+    amount: ing.amount != null ? String(ing.amount) : undefined,
+    unit: ing.unit,
+  }));
+}


### PR DESCRIPTION
## Summary
- Recipe steps already have the "Step Uses" hover hint (ADR-0021) — an ingredient named in a step's prose gets a dotted underline that reveals its quantity on hover/tap. The "Before you start" (mise en place) section never got this treatment, even though prep lines (e.g. "mince garlic", "slice spring onion") name ingredients without stating amounts.
- Since prep always consumes the ingredient's *whole* quantity (never a partial like a step can), the hint data is derived from the recipe's existing master ingredient list via a new `ingredientsToUses` helper — no schema or AI prompt changes needed, so it works on every existing recipe immediately.
- `DottedList` gained optional `uses`/`ratio` props that route each item through the existing `StepBody` component; notes callers pass neither, so their rendering is unchanged.
- Wired into all three prep surfaces: chat letter (`RecipeLetter.tsx`), saved cookbook view (`RecipeDisplay.tsx`), and cooking mode (`CookingMode.tsx`).

## Test plan
- [x] `pnpm test` — 726/726 passing, including new `ingredientUses.test.ts` and `DottedList.test.tsx`
- [x] `pnpm exec eslint` on changed files — clean
- [x] Manual verification via Playwright against a live-generated recipe (glutinous rice rolls): hovering "water" in "Before you start" showed "700 ml", hovering "garlic" showed "3 clove" — both matching the ingredient list; existing step hints below still work unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ingredient hints to recipe preparation lists and cooking steps.
  * Ingredient names can now reveal scaled amounts and units when applicable.
  * Preparation details remain plain text when amount information is unavailable.

* **Tests**
  * Added coverage for ingredient mapping, ordering, amounts, units, and interactive preparation hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->