### PR TITLE
feat(chat): render the clarify block — tappable single-select card

### DIFF
--- a/src/features/Chat/components/MessageList.test.tsx
+++ b/src/features/Chat/components/MessageList.test.tsx
@@ -69,6 +69,10 @@ jest.mock("./recipe/SuggestionsBlock", () => ({
   SuggestionsBlock: () => <div data-testid="suggestions-block" />,
 }));
 
+jest.mock("./recipe/ClarifyBlock", () => ({
+  ClarifyBlock: () => <div data-testid="clarify-block" />,
+}));
+
 jest.mock("./recipe/RecipeLetter", () => ({
   RecipeLetter: ({ onSave }: { onSave?: () => void }) => (
     <div data-testid="recipe-letter">
@@ -496,6 +500,36 @@ describe("MessageList", () => {
 
       // Should not make any API calls
       expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Clarify block rendering", () => {
+    const clarifyMessage = createMockMessage({
+      id: "msg-clarify",
+      role: "assistant",
+      parts: [
+        {
+          type: "text",
+          text:
+            "Quick question:\n```clarify\n" +
+            JSON.stringify({
+              question: "What kind of meal are you after?",
+              options: [
+                { id: "quick", label: "Something quick" },
+                { id: "comfort", label: "Comfort food" },
+              ],
+            }) +
+            "\n```",
+        },
+      ],
+    });
+
+    it("renders a ClarifyBlock for a completed clarify fence", () => {
+      render(<MessageList {...defaultProps} messages={[clarifyMessage]} />);
+
+      expect(screen.getByTestId("clarify-block")).toBeInTheDocument();
+      // The raw JSON must not leak into the prose renderer.
+      expect(screen.queryByText(/```clarify/)).not.toBeInTheDocument();
     });
   });
 

--- a/src/features/Chat/components/MessageList.tsx
+++ b/src/features/Chat/components/MessageList.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/recipes/parseBlocks";
 import type { OpenFenceKind } from "@/lib/recipes/parseBlocks";
 import type {
+  ClarifyBlockData,
   RecipeBlock,
   RecipeWithId,
   SuggestionsBlockData,
@@ -32,6 +33,7 @@ import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
 import { generateTempId } from "../constants";
 import { ChatLoader } from "./loaders";
+import { ClarifyBlock } from "./recipe/ClarifyBlock";
 import { RecipeLetter } from "./recipe/RecipeLetter";
 import { SuggestionsBlock } from "./recipe/SuggestionsBlock";
 
@@ -483,6 +485,19 @@ export const MessageList = ({
                         </div>
                       );
                     }
+                    if (block.kind === "clarify") {
+                      return (
+                        <div key={blockKey}>
+                          <hr className="border-t border-border my-3" />
+                          <ClarifyBlock
+                            data={block.payload}
+                            allMessages={messages}
+                            messageIndex={messageIndex}
+                            onSend={onSend}
+                          />
+                        </div>
+                      );
+                    }
                     if (block.kind === "recipe") {
                       const recipeKey = `${message.id}-${bi}`;
                       const savedRecipe = recipeSaved?.find(
@@ -519,6 +534,17 @@ export const MessageList = ({
                         recipe={activePartial.data as Partial<RecipeBlock>}
                         isStreaming
                       />
+                    ) : activePartial.kind === "clarify" ? (
+                      <div key={`${message.id}-streaming`}>
+                        <hr className="border-t border-border my-3" />
+                        <ClarifyBlock
+                          data={activePartial.data as Partial<ClarifyBlockData>}
+                          allMessages={messages}
+                          messageIndex={messageIndex}
+                          onSend={onSend}
+                          isStreaming
+                        />
+                      </div>
                     ) : (
                       <div key={`${message.id}-streaming`}>
                         <hr className="border-t border-border my-3" />

--- a/src/features/Chat/components/recipe/ClarifyBlock.test.tsx
+++ b/src/features/Chat/components/recipe/ClarifyBlock.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import { ClarifyBlock } from './ClarifyBlock';
+
+const data = {
+  question: 'What kind of meal are you after?',
+  options: [
+    { id: 'quick', label: 'Something quick', hint: 'under 20 min' },
+    { id: 'comfort', label: 'Comfort food' },
+  ],
+};
+
+// The clarify block is rendered against message #0; later messages are the
+// user's reply that locks a pick.
+const userReply = (text: string): UIMessage => ({
+  id: 'u1',
+  role: 'user',
+  parts: [{ type: 'text', text }],
+});
+
+const assistantMsg: UIMessage = { id: 'a0', role: 'assistant', parts: [] };
+
+describe('ClarifyBlock', () => {
+  it('renders the question and each option (label + optional hint)', () => {
+    render(
+      <ClarifyBlock data={data} allMessages={[assistantMsg]} messageIndex={0} onSend={jest.fn()} />
+    );
+    expect(screen.getByText('What kind of meal are you after?')).toBeInTheDocument();
+    expect(screen.getByText('Something quick')).toBeInTheDocument();
+    expect(screen.getByText('under 20 min')).toBeInTheDocument();
+    expect(screen.getByText('Comfort food')).toBeInTheDocument();
+  });
+
+  it('sends the option label when a card is tapped (tap = send)', () => {
+    const onSend = jest.fn();
+    render(
+      <ClarifyBlock data={data} allMessages={[assistantMsg]} messageIndex={0} onSend={onSend} />
+    );
+    fireEvent.click(screen.getByText('Something quick'));
+    expect(onSend).toHaveBeenCalledWith('Something quick');
+  });
+
+  it('locks the picked option and dims/disables the rest after the user answers', () => {
+    const onSend = jest.fn();
+    render(
+      <ClarifyBlock
+        data={data}
+        allMessages={[assistantMsg, userReply('Something quick')]}
+        messageIndex={0}
+        onSend={onSend}
+      />
+    );
+    expect(screen.getByText('✓ Picked')).toBeInTheDocument();
+    // Every option button is now disabled — the answer is locked in.
+    screen.getAllByRole('button').forEach(btn => expect(btn).toBeDisabled());
+    // Tapping the non-picked option does nothing.
+    fireEvent.click(screen.getByText('Comfort food'));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('shows the "or just tell me" escape-hatch footer', () => {
+    render(
+      <ClarifyBlock data={data} allMessages={[assistantMsg]} messageIndex={0} onSend={jest.fn()} />
+    );
+    expect(screen.getByText(/just tell me/i)).toBeInTheDocument();
+  });
+
+  it('suppresses the picked/locked state while streaming', () => {
+    render(
+      <ClarifyBlock
+        data={data}
+        allMessages={[assistantMsg, userReply('Something quick')]}
+        messageIndex={0}
+        onSend={jest.fn()}
+        isStreaming
+      />
+    );
+    // No pick is derived mid-stream; buttons stay disabled (still streaming) but
+    // none is marked picked.
+    expect(screen.queryByText('✓ Picked')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/Chat/components/recipe/ClarifyBlock.tsx
+++ b/src/features/Chat/components/recipe/ClarifyBlock.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { ClarifyBlockData, ClarifyOption } from '@/lib/recipes/schemas';
+import { cn } from '@/lib/utils';
+import { TextUIPart, UIMessage } from 'ai';
+
+interface ClarifyBlockProps {
+  // Partial during progressive reveal — question/options fill in as the JSON streams.
+  data: Partial<ClarifyBlockData>;
+  allMessages: UIMessage[];
+  messageIndex: number;
+  onSend: (text: string) => void;
+  // While true the block is still streaming: options may be incomplete and the
+  // picked/locked state is suppressed (mirrors SuggestionsBlock).
+  isStreaming?: boolean;
+}
+
+// A clarify answer is a canned user message: tapping an option sends its `label`.
+// So we recover which option was picked exactly like suggestions — scan the user
+// messages that came AFTER this block for one whose text matches an option label.
+function derivePickedId(
+  options: ClarifyOption[],
+  allMessages: UIMessage[],
+  messageIndex: number
+): string | null {
+  const laterMessages = allMessages.slice(messageIndex + 1);
+  for (const msg of laterMessages) {
+    if (msg.role !== 'user') continue;
+    const text =
+      msg.parts
+        ?.filter((p): p is TextUIPart => p.type === 'text')
+        .map(p => p.text)
+        .join('') ?? '';
+    for (const opt of options) {
+      if (text.toLowerCase().includes(opt.label.toLowerCase())) {
+        return opt.id;
+      }
+    }
+  }
+  return null;
+}
+
+interface ClarifyCardProps {
+  option: ClarifyOption;
+  isPicked: boolean;
+  isDimmed: boolean;
+  onSend: (text: string) => void;
+  isStreaming?: boolean;
+}
+
+function ClarifyCard({ option, isPicked, isDimmed, onSend, isStreaming = false }: ClarifyCardProps) {
+  // Tap = send the option's label as the user's reply (single-select, approved
+  // behaviour). The whole card is the control. Suppressed while streaming and
+  // once an answer is locked in.
+  const locked = isStreaming || isDimmed || isPicked;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSend(option.label)}
+      disabled={locked}
+      className={cn(
+        'w-full text-left bg-card rounded-xl px-4 py-3 relative transition-all duration-180 flex items-center gap-3',
+        isPicked
+          ? 'border border-primary shadow-[0_0_0_2px_oklch(0.56_0.135_35/0.18),0_1px_0_var(--border-soft)]'
+          : 'border border-border shadow-[0_1px_0_var(--border-soft),0_14px_24px_-22px_oklch(0.3_0.05_50/0.4)]',
+        isDimmed ? 'opacity-50' : 'opacity-100',
+        locked ? 'cursor-default' : 'cursor-pointer hover:border-primary/60'
+      )}
+    >
+      <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+        <span className="font-display font-semibold text-lg text-foreground leading-tight tracking-tight">
+          {option.label}
+        </span>
+        {option.hint && (
+          <span className="font-display italic text-sm text-muted-foreground leading-relaxed">
+            {option.hint}
+          </span>
+        )}
+      </div>
+      {isPicked && (
+        <span className="font-sans text-xs font-semibold text-primary-deep shrink-0">✓ Picked</span>
+      )}
+    </button>
+  );
+}
+
+export function ClarifyBlock({
+  data,
+  allMessages,
+  messageIndex,
+  onSend,
+  isStreaming = false,
+}: ClarifyBlockProps) {
+  // Streaming partials may omit question/options entirely; default them so the
+  // same render path serves both the live and the final view (ADR-0009).
+  const question = data.question ?? '';
+  const options = data.options ?? [];
+
+  const pickedId = isStreaming ? null : derivePickedId(options, allMessages, messageIndex);
+
+  return (
+    <div className="min-w-0">
+      {/* Question */}
+      <div className="font-display italic text-lg leading-relaxed text-foreground mb-3">
+        {question}
+      </div>
+
+      {/* Options */}
+      <div className="flex flex-col gap-2.5">
+        {options.map(option => (
+          <ClarifyCard
+            key={option.id}
+            option={option}
+            isPicked={pickedId === option.id}
+            isDimmed={pickedId !== null && pickedId !== option.id}
+            onSend={onSend}
+            isStreaming={isStreaming}
+          />
+        ))}
+      </div>
+
+      {/* Footer hint — the always-present composer is the escape hatch. */}
+      <div className="mt-2.5 font-display italic text-sm text-ink-faint leading-relaxed">
+        Or just tell me — type it below.
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Builds the presentational **ClarifyBlock** and wires it into the message list, so a `clarify` fenced block renders as a question with tappable single-select option cards. Mirrors `SuggestionsBlock` — invents no new design.

Frontier ticket #463 of the **Clarify block** wayfinder map (#461).

## Changes

- **`ClarifyBlock.tsx`** (new) — renders `question` + option cards. Tapping a card calls `onSend(option.label)` (**tap = send a canned user reply**, same pipeline as suggestions). Reuses the `derivePickedId` scan so the picked option locks (`✓ Picked`) and the rest dim/disable after the user answers. Footer hint points at the always-present composer ("or just tell me").
- **`MessageList.tsx`**
  - New `clarify` case in `blocks.map` (the final-render path previously returned `null` for it → the block vanished).
  - **Streaming-branch fix**: a streaming `clarify` fence used to fall through to `SuggestionsBlock` (whose `intro` + `{title, blurb, time}` shape doesn't match clarify) → garbled mid-stream. It now renders through `ClarifyBlock`.
- **Tests** — colocated `ClarifyBlock.test.tsx` (render, tap-to-send, answered/locked state, streaming) + a `MessageList` render assertion.

## Merge order

This is the **UI half** of the feature. Its sibling #464 (prompt policy that teaches the model to *emit* clarify) is now marked `Blocked by: #463` — it must merge **after** this PR, because turning on emission with no UI case renders broken. This PR is safe to merge alone: with no emitter yet, the new render path simply sees no clarify blocks.

## Verification

- `pnpm jest` — 778 passed (incl. new ClarifyBlock + MessageList assertions)
- `pnpm tsc --noEmit` — clean
- `pnpm eslint` on changed files — clean

End-to-end visual verification (driving the real app) is deferred to when #464 lands — there is no trigger path to emit a clarify block until the model is taught to, which is exactly the #463→#464 merge order.

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)