### PR TITLE
chore(deps): pin shiki 3.23.0 to satisfy Next external resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",
     "resend": "^6.16.0",
+    "shiki": "3.23.0",
     "sonner": "^2.0.7",
     "streamdown": "^1.2.0",
     "swr": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       resend:
         specifier: ^6.16.0
         version: 6.16.0
+      shiki:
+        specifier: 3.23.0
+        version: 3.23.0
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
## Summary
- `streamdown` pulls `shiki` in transitively, but Next lists `shiki` in `serverExternalPackages` and resolves it from the **project root** `node_modules` at runtime.
- Under pnpm's strict isolation, `shiki` was never hoisted to the root, so `pnpm run dev` logged repeated `Package shiki can't be external` warnings.
- Pinned `shiki` as a direct dependency at the exact version streamdown already uses (`3.23.0`) so it hoists to the project root with no version skew.

## Test plan
- `pnpm install` (already reflected in lockfile)
- `pnpm run dev` → confirm the `Package shiki can't be external` warnings no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)