### PR TITLE
chore(shared): relocate AboutPopOver into shared components

### DIFF
--- a/src/features/shared/components/AboutPopOver.tsx
+++ b/src/features/shared/components/AboutPopOver.tsx
@@ -7,6 +7,25 @@ import {
 } from "@/components/ui/popover";
 import { toast } from "sonner";
 
+const CONTACT_EMAIL = "lun.tay@gmail.com";
+const LINKEDIN_URL = "https://www.linkedin.com/in/tay-alan/";
+
+const ABOUT_COPY = {
+  heading: "About Ask Ah Mah",
+  intro: `A passion project inspired by my own cooking journey. I loved using
+    AI for cooking help, but it kept forgetting my ingredients! So I built Ask
+    Ah Mah with persistent memory and a caring personality.`,
+  mission: `But this app is about more than just fixing a technical problem,
+    it's about making cooking feel approachable, where you understand your
+    ingredients, learn the "why" behind each step, and cook with love!`,
+  feedbackHeading: "I'd love your feedback!",
+};
+
+const COPY_EMAIL_TOAST = {
+  success: "Email copied — drop Ah Mah a note!",
+  error: "Aiyah, couldn't copy. Try again?",
+};
+
 interface InfoPopoverProps {
   className?: string;
   svgSize?: string;
@@ -20,11 +39,11 @@ export default function AboutPopOver({
 }: InfoPopoverProps) {
   const copyEmail = async () => {
     try {
-      await navigator.clipboard.writeText("lun.tay@gmail.com");
-      toast.success("Email copied — drop Ah Mah a note!");
+      await navigator.clipboard.writeText(CONTACT_EMAIL);
+      toast.success(COPY_EMAIL_TOAST.success);
     } catch (err) {
       console.error("Failed to copy email", err);
-      toast.error("Aiyah, couldn't copy. Try again?");
+      toast.error(COPY_EMAIL_TOAST.error);
     }
   };
   return (
@@ -55,22 +74,12 @@ export default function AboutPopOver({
         className="w-150 max-w-[95vw]"
       >
         <div className="space-y-2">
-          <h4 className="font-medium leading-none">About Ask Ah Mah</h4>
+          <h4 className="font-medium leading-none">{ABOUT_COPY.heading}</h4>
           <div className="text-sm">
-            <p>
-              {`A passion project inspired by my own cooking journey. I loved
-              using AI for cooking help, but it kept forgetting my ingredients!
-              So I built Ask Ah Mah with persistent memory and a caring
-              personality.`}
-            </p>
-            <p className="mt-4">
-              {`But this app is about more than just fixing a technical problem,
-              it's about making cooking feel approachable, where you understand
-              your ingredients, learn the "why" behind each step, and cook with
-              love!`}
-            </p>
+            <p>{ABOUT_COPY.intro}</p>
+            <p className="mt-4">{ABOUT_COPY.mission}</p>
 
-            <h3 className="mt-4">{`I'd love your feedback!`}</h3>
+            <h3 className="mt-4">{ABOUT_COPY.feedbackHeading}</h3>
             <p>
               <Button
                 variant="ghost"
@@ -99,7 +108,7 @@ export default function AboutPopOver({
                 size="icon"
               >
                 <a
-                  href="https://www.linkedin.com/in/tay-alan/"
+                  href={LINKEDIN_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="LinkedIn profile"

--- a/src/features/shared/components/SidebarContent.tsx
+++ b/src/features/shared/components/SidebarContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import AboutPopOver from "@/components/AboutPopOver";
+import AboutPopOver from "./AboutPopOver";
 import { AuthButton } from "@/features/Auth";
 import { Conversations } from "@/features/Conversations";
 import { useConversationContext } from "@/contexts/ConversationContext";


### PR DESCRIPTION
## Summary
- Move `AboutPopOver` out of `src/components/` — which should hold only shadcn primitives (`ui/`) and vendored AI SDK components (`ai-elements/`) — into `src/features/shared/components/`, its natural home alongside its only consumer, `SidebarContent`.
- Flatten `AboutPopOver/index.tsx` → `AboutPopOver.tsx` to match its flat-file siblings (`AppSidebar`, `Stamp`, `TipsToggle`, …).
- Update the import in `SidebarContent.tsx` to the relative `./AboutPopOver`.
- Extract inline literals into module constants: `CONTACT_EMAIL`, `LINKEDIN_URL`, `ABOUT_COPY` (heading/intro/mission/feedback), and `COPY_EMAIL_TOAST` (success/error).

No behavior change — pure relocation + readability tidy. Not part of the claude.ai/design synced component set, so no re-sync needed.

## Test plan
- Open the sidebar footer, click the info (ⓘ) button → the About popover renders with the same copy.
- Click the email icon → toast "Email copied — drop Ah Mah a note!" and clipboard contains the address.
- Click the LinkedIn icon → opens the profile in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)