### PR TITLE
feat(recipes): clarify fenced-block contract, schema & stream plumbing

### DIFF
--- a/src/lib/recipes/parseBlocks.test.ts
+++ b/src/lib/recipes/parseBlocks.test.ts
@@ -34,6 +34,29 @@ describe("extractRecipeBlocks", () => {
     }
   });
 
+  it("parses a valid clarify block", () => {
+    const text = `Quick question:
+\`\`\`clarify
+{
+  "question": "What kind of meal are you after?",
+  "options": [
+    { "id": "quick", "label": "Something quick", "hint": "under 20 min" },
+    { "id": "comfort", "label": "Comfort food" }
+  ]
+}
+\`\`\``;
+
+    const blocks = extractRecipeBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].kind).toBe("clarify");
+    if (blocks[0].kind === "clarify") {
+      expect(blocks[0].payload.question).toBe("What kind of meal are you after?");
+      expect(blocks[0].payload.options[0].id).toBe("quick");
+      expect(blocks[0].payload.options[0].hint).toBe("under 20 min");
+      expect(blocks[0].payload.options[1].hint).toBeUndefined();
+    }
+  });
+
   it("parses a valid recipe block", () => {
     const text = `Here it is:
 \`\`\`recipe
@@ -157,6 +180,17 @@ describe("getOpenFence", () => {
     expect(getOpenFence('```suggestions\n{"intro":"hi"}\n```')).toBeNull();
   });
 
+  it("returns null when the clarify fence is closed", () => {
+    expect(getOpenFence('```clarify\n{"question":"hi","options":[]}\n```')).toBeNull();
+  });
+
+  it("detects an unclosed clarify fence", () => {
+    const text = 'Quick question:\n```clarify\n{"question":"What kind';
+    const fence = getOpenFence(text);
+    expect(fence?.kind).toBe("clarify");
+    expect(fence?.json).toBe('{"question":"What kind');
+  });
+
   it("detects an unclosed recipe fence with its prose offset and json body", () => {
     const text = 'Some prose\n```recipe\n{"title":"Gin';
     const fence = getOpenFence(text);
@@ -237,6 +271,14 @@ describe("parsePartialBlock", () => {
     expect(partial?.steps).toEqual([]); // in-progress step held back
   });
 
+  it("streams clarify options, holding back the in-progress one", async () => {
+    const partial = await parsePartialBlock(
+      '{"question":"What meal?","options":[{"id":"quick","label":"Quick"},{"id":"comf',
+    );
+    expect(partial?.question).toBe("What meal?");
+    expect(partial?.options).toEqual([{ id: "quick", label: "Quick" }]);
+  });
+
   it("returns the whole object untrimmed once the JSON is complete", async () => {
     const partial = await parsePartialBlock(
       '{"title":"X","baseServings":2,"ingredients":[{"name":"a"}],"steps":[]}',
@@ -252,6 +294,14 @@ describe("stripFences", () => {
     expect(result).toContain("Here are ideas:");
     expect(result).toContain("More prose.");
     expect(result).not.toContain("```suggestions");
+  });
+
+  it("strips clarify fences, leaving prose", () => {
+    const text = `Quick question:\n\`\`\`clarify\n{"question":"hi","options":[]}\n\`\`\`\nMore prose.`;
+    const result = stripFences(text);
+    expect(result).toContain("Quick question:");
+    expect(result).toContain("More prose.");
+    expect(result).not.toContain("```clarify");
   });
 
   it("strips recipe fences", () => {

--- a/src/lib/recipes/parseBlocks.ts
+++ b/src/lib/recipes/parseBlocks.ts
@@ -1,32 +1,39 @@
 import { parsePartialJson } from "ai";
 import {
+  ClarifyBlockSchema,
   RecipeBlockSchema,
   SuggestionsBlockSchema,
 } from "@/lib/recipes/schemas";
 import type {
+  ClarifyBlockData,
   RecipeBlock,
   SuggestionsBlockData,
 } from "@/lib/recipes/schemas";
 
 export type ParsedBlock =
   | { kind: "suggestions"; payload: SuggestionsBlockData; index: number }
+  | { kind: "clarify"; payload: ClarifyBlockData; index: number }
   | { kind: "recipe"; payload: RecipeBlock; index: number }
   | { kind: "legacy"; recipeStr: string; index: number };
 
 export function extractRecipeBlocks(text: string): ParsedBlock[] {
   const blocks: ParsedBlock[] = [];
 
-  const fenceRegex = /^```(suggestions|recipe)\n([\s\S]*?)\n```/gm;
+  const fenceRegex = /^```(suggestions|clarify|recipe)\n([\s\S]*?)\n```/gm;
   let match: RegExpExecArray | null;
 
   while ((match = fenceRegex.exec(text)) !== null) {
-    const kind = match[1] as "suggestions" | "recipe";
+    const kind = match[1] as "suggestions" | "clarify" | "recipe";
     try {
       const payload = JSON.parse(match[2]);
       if (kind === "suggestions") {
         const result = SuggestionsBlockSchema.safeParse(payload);
         if (result.success)
           blocks.push({ kind: "suggestions", payload: result.data, index: match.index });
+      } else if (kind === "clarify") {
+        const result = ClarifyBlockSchema.safeParse(payload);
+        if (result.success)
+          blocks.push({ kind: "clarify", payload: result.data, index: match.index });
       } else if (kind === "recipe") {
         const result = RecipeBlockSchema.safeParse(payload);
         if (result.success)
@@ -55,11 +62,11 @@ export function stripFences(text: string): string {
   return text
     // Keep stripping legacy `gate` fences for backward-compat and to avoid
     // rendering unsupported fenced-language blocks from older messages.
-    .replace(/^```(?:suggestions|gate|recipe)\n[\s\S]*?\n```/gm, "")
+    .replace(/^```(?:suggestions|clarify|gate|recipe)\n[\s\S]*?\n```/gm, "")
     .trim();
 }
 
-export type OpenFenceKind = "recipe" | "suggestions";
+export type OpenFenceKind = "recipe" | "suggestions" | "clarify";
 
 export interface OpenFence {
   kind: OpenFenceKind;
@@ -78,6 +85,7 @@ export function getOpenFence(text: string): OpenFence | null {
   const markers: { kind: OpenFenceKind; marker: string }[] = [
     { kind: "recipe", marker: "```recipe\n" },
     { kind: "suggestions", marker: "```suggestions\n" },
+    { kind: "clarify", marker: "```clarify\n" },
   ];
 
   let best: { kind: OpenFenceKind; index: number; markerLen: number } | null =

--- a/src/lib/recipes/parseBlocks.ts
+++ b/src/lib/recipes/parseBlocks.ts
@@ -3,12 +3,12 @@ import {
   ClarifyBlockSchema,
   RecipeBlockSchema,
   SuggestionsBlockSchema,
-} from "@/lib/recipes/schemas";
+} from "./schemas";
 import type {
   ClarifyBlockData,
   RecipeBlock,
   SuggestionsBlockData,
-} from "@/lib/recipes/schemas";
+} from "./schemas";
 
 export type ParsedBlock =
   | { kind: "suggestions"; payload: SuggestionsBlockData; index: number }

--- a/src/lib/recipes/schemas.ts
+++ b/src/lib/recipes/schemas.ts
@@ -88,6 +88,22 @@ export const SuggestionsBlockSchema = z.object({
 });
 export type SuggestionsBlockData = z.infer<typeof SuggestionsBlockSchema>;
 
+// One option inside a ```clarify block. Single-select: tapping sends `label`
+// back as the user's reply. `hint` is optional supporting text.
+export const ClarifyOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  hint: z.string().optional(),
+});
+export type ClarifyOption = z.infer<typeof ClarifyOptionSchema>;
+
+// Full ```clarify block — Ah Mah asks one question, offers tappable options.
+export const ClarifyBlockSchema = z.object({
+  question: z.string(),
+  options: z.array(ClarifyOptionSchema),
+});
+export type ClarifyBlockData = z.infer<typeof ClarifyBlockSchema>;
+
 // ```gate block
 export const GateSchema = z.object({
   recipeId: z.string(),


### PR DESCRIPTION
## What

Makes the `clarify` fenced block a first-class citizen alongside `recipe` and `suggestions`, so parsing, extraction, and progressive-reveal streaming all recognise it. Mirrors the `suggestions` path in every file.

This is the frontier ticket of the **Clarify block** wayfinder map (#461) — it must land before the UI (#463) and the prompt/docs (#464) can build on the contract.

## Changes

- **`schemas.ts`** — `ClarifyBlockSchema` = `{ question: string, options: ClarifyOption[] }`, where `ClarifyOption = { id, label, hint? }`. Exports the inferred types.
- **`parseBlocks.ts`**
  - `extractRecipeBlocks` — `clarify` added to the fence alternation + `safeParse` branch; `ParsedBlock` union gains a `clarify` variant.
  - `getOpenFence` — `` ```clarify\n `` marker + `clarify` in `OpenFenceKind`.
  - `stripFences` — `clarify` in the strip alternation.
  - `parsePartialBlock` — **unchanged**; it's generic and the streaming array key is `options`, exactly like suggestions.
- **Tests** — extended `parseBlocks.test.ts` with clarify fixtures for extract, open-fence detection, strip, and progressive-reveal streaming.

## Verification

- `pnpm jest` — 772 passed
- `pnpm tsc --noEmit` — clean
- `pnpm eslint` on changed files — clean

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for structured clarification prompts with a question and selectable options.
  * Clarification options can include labels, identifiers, and optional hints.
  * Clarification content is recognized during streaming and parsed once complete.
* **Bug Fixes**
  * Prevented unsupported clarification blocks from appearing as raw fenced text.
  * Improved handling of incomplete clarification content during streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->