### PR TITLE
fix(cookbook): populate createdAt + prepend live saves (follow-up to #439)

### DIFF
--- a/prisma/migrations/20260714000000_recipe_created_at_default/migration.sql
+++ b/prisma/migrations/20260714000000_recipe_created_at_default/migration.sql
@@ -1,0 +1,6 @@
+-- Default createdAt so newly saved recipes carry a real timestamp
+-- (previously null, which left the cookbook unsortable by save time).
+ALTER TABLE "recipes" ALTER COLUMN "createdAt" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- Backfill legacy rows that were saved before the default existed.
+UPDATE "recipes" SET "createdAt" = CURRENT_TIMESTAMP WHERE "createdAt" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,7 +105,7 @@ model Recipe {
   notes            String[] @default([])
   description      String?
   totalTimeMinutes Int?
-  createdAt        DateTime?
+  createdAt        DateTime? @default(now())
   imageUrl         String?
   photographerName String?
   photographerUrl  String?

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -223,7 +223,7 @@ export const MessageList = ({
         ingredients: [],
       };
 
-      mutate((current = []) => [...current, optimisticRecipe], {
+      mutate((current = []) => [optimisticRecipe, ...current], {
         revalidate: false,
         populateCache: true,
       });
@@ -265,7 +265,7 @@ export const MessageList = ({
         cooked,
       };
 
-      mutate((current = []) => [...current, optimisticRecipe], {
+      mutate((current = []) => [optimisticRecipe, ...current], {
         revalidate: false,
         populateCache: true,
       });


### PR DESCRIPTION
## Summary

Follow-up to #439, which was squash-merged with only its first commit (the `orderBy`). That change alone is a no-op: `Recipe.createdAt` had no default and was always saved null, so there was nothing to sort by. This PR ships the two commits that make the sort actually work:

- **`createdAt` default + migration** — adds `@default(now())` so new recipes carry a real timestamp, plus a migration that sets the column default and backfills existing null rows. Without this, prod recipes stay null and the sort does nothing.
- **Optimistic prepend** — the chat save-to-cookbook flow appended the new recipe to the end of the SWR cache with `revalidate: false`, pinning it to the bottom until a full reload. Now it prepends, matching the server's newest-first order.

## Deploy note

The migration runs automatically on deploy via the `build` script (`prisma migrate deploy`). No manual step needed on Vercel.

## Test plan
- Save a recipe from chat → it appears at the top immediately (no reload).
- Reload the cookbook → newest-first order holds.
- typecheck + MessageList/recipe tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)