### PR TITLE
chore(styles): define type-scale tokens in rem for font-size scaling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -60,17 +60,17 @@
   /* Kopitiam type scale — only sizes that don't map cleanly to Tailwind defaults.
      Use Tailwind text-xs (12) / text-sm (14) / text-lg (18) / text-xl (20) for everything else.
      Ban arbitrary text-[Npx] outside this scale. */
-  --text-eyebrow: 10px;
+  --text-eyebrow: 0.625rem;
   --text-eyebrow--line-height: 1.4;
-  --text-micro: 11px;
+  --text-micro: 0.6875rem;
   --text-micro--line-height: 1.35;
-  --text-dense: 13px;
+  --text-dense: 0.8125rem;
   --text-dense--line-height: 1.4;
-  --text-emphasis: 15px;
+  --text-emphasis: 0.9375rem;
   --text-emphasis--line-height: 1.5;
-  --text-heading: 22px;
+  --text-heading: 1.375rem;
   --text-heading--line-height: 1.15;
-  --text-display: 40px;
+  --text-display: 2.5rem;
   --text-display--line-height: 1;
 
   /* Eyebrow letter-spacing — the wide tracking on uppercase eyebrow/label text.


### PR DESCRIPTION
## Summary
- Converts the six `--text-*` type-scale tokens in `globals.css` from px to their rem equivalents (÷16).
- px font sizes ignore a user's browser **default font-size preference** (an accessibility setting, distinct from zoom); rem respects it. Tailwind's built-in scale is already rem — these custom tokens were the one deviation.
- Because the earlier cleanup (#433) routed every `text-[…px]` hardcode through these tokens, this single edit updates all consumers.

## Test plan
- At the default 16px root, rendered sizes are identical (0.8125rem = 13px) → no visual change; line-heights (unitless) untouched.
- Payoff: with a larger browser default font size, text using these tokens now scales up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)