### PR TITLE
test(coverage): add tests for useCyclingIndex, ScaledNum, AddRecipeModal

### DIFF
--- a/src/features/Recipe/ScaledNum.test.tsx
+++ b/src/features/Recipe/ScaledNum.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { ScaledNum } from "./ScaledNum";
+
+describe("ScaledNum", () => {
+  it("renders its children", () => {
+    render(<ScaledNum>250g</ScaledNum>);
+    expect(screen.getByText("250g")).toBeInTheDocument();
+  });
+
+  it("carries the pulse class", () => {
+    render(<ScaledNum>1 cup</ScaledNum>);
+    expect(screen.getByText("1 cup")).toHaveClass("scaled-num-pulse");
+  });
+
+  it("keeps the same DOM node when the value is unchanged", () => {
+    const { rerender } = render(<ScaledNum>2 tbsp</ScaledNum>);
+    const first = screen.getByText("2 tbsp");
+
+    rerender(<ScaledNum>2 tbsp</ScaledNum>);
+    expect(screen.getByText("2 tbsp")).toBe(first);
+  });
+
+  it("remounts (bumps the key) when the value changes to retrigger the pulse", () => {
+    const { rerender } = render(<ScaledNum>100g</ScaledNum>);
+    const first = screen.getByText("100g");
+
+    rerender(<ScaledNum>200g</ScaledNum>);
+    const next = screen.getByText("200g");
+
+    expect(next).not.toBe(first);
+    expect(next).toHaveClass("scaled-num-pulse");
+  });
+});

--- a/src/features/RecipeList/components/AddRecipeModal.test.tsx
+++ b/src/features/RecipeList/components/AddRecipeModal.test.tsx
@@ -1,0 +1,183 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { AddRecipeModal } from "./AddRecipeModal";
+import type { RecipeBlock } from "@/lib/recipes/schemas";
+
+jest.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => ({ userId: "user-1" }),
+}));
+
+const toastSuccess = jest.fn();
+const toastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+const mutate = jest.fn();
+jest.mock("swr", () => ({
+  __esModule: true,
+  mutate: (...args: unknown[]) => mutate(...args),
+}));
+
+// The preview step renders the heavy RecipeDisplay tree — stub it so the test
+// stays focused on the modal's own flow logic.
+jest.mock("@/features/RecipeDisplay/RecipeDisplay", () => ({
+  __esModule: true,
+  default: ({ recipe }: { recipe: { name: string } }) => (
+    <div data-testid="recipe-preview">preview:{recipe.name}</div>
+  ),
+}));
+
+const BLOCK: RecipeBlock = {
+  title: "Fried Rice",
+  baseServings: 2,
+  ingredients: [],
+  steps: [],
+};
+
+function mockFetch(impl: (url: string) => Promise<unknown>) {
+  global.fetch = jest.fn((url: string) => impl(url)) as never;
+}
+
+async function typeAndExtract(text = "some recipe text") {
+  const textarea = screen.getByPlaceholderText(/Paste recipe text here/);
+  fireEvent.change(textarea, { target: { value: text } });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /Extract recipe/ }));
+  });
+}
+
+describe("AddRecipeModal", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  describe("paste step", () => {
+    it("disables Extract until text is entered", () => {
+      render(<AddRecipeModal open onOpenChange={jest.fn()} />);
+      const extract = screen.getByRole("button", { name: /Extract recipe/ });
+      expect(extract).toBeDisabled();
+
+      fireEvent.change(screen.getByPlaceholderText(/Paste recipe text here/), {
+        target: { value: "chicken rice" },
+      });
+      expect(extract).toBeEnabled();
+    });
+
+    it("reflects the character count as the user types", () => {
+      render(<AddRecipeModal open onOpenChange={jest.fn()} />);
+      fireEvent.change(screen.getByPlaceholderText(/Paste recipe text here/), {
+        target: { value: "abcde" },
+      });
+      expect(screen.getByText(/5 \/ 8,000/)).toBeInTheDocument();
+    });
+  });
+
+  describe("extract → preview", () => {
+    it("waits for the min-timer before transitioning even after the fetch resolves", async () => {
+      mockFetch(async () => ({ ok: true, json: async () => BLOCK }));
+      render(<AddRecipeModal open onOpenChange={jest.fn()} />);
+
+      await typeAndExtract();
+
+      // Fetch has resolved, but the 1200ms minimum hasn't elapsed — still extracting.
+      expect(screen.getByText(/Ah Mah is reading your recipe/)).toBeInTheDocument();
+      expect(screen.queryByTestId("recipe-preview")).not.toBeInTheDocument();
+
+      await act(async () => {
+        jest.advanceTimersByTime(1200);
+      });
+
+      expect(await screen.findByTestId("recipe-preview")).toHaveTextContent(
+        "preview:Fried Rice",
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/recipe/extract",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ text: "some recipe text" }),
+        }),
+      );
+    });
+
+    it("returns to the paste step and shows the error banner on an API error", async () => {
+      mockFetch(async () => ({ ok: false, json: async () => ({ error: "nope" }) }));
+      render(<AddRecipeModal open onOpenChange={jest.fn()} />);
+
+      await typeAndExtract();
+
+      expect(
+        await screen.findByText(/couldn.t find a recipe in this/i),
+      ).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/Paste recipe text here/)).toBeInTheDocument();
+      expect(screen.queryByTestId("recipe-preview")).not.toBeInTheDocument();
+    });
+
+    it("returns to the paste step on a network error", async () => {
+      mockFetch(async () => {
+        throw new Error("network down");
+      });
+      render(<AddRecipeModal open onOpenChange={jest.fn()} />);
+
+      await typeAndExtract();
+
+      expect(
+        await screen.findByText(/couldn.t find a recipe in this/i),
+      ).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/Paste recipe text here/)).toBeInTheDocument();
+    });
+  });
+
+  describe("save flow", () => {
+    async function reachPreview() {
+      mockFetch(async () => ({ ok: true, json: async () => BLOCK }));
+      await typeAndExtract();
+      await act(async () => {
+        jest.advanceTimersByTime(1200);
+      });
+      await screen.findByTestId("recipe-preview");
+    }
+
+    it("saves, revalidates the cache, toasts, and closes on success", async () => {
+      const onOpenChange = jest.fn();
+      render(<AddRecipeModal open onOpenChange={onOpenChange} />);
+      await reachPreview();
+
+      mockFetch(async () => ({ ok: true, json: async () => ({}) }));
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Save to cookbook/ }));
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/recipe",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(mutate).toHaveBeenCalledWith("/api/recipe?userId=user-1");
+      expect(toastSuccess).toHaveBeenCalled();
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("toasts an error and stays open when the save fails", async () => {
+      const onOpenChange = jest.fn();
+      render(<AddRecipeModal open onOpenChange={onOpenChange} />);
+      await reachPreview();
+
+      mockFetch(async () => ({ ok: false, json: async () => ({}) }));
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Save to cookbook/ }));
+      });
+
+      expect(toastError).toHaveBeenCalled();
+      expect(mutate).not.toHaveBeenCalled();
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/src/features/shared/components/loaders/useCyclingIndex.test.ts
+++ b/src/features/shared/components/loaders/useCyclingIndex.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from "@testing-library/react";
+import { useCyclingIndex } from "./useCyclingIndex";
+
+describe("useCyclingIndex", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("starts at 0", () => {
+    const { result } = renderHook(() => useCyclingIndex(3));
+    expect(result.current).toBe(0);
+  });
+
+  it("stays at 0 when count <= 1 (guards against % 0)", () => {
+    const { result, rerender } = renderHook(({ c }) => useCyclingIndex(c), {
+      initialProps: { c: 1 },
+    });
+    act(() => jest.advanceTimersByTime(5000));
+    expect(result.current).toBe(0);
+
+    rerender({ c: 0 });
+    act(() => jest.advanceTimersByTime(5000));
+    expect(result.current).toBe(0);
+  });
+
+  it("advances one step per interval then holds on the last item (non-loop)", () => {
+    const { result } = renderHook(() => useCyclingIndex(3, { intervalMs: 1000 }));
+
+    act(() => jest.advanceTimersByTime(1000));
+    expect(result.current).toBe(1);
+
+    act(() => jest.advanceTimersByTime(1000));
+    expect(result.current).toBe(2);
+
+    // Holds on count-1 and never overshoots.
+    act(() => jest.advanceTimersByTime(3000));
+    expect(result.current).toBe(2);
+  });
+
+  it("wraps back to 0 and keeps cycling when loop is true", () => {
+    const { result } = renderHook(() =>
+      useCyclingIndex(3, { intervalMs: 1000, loop: true }),
+    );
+
+    act(() => jest.advanceTimersByTime(2000));
+    expect(result.current).toBe(2);
+
+    act(() => jest.advanceTimersByTime(1000));
+    expect(result.current).toBe(0);
+
+    act(() => jest.advanceTimersByTime(1000));
+    expect(result.current).toBe(1);
+  });
+
+  it("resets to 0 when count changes", () => {
+    const { result, rerender } = renderHook(({ c }) => useCyclingIndex(c, { intervalMs: 1000 }), {
+      initialProps: { c: 3 },
+    });
+
+    act(() => jest.advanceTimersByTime(2000));
+    expect(result.current).toBe(2);
+
+    rerender({ c: 5 });
+    expect(result.current).toBe(0);
+
+    act(() => jest.advanceTimersByTime(1000));
+    expect(result.current).toBe(1);
+  });
+
+  it("honors a custom intervalMs", () => {
+    const { result } = renderHook(() => useCyclingIndex(3, { intervalMs: 500 }));
+
+    act(() => jest.advanceTimersByTime(400));
+    expect(result.current).toBe(0);
+
+    act(() => jest.advanceTimersByTime(100));
+    expect(result.current).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds tests to three previously near-untested units with real branching logic, guarding behaviour that the existing suite missed:

- **`useCyclingIndex`** (7% → 100%) — initial `0`, `count<=1` guard (no `% 0`), non-loop advance-then-hold, loop wrap-around, reset on `count` change, custom interval.
- **`ScaledNum`** (10% → 100%) — renders children, keeps the same DOM node on unchanged value, remounts (key bump → re-pulse) on value change.
- **`AddRecipeModal`** (31% → 94%) — Extract disabled until text, char counter, the 1200ms min-timer gating (stays on the extracting screen even after fetch resolves), API-error and network-error both fall back to paste with the banner, and the save flow (SWR revalidate + success toast + close, error toast + stay-open on failure).

Tests only — no source changes.

## Test plan
- `pnpm test` — full suite green (767 passing).
- `pnpm test:coverage` — confirms the three files jump to 100% / 100% / 94%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)