### PR TITLE
docs(agents): document wayfinding operations on the issue tracker

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -28,13 +28,13 @@ Run `gh issue view <number> --comments`.
 - **Map** — an issue labelled `wayfinder:map`. Its body is the low-res index (Destination, Notes, Decisions so far, Not yet specified, Out of scope). It does **not** list open tickets.
 - **Ticket** — a child issue labelled `wayfinder:ticket` plus one type label (`wayfinder:research` / `wayfinder:prototype` / `wayfinder:grilling` / `wayfinder:task`). Its body carries two lines: `Map: #<map>` and `Blocked by: #a, #b` (or `—` when unblocked).
 - **Claim** — assign the ticket to yourself before working it. An open, unassigned ticket is unclaimed.
-- **Frontier query** — open `wayfinder:ticket` issues for a map whose every `Blocked by:` issue is closed and which are unassigned:
+- **Frontier query** — the frontier is open `wayfinder:ticket` issues for a map that are **unassigned** and whose every `Blocked by:` issue is **closed**. The command below is only a **candidate query** — it lists the map's open tickets; you still have to apply the unassigned + closed-blockers filter yourself. Replace `<map>` with the numeric map ID (e.g. `445`):
 
-  ```
+  ```sh
   gh issue list --state open --label wayfinder:ticket \
     --json number,title,body,assignees \
-    --jq '[.[] | select(.body | contains("Map: #<map>"))]'
+    --jq '[.[] | select(.body | test("(^|\\n)Map: #<map>(\\r?\\n|$)"))]'
   ```
 
-  Then keep the ones whose `Blocked by:` numbers are all closed and that have no assignee.
+  The `test(...)` regex anchors the whole `Map:` line so `#12` doesn't match `#123`. From the candidates, drop any with a non-empty `assignees`, then drop any whose `Blocked by:` numbers aren't all closed (check each with `gh issue view <n> --json state`). What remains is the frontier.
 - **Resolve** — post the answer as a comment, `gh issue close` the ticket, and append a one-line pointer to the map's *Decisions so far*.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -20,3 +20,21 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+`gh` cannot reliably set GitHub's native issue-dependency edges, so a wayfinder map expresses its structure by **labels + body conventions**, and the frontier is a **query**, not a stored list.
+
+- **Map** — an issue labelled `wayfinder:map`. Its body is the low-res index (Destination, Notes, Decisions so far, Not yet specified, Out of scope). It does **not** list open tickets.
+- **Ticket** — a child issue labelled `wayfinder:ticket` plus one type label (`wayfinder:research` / `wayfinder:prototype` / `wayfinder:grilling` / `wayfinder:task`). Its body carries two lines: `Map: #<map>` and `Blocked by: #a, #b` (or `—` when unblocked).
+- **Claim** — assign the ticket to yourself before working it. An open, unassigned ticket is unclaimed.
+- **Frontier query** — open `wayfinder:ticket` issues for a map whose every `Blocked by:` issue is closed and which are unassigned:
+
+  ```
+  gh issue list --state open --label wayfinder:ticket \
+    --json number,title,body,assignees \
+    --jq '[.[] | select(.body | contains("Map: #<map>"))]'
+  ```
+
+  Then keep the ones whose `Blocked by:` numbers are all closed and that have no assignee.
+- **Resolve** — post the answer as a comment, `gh issue close` the ticket, and append a one-line pointer to the map's *Decisions so far*.


### PR DESCRIPTION
## What

Adds a **Wayfinding operations** section to `docs/agents/issue-tracker.md` documenting how a wayfinder map is expressed on GitHub.

## Why

`gh` can't reliably set GitHub's native issue-dependency edges, so wayfinder maps in this repo use **labels + body conventions** (`wayfinder:map` / `wayfinder:ticket` + type labels, `Map:` / `Blocked by:` lines) and the frontier is a **query**. Without this documented, a future "work through the map" session can't find the frontier.

Surfaced while charting the first map in the repo — #445 (*Technique helpers spec*, for #444).

## Scope

Docs only. New `wayfinder:*` labels were also created on the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LB1LYuwSnNMaedHH9XjBue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for navigating issue workflows using labels and structured issue content.
  * Documented how to create and manage Maps and Tickets, assign Claims, identify available work, and resolve tickets.
  * Clarified conventions for recording decisions and tracking dependencies through issue details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->