### PR TITLE
fix(cookbook): sort saved recipes newest-first

### DIFF
--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -10,6 +10,7 @@ import { Recipe, RecipeBlock } from "./schemas";
 export async function getRecipes(userId: string) {
   const recipes = await prisma.recipe.findMany({
     where: { userId },
+    orderBy: { createdAt: { sort: "desc", nulls: "last" } },
   });
 
   return recipes;


### PR DESCRIPTION
## Summary
- `getRecipes` returned recipes in raw insertion order, so a newly saved recipe always landed at the bottom of the cookbook.
- Added `orderBy: { createdAt: { sort: "desc", nulls: "last" } }` so newest recipes appear first.
- `nulls: "last"` guards against Postgres putting NULL timestamps first on a `DESC` sort — legacy rows without a `createdAt` stay at the bottom instead of floating to the top.
- Fixed server-side since `getRecipes` is the single source feeding the cookbook (via SWR), so ordering is corrected everywhere with no component changes.

## Test plan
- Save a new recipe to the cookbook and confirm it appears at the top of the grid.
- Existing recipe route + `getRecipes` tests pass (43 tests); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recipe lists now appear in a consistent order, with the newest recipes shown first and undated recipes placed last.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->